### PR TITLE
Retry list/watch on failures

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
@@ -33,6 +33,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *examples) List(opts metav1.ListOptions) (result *v1.ExampleList, err er
 		for i, client := range c.clients {
 			go func(c *examples, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ExampleList, errMap map[int]error) {
 				r := &v1.ExampleList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("examples").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("examples").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *examples) List(opts metav1.ListOptions) (result *v1.ExampleList, err er
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("examples").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("examples").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *examples) List(opts metav1.ListOptions) (result *v1.ExampleList, err er
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("examples").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("examples").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *examples) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("examples").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("examples").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/customresourcedefinition.go
@@ -33,6 +33,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -116,13 +117,15 @@ func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *apiextens
 		for i, client := range c.clients {
 			go func(c *customResourceDefinitions, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*apiextensions.CustomResourceDefinitionList, errMap map[int]error) {
 				r := &apiextensions.CustomResourceDefinitionList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("customresourcedefinitions").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("customresourcedefinitions").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -178,13 +181,15 @@ func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *apiextens
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("customresourcedefinitions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("customresourcedefinitions").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -199,13 +204,15 @@ func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *apiextens
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("customresourcedefinitions").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("customresourcedefinitions").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -231,12 +238,14 @@ func (c *customResourceDefinitions) Watch(opts v1.ListOptions) watch.AggregatedW
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("customresourcedefinitions").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("customresourcedefinitions").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -107,12 +108,14 @@ func (c *mutatingWebhookConfigurations) List(opts v1.ListOptions) (result *v1bet
 		for i, client := range c.clients {
 			go func(c *mutatingWebhookConfigurations, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.MutatingWebhookConfigurationList, errMap map[int]error) {
 				r := &v1beta1.MutatingWebhookConfigurationList{}
-				err := ci.Get().
-					Resource("mutatingwebhookconfigurations").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("mutatingwebhookconfigurations").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -168,12 +171,14 @@ func (c *mutatingWebhookConfigurations) List(opts v1.ListOptions) (result *v1bet
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("mutatingwebhookconfigurations").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("mutatingwebhookconfigurations").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -188,12 +193,14 @@ func (c *mutatingWebhookConfigurations) List(opts v1.ListOptions) (result *v1bet
 			continue
 		}
 
-		err = client.Get().
-			Resource("mutatingwebhookconfigurations").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("mutatingwebhookconfigurations").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -219,11 +226,13 @@ func (c *mutatingWebhookConfigurations) Watch(opts v1.ListOptions) watch.Aggrega
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("mutatingwebhookconfigurations").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("mutatingwebhookconfigurations").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -107,12 +108,14 @@ func (c *validatingWebhookConfigurations) List(opts v1.ListOptions) (result *v1b
 		for i, client := range c.clients {
 			go func(c *validatingWebhookConfigurations, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.ValidatingWebhookConfigurationList, errMap map[int]error) {
 				r := &v1beta1.ValidatingWebhookConfigurationList{}
-				err := ci.Get().
-					Resource("validatingwebhookconfigurations").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("validatingwebhookconfigurations").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -168,12 +171,14 @@ func (c *validatingWebhookConfigurations) List(opts v1.ListOptions) (result *v1b
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("validatingwebhookconfigurations").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("validatingwebhookconfigurations").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -188,12 +193,14 @@ func (c *validatingWebhookConfigurations) List(opts v1.ListOptions) (result *v1b
 			continue
 		}
 
-		err = client.Get().
-			Resource("validatingwebhookconfigurations").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("validatingwebhookconfigurations").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -219,11 +226,13 @@ func (c *validatingWebhookConfigurations) Watch(opts v1.ListOptions) watch.Aggre
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("validatingwebhookconfigurations").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("validatingwebhookconfigurations").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *controllerRevisions) List(opts metav1.ListOptions) (result *v1.Controll
 		for i, client := range c.clients {
 			go func(c *controllerRevisions, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ControllerRevisionList, errMap map[int]error) {
 				r := &v1.ControllerRevisionList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("controllerrevisions").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("controllerrevisions").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *controllerRevisions) List(opts metav1.ListOptions) (result *v1.Controll
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("controllerrevisions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("controllerrevisions").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *controllerRevisions) List(opts metav1.ListOptions) (result *v1.Controll
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("controllerrevisions").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("controllerrevisions").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *controllerRevisions) Watch(opts metav1.ListOptions) watch.AggregatedWat
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("controllerrevisions").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("controllerrevisions").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *daemonSets) List(opts metav1.ListOptions) (result *v1.DaemonSetList, er
 		for i, client := range c.clients {
 			go func(c *daemonSets, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.DaemonSetList, errMap map[int]error) {
 				r := &v1.DaemonSetList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("daemonsets").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("daemonsets").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *daemonSets) List(opts metav1.ListOptions) (result *v1.DaemonSetList, er
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("daemonsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("daemonsets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *daemonSets) List(opts metav1.ListOptions) (result *v1.DaemonSetList, er
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("daemonsets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("daemonsets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *daemonSets) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfa
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("daemonsets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("daemonsets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
@@ -34,6 +34,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -123,13 +124,15 @@ func (c *deployments) List(opts metav1.ListOptions) (result *v1.DeploymentList, 
 		for i, client := range c.clients {
 			go func(c *deployments, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.DeploymentList, errMap map[int]error) {
 				r := &v1.DeploymentList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("deployments").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("deployments").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -185,13 +188,15 @@ func (c *deployments) List(opts metav1.ListOptions) (result *v1.DeploymentList, 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("deployments").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -206,13 +211,15 @@ func (c *deployments) List(opts metav1.ListOptions) (result *v1.DeploymentList, 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("deployments").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("deployments").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -238,13 +245,15 @@ func (c *deployments) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterf
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("deployments").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("deployments").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
@@ -34,6 +34,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -123,13 +124,15 @@ func (c *replicaSets) List(opts metav1.ListOptions) (result *v1.ReplicaSetList, 
 		for i, client := range c.clients {
 			go func(c *replicaSets, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ReplicaSetList, errMap map[int]error) {
 				r := &v1.ReplicaSetList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("replicasets").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("replicasets").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -185,13 +188,15 @@ func (c *replicaSets) List(opts metav1.ListOptions) (result *v1.ReplicaSetList, 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("replicasets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("replicasets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -206,13 +211,15 @@ func (c *replicaSets) List(opts metav1.ListOptions) (result *v1.ReplicaSetList, 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("replicasets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("replicasets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -238,13 +245,15 @@ func (c *replicaSets) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterf
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("replicasets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("replicasets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
@@ -34,6 +34,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -123,13 +124,15 @@ func (c *statefulSets) List(opts metav1.ListOptions) (result *v1.StatefulSetList
 		for i, client := range c.clients {
 			go func(c *statefulSets, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.StatefulSetList, errMap map[int]error) {
 				r := &v1.StatefulSetList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("statefulsets").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("statefulsets").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -185,13 +188,15 @@ func (c *statefulSets) List(opts metav1.ListOptions) (result *v1.StatefulSetList
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("statefulsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("statefulsets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -206,13 +211,15 @@ func (c *statefulSets) List(opts metav1.ListOptions) (result *v1.StatefulSetList
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("statefulsets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("statefulsets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -238,13 +245,15 @@ func (c *statefulSets) Watch(opts metav1.ListOptions) watch.AggregatedWatchInter
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("statefulsets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("statefulsets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta1.Control
 		for i, client := range c.clients {
 			go func(c *controllerRevisions, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.ControllerRevisionList, errMap map[int]error) {
 				r := &v1beta1.ControllerRevisionList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("controllerrevisions").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("controllerrevisions").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta1.Control
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("controllerrevisions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("controllerrevisions").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta1.Control
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("controllerrevisions").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("controllerrevisions").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *controllerRevisions) Watch(opts v1.ListOptions) watch.AggregatedWatchIn
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("controllerrevisions").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("controllerrevisions").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 		for i, client := range c.clients {
 			go func(c *deployments, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.DeploymentList, errMap map[int]error) {
 				r := &v1beta1.DeploymentList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("deployments").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("deployments").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("deployments").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("deployments").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("deployments").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *deployments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface 
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("deployments").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("deployments").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta1.StatefulSetLis
 		for i, client := range c.clients {
 			go func(c *statefulSets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.StatefulSetList, errMap map[int]error) {
 				r := &v1beta1.StatefulSetList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("statefulsets").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("statefulsets").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta1.StatefulSetLis
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("statefulsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("statefulsets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta1.StatefulSetLis
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("statefulsets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("statefulsets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *statefulSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("statefulsets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("statefulsets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta2.Control
 		for i, client := range c.clients {
 			go func(c *controllerRevisions, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta2.ControllerRevisionList, errMap map[int]error) {
 				r := &v1beta2.ControllerRevisionList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("controllerrevisions").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("controllerrevisions").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta2.Control
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("controllerrevisions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("controllerrevisions").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta2.Control
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("controllerrevisions").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("controllerrevisions").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *controllerRevisions) Watch(opts v1.ListOptions) watch.AggregatedWatchIn
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("controllerrevisions").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("controllerrevisions").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta2.DaemonSetList, e
 		for i, client := range c.clients {
 			go func(c *daemonSets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta2.DaemonSetList, errMap map[int]error) {
 				r := &v1beta2.DaemonSetList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("daemonsets").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("daemonsets").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta2.DaemonSetList, e
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("daemonsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("daemonsets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta2.DaemonSetList, e
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("daemonsets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("daemonsets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *daemonSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("daemonsets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("daemonsets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta2.DeploymentList,
 		for i, client := range c.clients {
 			go func(c *deployments, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta2.DeploymentList, errMap map[int]error) {
 				r := &v1beta2.DeploymentList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("deployments").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("deployments").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta2.DeploymentList,
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("deployments").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta2.DeploymentList,
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("deployments").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("deployments").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *deployments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface 
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("deployments").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("deployments").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta2.ReplicaSetList,
 		for i, client := range c.clients {
 			go func(c *replicaSets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta2.ReplicaSetList, errMap map[int]error) {
 				r := &v1beta2.ReplicaSetList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("replicasets").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("replicasets").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta2.ReplicaSetList,
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("replicasets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("replicasets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta2.ReplicaSetList,
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("replicasets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("replicasets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *replicaSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface 
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("replicasets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("replicasets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -122,13 +123,15 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta2.StatefulSetLis
 		for i, client := range c.clients {
 			go func(c *statefulSets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta2.StatefulSetList, errMap map[int]error) {
 				r := &v1beta2.StatefulSetList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("statefulsets").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("statefulsets").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -184,13 +187,15 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta2.StatefulSetLis
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("statefulsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("statefulsets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -205,13 +210,15 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta2.StatefulSetLis
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("statefulsets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("statefulsets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -237,13 +244,15 @@ func (c *statefulSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("statefulsets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("statefulsets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/auditsink.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/auditsink.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -115,13 +116,15 @@ func (c *auditSinks) List(opts v1.ListOptions) (result *v1alpha1.AuditSinkList, 
 		for i, client := range c.clients {
 			go func(c *auditSinks, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.AuditSinkList, errMap map[int]error) {
 				r := &v1alpha1.AuditSinkList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("auditsinks").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("auditsinks").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -177,13 +180,15 @@ func (c *auditSinks) List(opts v1.ListOptions) (result *v1alpha1.AuditSinkList, 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("auditsinks").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("auditsinks").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -198,13 +203,15 @@ func (c *auditSinks) List(opts v1.ListOptions) (result *v1alpha1.AuditSinkList, 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("auditsinks").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("auditsinks").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -230,12 +237,14 @@ func (c *auditSinks) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("auditsinks").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("auditsinks").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *horizontalPodAutoscalers) List(opts metav1.ListOptions) (result *v1.Hor
 		for i, client := range c.clients {
 			go func(c *horizontalPodAutoscalers, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.HorizontalPodAutoscalerList, errMap map[int]error) {
 				r := &v1.HorizontalPodAutoscalerList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("horizontalpodautoscalers").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("horizontalpodautoscalers").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *horizontalPodAutoscalers) List(opts metav1.ListOptions) (result *v1.Hor
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("horizontalpodautoscalers").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *horizontalPodAutoscalers) List(opts metav1.ListOptions) (result *v1.Hor
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("horizontalpodautoscalers").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("horizontalpodautoscalers").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *horizontalPodAutoscalers) Watch(opts metav1.ListOptions) watch.Aggregat
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("horizontalpodautoscalers").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("horizontalpodautoscalers").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta1.Ho
 		for i, client := range c.clients {
 			go func(c *horizontalPodAutoscalers, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v2beta1.HorizontalPodAutoscalerList, errMap map[int]error) {
 				r := &v2beta1.HorizontalPodAutoscalerList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("horizontalpodautoscalers").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("horizontalpodautoscalers").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta1.Ho
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("horizontalpodautoscalers").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta1.Ho
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("horizontalpodautoscalers").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("horizontalpodautoscalers").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) watch.AggregatedWa
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("horizontalpodautoscalers").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("horizontalpodautoscalers").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta2.Ho
 		for i, client := range c.clients {
 			go func(c *horizontalPodAutoscalers, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v2beta2.HorizontalPodAutoscalerList, errMap map[int]error) {
 				r := &v2beta2.HorizontalPodAutoscalerList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("horizontalpodautoscalers").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("horizontalpodautoscalers").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta2.Ho
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("horizontalpodautoscalers").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta2.Ho
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("horizontalpodautoscalers").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("horizontalpodautoscalers").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) watch.AggregatedWa
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("horizontalpodautoscalers").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("horizontalpodautoscalers").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *jobs) List(opts metav1.ListOptions) (result *v1.JobList, err error) {
 		for i, client := range c.clients {
 			go func(c *jobs, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.JobList, errMap map[int]error) {
 				r := &v1.JobList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("jobs").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("jobs").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *jobs) List(opts metav1.ListOptions) (result *v1.JobList, err error) {
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("jobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("jobs").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *jobs) List(opts metav1.ListOptions) (result *v1.JobList, err error) {
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("jobs").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("jobs").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *jobs) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("jobs").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("jobs").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *v1beta1.CronJobList, err e
 		for i, client := range c.clients {
 			go func(c *cronJobs, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.CronJobList, errMap map[int]error) {
 				r := &v1beta1.CronJobList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("cronjobs").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("cronjobs").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *v1beta1.CronJobList, err e
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("cronjobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("cronjobs").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *v1beta1.CronJobList, err e
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("cronjobs").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("cronjobs").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *cronJobs) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("cronjobs").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("cronjobs").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/cronjob.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *v2alpha1.CronJobList, err 
 		for i, client := range c.clients {
 			go func(c *cronJobs, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v2alpha1.CronJobList, errMap map[int]error) {
 				r := &v2alpha1.CronJobList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("cronjobs").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("cronjobs").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *v2alpha1.CronJobList, err 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("cronjobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("cronjobs").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *v2alpha1.CronJobList, err 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("cronjobs").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("cronjobs").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *cronJobs) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("cronjobs").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("cronjobs").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -116,13 +117,15 @@ func (c *certificateSigningRequests) List(opts v1.ListOptions) (result *v1beta1.
 		for i, client := range c.clients {
 			go func(c *certificateSigningRequests, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.CertificateSigningRequestList, errMap map[int]error) {
 				r := &v1beta1.CertificateSigningRequestList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("certificatesigningrequests").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("certificatesigningrequests").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -178,13 +181,15 @@ func (c *certificateSigningRequests) List(opts v1.ListOptions) (result *v1beta1.
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("certificatesigningrequests").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("certificatesigningrequests").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -199,13 +204,15 @@ func (c *certificateSigningRequests) List(opts v1.ListOptions) (result *v1beta1.
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("certificatesigningrequests").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("certificatesigningrequests").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -231,12 +238,14 @@ func (c *certificateSigningRequests) Watch(opts v1.ListOptions) watch.Aggregated
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("certificatesigningrequests").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("certificatesigningrequests").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *leases) List(opts metav1.ListOptions) (result *v1.LeaseList, err error)
 		for i, client := range c.clients {
 			go func(c *leases, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.LeaseList, errMap map[int]error) {
 				r := &v1.LeaseList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("leases").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("leases").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *leases) List(opts metav1.ListOptions) (result *v1.LeaseList, err error)
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("leases").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("leases").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *leases) List(opts metav1.ListOptions) (result *v1.LeaseList, err error)
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("leases").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("leases").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *leases) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("leases").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("leases").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *leases) List(opts v1.ListOptions) (result *v1beta1.LeaseList, err error
 		for i, client := range c.clients {
 			go func(c *leases, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.LeaseList, errMap map[int]error) {
 				r := &v1beta1.LeaseList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("leases").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("leases").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *leases) List(opts v1.ListOptions) (result *v1beta1.LeaseList, err error
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("leases").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("leases").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *leases) List(opts v1.ListOptions) (result *v1beta1.LeaseList, err error
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("leases").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("leases").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *leases) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("leases").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("leases").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/BUILD
@@ -59,6 +59,7 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/tools/reference:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/action.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/action.go
@@ -32,6 +32,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *actions) List(opts metav1.ListOptions) (result *v1.ActionList, err erro
 		for i, client := range c.clients {
 			go func(c *actions, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ActionList, errMap map[int]error) {
 				r := &v1.ActionList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("actions").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("actions").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *actions) List(opts metav1.ListOptions) (result *v1.ActionList, err erro
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("actions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("actions").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *actions) List(opts metav1.ListOptions) (result *v1.ActionList, err erro
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("actions").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("actions").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *actions) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface 
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("actions").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("actions").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -107,12 +108,14 @@ func (c *componentStatuses) List(opts metav1.ListOptions) (result *v1.ComponentS
 		for i, client := range c.clients {
 			go func(c *componentStatuses, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ComponentStatusList, errMap map[int]error) {
 				r := &v1.ComponentStatusList{}
-				err := ci.Get().
-					Resource("componentstatuses").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("componentstatuses").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -168,12 +171,14 @@ func (c *componentStatuses) List(opts metav1.ListOptions) (result *v1.ComponentS
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("componentstatuses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("componentstatuses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -188,12 +193,14 @@ func (c *componentStatuses) List(opts metav1.ListOptions) (result *v1.ComponentS
 			continue
 		}
 
-		err = client.Get().
-			Resource("componentstatuses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("componentstatuses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -219,11 +226,13 @@ func (c *componentStatuses) Watch(opts metav1.ListOptions) watch.AggregatedWatch
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("componentstatuses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("componentstatuses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *configMaps) List(opts metav1.ListOptions) (result *v1.ConfigMapList, er
 		for i, client := range c.clients {
 			go func(c *configMaps, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ConfigMapList, errMap map[int]error) {
 				r := &v1.ConfigMapList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("configmaps").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("configmaps").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *configMaps) List(opts metav1.ListOptions) (result *v1.ConfigMapList, er
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("configmaps").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("configmaps").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *configMaps) List(opts metav1.ListOptions) (result *v1.ConfigMapList, er
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("configmaps").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("configmaps").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *configMaps) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfa
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("configmaps").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("configmaps").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/controllerinstance.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/controllerinstance.go
@@ -32,6 +32,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -106,12 +107,14 @@ func (c *controllerInstances) List(opts metav1.ListOptions) (result *v1.Controll
 		for i, client := range c.clients {
 			go func(c *controllerInstances, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ControllerInstanceList, errMap map[int]error) {
 				r := &v1.ControllerInstanceList{}
-				err := ci.Get().
-					Resource("controllerinstances").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("controllerinstances").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -167,12 +170,14 @@ func (c *controllerInstances) List(opts metav1.ListOptions) (result *v1.Controll
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("controllerinstances").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("controllerinstances").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -187,12 +192,14 @@ func (c *controllerInstances) List(opts metav1.ListOptions) (result *v1.Controll
 			continue
 		}
 
-		err = client.Get().
-			Resource("controllerinstances").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("controllerinstances").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -218,11 +225,13 @@ func (c *controllerInstances) Watch(opts metav1.ListOptions) watch.AggregatedWat
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("controllerinstances").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("controllerinstances").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *endpoints) List(opts metav1.ListOptions) (result *v1.EndpointsList, err
 		for i, client := range c.clients {
 			go func(c *endpoints, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.EndpointsList, errMap map[int]error) {
 				r := &v1.EndpointsList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("endpoints").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("endpoints").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *endpoints) List(opts metav1.ListOptions) (result *v1.EndpointsList, err
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("endpoints").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("endpoints").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *endpoints) List(opts metav1.ListOptions) (result *v1.EndpointsList, err
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("endpoints").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("endpoints").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *endpoints) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfac
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("endpoints").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("endpoints").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *events) List(opts metav1.ListOptions) (result *v1.EventList, err error)
 		for i, client := range c.clients {
 			go func(c *events, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.EventList, errMap map[int]error) {
 				r := &v1.EventList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("events").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("events").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *events) List(opts metav1.ListOptions) (result *v1.EventList, err error)
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("events").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("events").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *events) List(opts metav1.ListOptions) (result *v1.EventList, err error)
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("events").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("events").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *events) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("events").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("events").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *limitRanges) List(opts metav1.ListOptions) (result *v1.LimitRangeList, 
 		for i, client := range c.clients {
 			go func(c *limitRanges, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.LimitRangeList, errMap map[int]error) {
 				r := &v1.LimitRangeList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("limitranges").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("limitranges").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *limitRanges) List(opts metav1.ListOptions) (result *v1.LimitRangeList, 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("limitranges").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("limitranges").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *limitRanges) List(opts metav1.ListOptions) (result *v1.LimitRangeList, 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("limitranges").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("limitranges").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *limitRanges) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterf
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("limitranges").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("limitranges").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -115,13 +116,15 @@ func (c *namespaces) List(opts metav1.ListOptions) (result *v1.NamespaceList, er
 		for i, client := range c.clients {
 			go func(c *namespaces, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.NamespaceList, errMap map[int]error) {
 				r := &v1.NamespaceList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("namespaces").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("namespaces").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -177,13 +180,15 @@ func (c *namespaces) List(opts metav1.ListOptions) (result *v1.NamespaceList, er
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("namespaces").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("namespaces").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -198,13 +203,15 @@ func (c *namespaces) List(opts metav1.ListOptions) (result *v1.NamespaceList, er
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("namespaces").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("namespaces").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -230,12 +237,14 @@ func (c *namespaces) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfa
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("namespaces").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("namespaces").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -108,12 +109,14 @@ func (c *nodes) List(opts metav1.ListOptions) (result *v1.NodeList, err error) {
 		for i, client := range c.clients {
 			go func(c *nodes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.NodeList, errMap map[int]error) {
 				r := &v1.NodeList{}
-				err := ci.Get().
-					Resource("nodes").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("nodes").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -169,12 +172,14 @@ func (c *nodes) List(opts metav1.ListOptions) (result *v1.NodeList, err error) {
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("nodes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("nodes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -189,12 +194,14 @@ func (c *nodes) List(opts metav1.ListOptions) (result *v1.NodeList, err error) {
 			continue
 		}
 
-		err = client.Get().
-			Resource("nodes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("nodes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -220,11 +227,13 @@ func (c *nodes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("nodes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("nodes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -116,13 +117,15 @@ func (c *persistentVolumes) List(opts metav1.ListOptions) (result *v1.Persistent
 		for i, client := range c.clients {
 			go func(c *persistentVolumes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.PersistentVolumeList, errMap map[int]error) {
 				r := &v1.PersistentVolumeList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("persistentvolumes").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("persistentvolumes").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -178,13 +181,15 @@ func (c *persistentVolumes) List(opts metav1.ListOptions) (result *v1.Persistent
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("persistentvolumes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("persistentvolumes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -199,13 +204,15 @@ func (c *persistentVolumes) List(opts metav1.ListOptions) (result *v1.Persistent
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("persistentvolumes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("persistentvolumes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -231,12 +238,14 @@ func (c *persistentVolumes) Watch(opts metav1.ListOptions) watch.AggregatedWatch
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("persistentvolumes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("persistentvolumes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *persistentVolumeClaims) List(opts metav1.ListOptions) (result *v1.Persi
 		for i, client := range c.clients {
 			go func(c *persistentVolumeClaims, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.PersistentVolumeClaimList, errMap map[int]error) {
 				r := &v1.PersistentVolumeClaimList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("persistentvolumeclaims").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("persistentvolumeclaims").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *persistentVolumeClaims) List(opts metav1.ListOptions) (result *v1.Persi
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("persistentvolumeclaims").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("persistentvolumeclaims").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *persistentVolumeClaims) List(opts metav1.ListOptions) (result *v1.Persi
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("persistentvolumeclaims").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("persistentvolumeclaims").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *persistentVolumeClaims) Watch(opts metav1.ListOptions) watch.Aggregated
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("persistentvolumeclaims").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("persistentvolumeclaims").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *pods) List(opts metav1.ListOptions) (result *v1.PodList, err error) {
 		for i, client := range c.clients {
 			go func(c *pods, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.PodList, errMap map[int]error) {
 				r := &v1.PodList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("pods").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("pods").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *pods) List(opts metav1.ListOptions) (result *v1.PodList, err error) {
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("pods").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("pods").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *pods) List(opts metav1.ListOptions) (result *v1.PodList, err error) {
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("pods").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("pods").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *pods) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("pods").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("pods").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *podTemplates) List(opts metav1.ListOptions) (result *v1.PodTemplateList
 		for i, client := range c.clients {
 			go func(c *podTemplates, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.PodTemplateList, errMap map[int]error) {
 				r := &v1.PodTemplateList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("podtemplates").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("podtemplates").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *podTemplates) List(opts metav1.ListOptions) (result *v1.PodTemplateList
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("podtemplates").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("podtemplates").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *podTemplates) List(opts metav1.ListOptions) (result *v1.PodTemplateList
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("podtemplates").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("podtemplates").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *podTemplates) Watch(opts metav1.ListOptions) watch.AggregatedWatchInter
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("podtemplates").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("podtemplates").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
@@ -34,6 +34,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -123,13 +124,15 @@ func (c *replicationControllers) List(opts metav1.ListOptions) (result *v1.Repli
 		for i, client := range c.clients {
 			go func(c *replicationControllers, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ReplicationControllerList, errMap map[int]error) {
 				r := &v1.ReplicationControllerList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("replicationcontrollers").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("replicationcontrollers").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -185,13 +188,15 @@ func (c *replicationControllers) List(opts metav1.ListOptions) (result *v1.Repli
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("replicationcontrollers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("replicationcontrollers").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -206,13 +211,15 @@ func (c *replicationControllers) List(opts metav1.ListOptions) (result *v1.Repli
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("replicationcontrollers").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("replicationcontrollers").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -238,13 +245,15 @@ func (c *replicationControllers) Watch(opts metav1.ListOptions) watch.Aggregated
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("replicationcontrollers").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("replicationcontrollers").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *resourceQuotas) List(opts metav1.ListOptions) (result *v1.ResourceQuota
 		for i, client := range c.clients {
 			go func(c *resourceQuotas, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ResourceQuotaList, errMap map[int]error) {
 				r := &v1.ResourceQuotaList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("resourcequotas").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("resourcequotas").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *resourceQuotas) List(opts metav1.ListOptions) (result *v1.ResourceQuota
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("resourcequotas").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("resourcequotas").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *resourceQuotas) List(opts metav1.ListOptions) (result *v1.ResourceQuota
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("resourcequotas").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("resourcequotas").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *resourceQuotas) Watch(opts metav1.ListOptions) watch.AggregatedWatchInt
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("resourcequotas").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("resourcequotas").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *secrets) List(opts metav1.ListOptions) (result *v1.SecretList, err erro
 		for i, client := range c.clients {
 			go func(c *secrets, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.SecretList, errMap map[int]error) {
 				r := &v1.SecretList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("secrets").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("secrets").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *secrets) List(opts metav1.ListOptions) (result *v1.SecretList, err erro
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("secrets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("secrets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *secrets) List(opts metav1.ListOptions) (result *v1.SecretList, err erro
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("secrets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("secrets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *secrets) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface 
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("secrets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("secrets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *services) List(opts metav1.ListOptions) (result *v1.ServiceList, err er
 		for i, client := range c.clients {
 			go func(c *services, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ServiceList, errMap map[int]error) {
 				r := &v1.ServiceList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("services").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("services").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *services) List(opts metav1.ListOptions) (result *v1.ServiceList, err er
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("services").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("services").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *services) List(opts metav1.ListOptions) (result *v1.ServiceList, err er
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("services").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("services").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *services) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("services").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("services").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *serviceAccounts) List(opts metav1.ListOptions) (result *v1.ServiceAccou
 		for i, client := range c.clients {
 			go func(c *serviceAccounts, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ServiceAccountList, errMap map[int]error) {
 				r := &v1.ServiceAccountList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("serviceaccounts").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("serviceaccounts").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *serviceAccounts) List(opts metav1.ListOptions) (result *v1.ServiceAccou
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("serviceaccounts").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("serviceaccounts").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *serviceAccounts) List(opts metav1.ListOptions) (result *v1.ServiceAccou
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("serviceaccounts").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("serviceaccounts").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *serviceAccounts) Watch(opts metav1.ListOptions) watch.AggregatedWatchIn
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("serviceaccounts").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("serviceaccounts").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/storagecluster.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/storagecluster.go
@@ -32,6 +32,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -106,12 +107,14 @@ func (c *storageClusters) List(opts metav1.ListOptions) (result *v1.StorageClust
 		for i, client := range c.clients {
 			go func(c *storageClusters, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.StorageClusterList, errMap map[int]error) {
 				r := &v1.StorageClusterList{}
-				err := ci.Get().
-					Resource("storageclusters").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("storageclusters").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -167,12 +170,14 @@ func (c *storageClusters) List(opts metav1.ListOptions) (result *v1.StorageClust
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("storageclusters").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("storageclusters").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -187,12 +192,14 @@ func (c *storageClusters) List(opts metav1.ListOptions) (result *v1.StorageClust
 			continue
 		}
 
-		err = client.Get().
-			Resource("storageclusters").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("storageclusters").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -218,11 +225,13 @@ func (c *storageClusters) Watch(opts metav1.ListOptions) watch.AggregatedWatchIn
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("storageclusters").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("storageclusters").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/tenant.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/tenant.go
@@ -32,6 +32,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -106,12 +107,14 @@ func (c *tenants) List(opts metav1.ListOptions) (result *v1.TenantList, err erro
 		for i, client := range c.clients {
 			go func(c *tenants, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.TenantList, errMap map[int]error) {
 				r := &v1.TenantList{}
-				err := ci.Get().
-					Resource("tenants").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("tenants").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -167,12 +170,14 @@ func (c *tenants) List(opts metav1.ListOptions) (result *v1.TenantList, err erro
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("tenants").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("tenants").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -187,12 +192,14 @@ func (c *tenants) List(opts metav1.ListOptions) (result *v1.TenantList, err erro
 			continue
 		}
 
-		err = client.Get().
-			Resource("tenants").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("tenants").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -218,11 +225,13 @@ func (c *tenants) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface 
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("tenants").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("tenants").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *events) List(opts v1.ListOptions) (result *v1beta1.EventList, err error
 		for i, client := range c.clients {
 			go func(c *events, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.EventList, errMap map[int]error) {
 				r := &v1beta1.EventList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("events").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("events").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *events) List(opts v1.ListOptions) (result *v1beta1.EventList, err error
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("events").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("events").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *events) List(opts v1.ListOptions) (result *v1beta1.EventList, err error
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("events").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("events").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *events) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("events").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("events").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/BUILD
@@ -31,6 +31,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, e
 		for i, client := range c.clients {
 			go func(c *daemonSets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.DaemonSetList, errMap map[int]error) {
 				r := &v1beta1.DaemonSetList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("daemonsets").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("daemonsets").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, e
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("daemonsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("daemonsets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, e
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("daemonsets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("daemonsets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *daemonSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("daemonsets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("daemonsets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -122,13 +123,15 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 		for i, client := range c.clients {
 			go func(c *deployments, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.DeploymentList, errMap map[int]error) {
 				r := &v1beta1.DeploymentList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("deployments").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("deployments").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -184,13 +187,15 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("deployments").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -205,13 +210,15 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("deployments").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("deployments").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -237,13 +244,15 @@ func (c *deployments) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface 
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("deployments").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("deployments").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 		for i, client := range c.clients {
 			go func(c *ingresses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.IngressList, errMap map[int]error) {
 				r := &v1beta1.IngressList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("ingresses").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("ingresses").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("ingresses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("ingresses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("ingresses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("ingresses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *ingresses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("ingresses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("ingresses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *networkPolicies) List(opts v1.ListOptions) (result *v1beta1.NetworkPoli
 		for i, client := range c.clients {
 			go func(c *networkPolicies, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.NetworkPolicyList, errMap map[int]error) {
 				r := &v1beta1.NetworkPolicyList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("networkpolicies").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("networkpolicies").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *networkPolicies) List(opts v1.ListOptions) (result *v1beta1.NetworkPoli
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("networkpolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("networkpolicies").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *networkPolicies) List(opts v1.ListOptions) (result *v1beta1.NetworkPoli
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("networkpolicies").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("networkpolicies").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *networkPolicies) Watch(opts v1.ListOptions) watch.AggregatedWatchInterf
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("networkpolicies").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("networkpolicies").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -115,13 +116,15 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecu
 		for i, client := range c.clients {
 			go func(c *podSecurityPolicies, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.PodSecurityPolicyList, errMap map[int]error) {
 				r := &v1beta1.PodSecurityPolicyList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("podsecuritypolicies").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("podsecuritypolicies").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -177,13 +180,15 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecu
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("podsecuritypolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("podsecuritypolicies").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -198,13 +203,15 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecu
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("podsecuritypolicies").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("podsecuritypolicies").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -230,12 +237,14 @@ func (c *podSecurityPolicies) Watch(opts v1.ListOptions) watch.AggregatedWatchIn
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("podsecuritypolicies").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("podsecuritypolicies").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -122,13 +123,15 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList,
 		for i, client := range c.clients {
 			go func(c *replicaSets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.ReplicaSetList, errMap map[int]error) {
 				r := &v1beta1.ReplicaSetList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("replicasets").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("replicasets").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -184,13 +187,15 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList,
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("replicasets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("replicasets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -205,13 +210,15 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList,
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("replicasets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("replicasets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -237,13 +244,15 @@ func (c *replicaSets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface 
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("replicasets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("replicasets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *networkPolicies) List(opts metav1.ListOptions) (result *v1.NetworkPolic
 		for i, client := range c.clients {
 			go func(c *networkPolicies, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.NetworkPolicyList, errMap map[int]error) {
 				r := &v1.NetworkPolicyList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("networkpolicies").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("networkpolicies").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *networkPolicies) List(opts metav1.ListOptions) (result *v1.NetworkPolic
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("networkpolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("networkpolicies").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *networkPolicies) List(opts metav1.ListOptions) (result *v1.NetworkPolic
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("networkpolicies").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("networkpolicies").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *networkPolicies) Watch(opts metav1.ListOptions) watch.AggregatedWatchIn
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("networkpolicies").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("networkpolicies").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 		for i, client := range c.clients {
 			go func(c *ingresses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.IngressList, errMap map[int]error) {
 				r := &v1beta1.IngressList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("ingresses").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("ingresses").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("ingresses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("ingresses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("ingresses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("ingresses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *ingresses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("ingresses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("ingresses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -107,12 +108,14 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1alpha1.RuntimeClas
 		for i, client := range c.clients {
 			go func(c *runtimeClasses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.RuntimeClassList, errMap map[int]error) {
 				r := &v1alpha1.RuntimeClassList{}
-				err := ci.Get().
-					Resource("runtimeclasses").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("runtimeclasses").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -168,12 +171,14 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1alpha1.RuntimeClas
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("runtimeclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("runtimeclasses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -188,12 +193,14 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1alpha1.RuntimeClas
 			continue
 		}
 
-		err = client.Get().
-			Resource("runtimeclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("runtimeclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -219,11 +226,13 @@ func (c *runtimeClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterfa
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("runtimeclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("runtimeclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -107,12 +108,14 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1beta1.RuntimeClass
 		for i, client := range c.clients {
 			go func(c *runtimeClasses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.RuntimeClassList, errMap map[int]error) {
 				r := &v1beta1.RuntimeClassList{}
-				err := ci.Get().
-					Resource("runtimeclasses").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("runtimeclasses").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -168,12 +171,14 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1beta1.RuntimeClass
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("runtimeclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("runtimeclasses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -188,12 +193,14 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1beta1.RuntimeClass
 			continue
 		}
 
-		err = client.Get().
-			Resource("runtimeclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("runtimeclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -219,11 +226,13 @@ func (c *runtimeClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterfa
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("runtimeclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("runtimeclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -119,13 +120,15 @@ func (c *podDisruptionBudgets) List(opts v1.ListOptions) (result *v1beta1.PodDis
 		for i, client := range c.clients {
 			go func(c *podDisruptionBudgets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.PodDisruptionBudgetList, errMap map[int]error) {
 				r := &v1beta1.PodDisruptionBudgetList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("poddisruptionbudgets").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("poddisruptionbudgets").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *podDisruptionBudgets) List(opts v1.ListOptions) (result *v1beta1.PodDis
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("poddisruptionbudgets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("poddisruptionbudgets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *podDisruptionBudgets) List(opts v1.ListOptions) (result *v1beta1.PodDis
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("poddisruptionbudgets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("poddisruptionbudgets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *podDisruptionBudgets) Watch(opts v1.ListOptions) watch.AggregatedWatchI
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("poddisruptionbudgets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("poddisruptionbudgets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -115,13 +116,15 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecu
 		for i, client := range c.clients {
 			go func(c *podSecurityPolicies, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.PodSecurityPolicyList, errMap map[int]error) {
 				r := &v1beta1.PodSecurityPolicyList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("podsecuritypolicies").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("podsecuritypolicies").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -177,13 +180,15 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecu
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("podsecuritypolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("podsecuritypolicies").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -198,13 +203,15 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecu
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("podsecuritypolicies").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("podsecuritypolicies").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -230,12 +237,14 @@ func (c *podSecurityPolicies) Watch(opts v1.ListOptions) watch.AggregatedWatchIn
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("podsecuritypolicies").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("podsecuritypolicies").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -115,13 +116,15 @@ func (c *clusterRoles) List(opts metav1.ListOptions) (result *v1.ClusterRoleList
 		for i, client := range c.clients {
 			go func(c *clusterRoles, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ClusterRoleList, errMap map[int]error) {
 				r := &v1.ClusterRoleList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("clusterroles").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("clusterroles").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -177,13 +180,15 @@ func (c *clusterRoles) List(opts metav1.ListOptions) (result *v1.ClusterRoleList
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("clusterroles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("clusterroles").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -198,13 +203,15 @@ func (c *clusterRoles) List(opts metav1.ListOptions) (result *v1.ClusterRoleList
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("clusterroles").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("clusterroles").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -230,12 +237,14 @@ func (c *clusterRoles) Watch(opts metav1.ListOptions) watch.AggregatedWatchInter
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("clusterroles").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("clusterroles").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -115,13 +116,15 @@ func (c *clusterRoleBindings) List(opts metav1.ListOptions) (result *v1.ClusterR
 		for i, client := range c.clients {
 			go func(c *clusterRoleBindings, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ClusterRoleBindingList, errMap map[int]error) {
 				r := &v1.ClusterRoleBindingList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("clusterrolebindings").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("clusterrolebindings").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -177,13 +180,15 @@ func (c *clusterRoleBindings) List(opts metav1.ListOptions) (result *v1.ClusterR
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("clusterrolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("clusterrolebindings").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -198,13 +203,15 @@ func (c *clusterRoleBindings) List(opts metav1.ListOptions) (result *v1.ClusterR
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("clusterrolebindings").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("clusterrolebindings").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -230,12 +237,14 @@ func (c *clusterRoleBindings) Watch(opts metav1.ListOptions) watch.AggregatedWat
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("clusterrolebindings").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("clusterrolebindings").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *roles) List(opts metav1.ListOptions) (result *v1.RoleList, err error) {
 		for i, client := range c.clients {
 			go func(c *roles, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.RoleList, errMap map[int]error) {
 				r := &v1.RoleList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("roles").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("roles").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *roles) List(opts metav1.ListOptions) (result *v1.RoleList, err error) {
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("roles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("roles").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *roles) List(opts metav1.ListOptions) (result *v1.RoleList, err error) {
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("roles").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("roles").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *roles) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("roles").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("roles").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *roleBindings) List(opts metav1.ListOptions) (result *v1.RoleBindingList
 		for i, client := range c.clients {
 			go func(c *roleBindings, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.RoleBindingList, errMap map[int]error) {
 				r := &v1.RoleBindingList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("rolebindings").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("rolebindings").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *roleBindings) List(opts metav1.ListOptions) (result *v1.RoleBindingList
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("rolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("rolebindings").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *roleBindings) List(opts metav1.ListOptions) (result *v1.RoleBindingList
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("rolebindings").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("rolebindings").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *roleBindings) Watch(opts metav1.ListOptions) watch.AggregatedWatchInter
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("rolebindings").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("rolebindings").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -115,13 +116,15 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1alpha1.ClusterRoleLi
 		for i, client := range c.clients {
 			go func(c *clusterRoles, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.ClusterRoleList, errMap map[int]error) {
 				r := &v1alpha1.ClusterRoleList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("clusterroles").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("clusterroles").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -177,13 +180,15 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1alpha1.ClusterRoleLi
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("clusterroles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("clusterroles").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -198,13 +203,15 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1alpha1.ClusterRoleLi
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("clusterroles").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("clusterroles").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -230,12 +237,14 @@ func (c *clusterRoles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("clusterroles").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("clusterroles").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -115,13 +116,15 @@ func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1alpha1.Cluste
 		for i, client := range c.clients {
 			go func(c *clusterRoleBindings, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.ClusterRoleBindingList, errMap map[int]error) {
 				r := &v1alpha1.ClusterRoleBindingList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("clusterrolebindings").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("clusterrolebindings").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -177,13 +180,15 @@ func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1alpha1.Cluste
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("clusterrolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("clusterrolebindings").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -198,13 +203,15 @@ func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1alpha1.Cluste
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("clusterrolebindings").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("clusterrolebindings").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -230,12 +237,14 @@ func (c *clusterRoleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchIn
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("clusterrolebindings").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("clusterrolebindings").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *roles) List(opts v1.ListOptions) (result *v1alpha1.RoleList, err error)
 		for i, client := range c.clients {
 			go func(c *roles, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.RoleList, errMap map[int]error) {
 				r := &v1alpha1.RoleList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("roles").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("roles").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *roles) List(opts v1.ListOptions) (result *v1alpha1.RoleList, err error)
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("roles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("roles").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *roles) List(opts v1.ListOptions) (result *v1alpha1.RoleList, err error)
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("roles").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("roles").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *roles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("roles").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("roles").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1alpha1.RoleBindingLi
 		for i, client := range c.clients {
 			go func(c *roleBindings, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.RoleBindingList, errMap map[int]error) {
 				r := &v1alpha1.RoleBindingList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("rolebindings").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("rolebindings").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1alpha1.RoleBindingLi
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("rolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("rolebindings").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1alpha1.RoleBindingLi
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("rolebindings").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("rolebindings").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *roleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("rolebindings").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("rolebindings").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -115,13 +116,15 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1beta1.ClusterRoleLis
 		for i, client := range c.clients {
 			go func(c *clusterRoles, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.ClusterRoleList, errMap map[int]error) {
 				r := &v1beta1.ClusterRoleList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("clusterroles").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("clusterroles").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -177,13 +180,15 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1beta1.ClusterRoleLis
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("clusterroles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("clusterroles").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -198,13 +203,15 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1beta1.ClusterRoleLis
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("clusterroles").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("clusterroles").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -230,12 +237,14 @@ func (c *clusterRoles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("clusterroles").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("clusterroles").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *roles) List(opts v1.ListOptions) (result *v1beta1.RoleList, err error) 
 		for i, client := range c.clients {
 			go func(c *roles, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.RoleList, errMap map[int]error) {
 				r := &v1beta1.RoleList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("roles").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("roles").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *roles) List(opts v1.ListOptions) (result *v1beta1.RoleList, err error) 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("roles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("roles").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *roles) List(opts v1.ListOptions) (result *v1beta1.RoleList, err error) 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("roles").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("roles").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *roles) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("roles").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("roles").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1beta1.RoleBindingLis
 		for i, client := range c.clients {
 			go func(c *roleBindings, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.RoleBindingList, errMap map[int]error) {
 				r := &v1beta1.RoleBindingList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("rolebindings").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("rolebindings").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1beta1.RoleBindingLis
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("rolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("rolebindings").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1beta1.RoleBindingLis
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("rolebindings").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("rolebindings").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *roleBindings) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("rolebindings").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("rolebindings").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -107,12 +108,14 @@ func (c *priorityClasses) List(opts metav1.ListOptions) (result *v1.PriorityClas
 		for i, client := range c.clients {
 			go func(c *priorityClasses, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.PriorityClassList, errMap map[int]error) {
 				r := &v1.PriorityClassList{}
-				err := ci.Get().
-					Resource("priorityclasses").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("priorityclasses").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -168,12 +171,14 @@ func (c *priorityClasses) List(opts metav1.ListOptions) (result *v1.PriorityClas
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("priorityclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("priorityclasses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -188,12 +193,14 @@ func (c *priorityClasses) List(opts metav1.ListOptions) (result *v1.PriorityClas
 			continue
 		}
 
-		err = client.Get().
-			Resource("priorityclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("priorityclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -219,11 +226,13 @@ func (c *priorityClasses) Watch(opts metav1.ListOptions) watch.AggregatedWatchIn
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("priorityclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("priorityclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -107,12 +108,14 @@ func (c *priorityClasses) List(opts v1.ListOptions) (result *v1alpha1.PriorityCl
 		for i, client := range c.clients {
 			go func(c *priorityClasses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.PriorityClassList, errMap map[int]error) {
 				r := &v1alpha1.PriorityClassList{}
-				err := ci.Get().
-					Resource("priorityclasses").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("priorityclasses").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -168,12 +171,14 @@ func (c *priorityClasses) List(opts v1.ListOptions) (result *v1alpha1.PriorityCl
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("priorityclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("priorityclasses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -188,12 +193,14 @@ func (c *priorityClasses) List(opts v1.ListOptions) (result *v1alpha1.PriorityCl
 			continue
 		}
 
-		err = client.Get().
-			Resource("priorityclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("priorityclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -219,11 +226,13 @@ func (c *priorityClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterf
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("priorityclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("priorityclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -107,12 +108,14 @@ func (c *priorityClasses) List(opts v1.ListOptions) (result *v1beta1.PriorityCla
 		for i, client := range c.clients {
 			go func(c *priorityClasses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.PriorityClassList, errMap map[int]error) {
 				r := &v1beta1.PriorityClassList{}
-				err := ci.Get().
-					Resource("priorityclasses").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("priorityclasses").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -168,12 +171,14 @@ func (c *priorityClasses) List(opts v1.ListOptions) (result *v1beta1.PriorityCla
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("priorityclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("priorityclasses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -188,12 +193,14 @@ func (c *priorityClasses) List(opts v1.ListOptions) (result *v1beta1.PriorityCla
 			continue
 		}
 
-		err = client.Get().
-			Resource("priorityclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("priorityclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -219,11 +226,13 @@ func (c *priorityClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterf
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("priorityclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("priorityclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/podpreset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/podpreset.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -118,13 +119,15 @@ func (c *podPresets) List(opts v1.ListOptions) (result *v1alpha1.PodPresetList, 
 		for i, client := range c.clients {
 			go func(c *podPresets, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.PodPresetList, errMap map[int]error) {
 				r := &v1alpha1.PodPresetList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("podpresets").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("podpresets").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -180,13 +183,15 @@ func (c *podPresets) List(opts v1.ListOptions) (result *v1alpha1.PodPresetList, 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("podpresets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("podpresets").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -201,13 +206,15 @@ func (c *podPresets) List(opts v1.ListOptions) (result *v1alpha1.PodPresetList, 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("podpresets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("podpresets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -233,13 +240,15 @@ func (c *podPresets) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("podpresets").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("podpresets").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -107,12 +108,14 @@ func (c *storageClasses) List(opts metav1.ListOptions) (result *v1.StorageClassL
 		for i, client := range c.clients {
 			go func(c *storageClasses, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.StorageClassList, errMap map[int]error) {
 				r := &v1.StorageClassList{}
-				err := ci.Get().
-					Resource("storageclasses").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("storageclasses").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -168,12 +171,14 @@ func (c *storageClasses) List(opts metav1.ListOptions) (result *v1.StorageClassL
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("storageclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("storageclasses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -188,12 +193,14 @@ func (c *storageClasses) List(opts metav1.ListOptions) (result *v1.StorageClassL
 			continue
 		}
 
-		err = client.Get().
-			Resource("storageclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("storageclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -219,11 +226,13 @@ func (c *storageClasses) Watch(opts metav1.ListOptions) watch.AggregatedWatchInt
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("storageclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("storageclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -116,13 +117,15 @@ func (c *volumeAttachments) List(opts metav1.ListOptions) (result *v1.VolumeAtta
 		for i, client := range c.clients {
 			go func(c *volumeAttachments, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.VolumeAttachmentList, errMap map[int]error) {
 				r := &v1.VolumeAttachmentList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("volumeattachments").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("volumeattachments").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -178,13 +181,15 @@ func (c *volumeAttachments) List(opts metav1.ListOptions) (result *v1.VolumeAtta
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("volumeattachments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("volumeattachments").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -199,13 +204,15 @@ func (c *volumeAttachments) List(opts metav1.ListOptions) (result *v1.VolumeAtta
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("volumeattachments").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("volumeattachments").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -231,12 +238,14 @@ func (c *volumeAttachments) Watch(opts metav1.ListOptions) watch.AggregatedWatch
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("volumeattachments").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("volumeattachments").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -116,13 +117,15 @@ func (c *volumeAttachments) List(opts v1.ListOptions) (result *v1alpha1.VolumeAt
 		for i, client := range c.clients {
 			go func(c *volumeAttachments, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.VolumeAttachmentList, errMap map[int]error) {
 				r := &v1alpha1.VolumeAttachmentList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("volumeattachments").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("volumeattachments").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -178,13 +181,15 @@ func (c *volumeAttachments) List(opts v1.ListOptions) (result *v1alpha1.VolumeAt
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("volumeattachments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("volumeattachments").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -199,13 +204,15 @@ func (c *volumeAttachments) List(opts v1.ListOptions) (result *v1alpha1.VolumeAt
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("volumeattachments").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("volumeattachments").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -231,12 +238,14 @@ func (c *volumeAttachments) Watch(opts v1.ListOptions) watch.AggregatedWatchInte
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("volumeattachments").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("volumeattachments").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -107,12 +108,14 @@ func (c *cSINodes) List(opts v1.ListOptions) (result *v1beta1.CSINodeList, err e
 		for i, client := range c.clients {
 			go func(c *cSINodes, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.CSINodeList, errMap map[int]error) {
 				r := &v1beta1.CSINodeList{}
-				err := ci.Get().
-					Resource("csinodes").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("csinodes").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -168,12 +171,14 @@ func (c *cSINodes) List(opts v1.ListOptions) (result *v1beta1.CSINodeList, err e
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("csinodes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("csinodes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -188,12 +193,14 @@ func (c *cSINodes) List(opts v1.ListOptions) (result *v1beta1.CSINodeList, err e
 			continue
 		}
 
-		err = client.Get().
-			Resource("csinodes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("csinodes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -219,11 +226,13 @@ func (c *cSINodes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("csinodes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("csinodes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -107,12 +108,14 @@ func (c *storageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClass
 		for i, client := range c.clients {
 			go func(c *storageClasses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.StorageClassList, errMap map[int]error) {
 				r := &v1beta1.StorageClassList{}
-				err := ci.Get().
-					Resource("storageclasses").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("storageclasses").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -168,12 +171,14 @@ func (c *storageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClass
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("storageclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("storageclasses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -188,12 +193,14 @@ func (c *storageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClass
 			continue
 		}
 
-		err = client.Get().
-			Resource("storageclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("storageclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -219,11 +226,13 @@ func (c *storageClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterfa
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("storageclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("storageclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
@@ -33,6 +33,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 )
 
@@ -116,13 +117,15 @@ func (c *volumeAttachments) List(opts v1.ListOptions) (result *v1beta1.VolumeAtt
 		for i, client := range c.clients {
 			go func(c *volumeAttachments, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.VolumeAttachmentList, errMap map[int]error) {
 				r := &v1beta1.VolumeAttachmentList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("volumeattachments").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("volumeattachments").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -178,13 +181,15 @@ func (c *volumeAttachments) List(opts v1.ListOptions) (result *v1beta1.VolumeAtt
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("volumeattachments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("volumeattachments").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -199,13 +204,15 @@ func (c *volumeAttachments) List(opts v1.ListOptions) (result *v1beta1.VolumeAtt
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("volumeattachments").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("volumeattachments").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -231,12 +238,14 @@ func (c *volumeAttachments) Watch(opts v1.ListOptions) watch.AggregatedWatchInte
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("volumeattachments").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("volumeattachments").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/client-go/util/retry/BUILD
+++ b/staging/src/k8s.io/client-go/util/retry/BUILD
@@ -27,6 +27,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/client-go/util/retry/BUILD
+++ b/staging/src/k8s.io/client-go/util/retry/BUILD
@@ -14,6 +14,8 @@ go_library(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/client-go/util/retry/util.go
+++ b/staging/src/k8s.io/client-go/util/retry/util.go
@@ -89,10 +89,11 @@ func RetryOnTimeout(backoff wait.Backoff, fn func() error) error {
 		case err == nil:
 			return true, nil
 		case errors.IsTimeout(err) || errors.IsServerTimeout(err) || errors.IsServiceUnavailable(err):
-			klog.Infof("Timeout. retry %v", backoff.Steps)
+			klog.Errorf("Encountered error %v. retry %v", err, backoff.Steps)
 			lastTimeoutErr = err
 			return false, nil
 		default: // only retry on timeout error. So return for all other errors
+			klog.Errorf("Encountered error %v. no retry", err)
 			return true, err
 		}
 	})
@@ -114,10 +115,11 @@ func RetryOnNoResponse(backoff wait.Backoff, fn func() (watch.Interface, error))
 			resultObj = obj
 			return true, nil
 		case errors.IsInternalError(err) || errors.IsServiceUnavailable(err):
-			klog.Infof("No response. retry %v", backoff.Steps)
+			klog.Errorf("Encountered error %v. retry %v", err, backoff.Steps)
 			lastTimeoutErr = err
 			return false, nil
 		default: // only retry on no response error. So return for all other errors
+			klog.Errorf("Encountered error %v. no retry", err)
 			return true, err
 		}
 	})

--- a/staging/src/k8s.io/client-go/util/retry/util.go
+++ b/staging/src/k8s.io/client-go/util/retry/util.go
@@ -92,7 +92,7 @@ func RetryOnTimeout(backoff wait.Backoff, fn func() error) error {
 			klog.Infof("Timeout. retry %v", backoff.Steps)
 			lastTimeoutErr = err
 			return false, nil
-		default:	// only retry on timeout error. So return for all other errors
+		default: // only retry on timeout error. So return for all other errors
 			return true, err
 		}
 	})
@@ -117,7 +117,7 @@ func RetryOnNoResponse(backoff wait.Backoff, fn func() (watch.Interface, error))
 			klog.Infof("No response. retry %v", backoff.Steps)
 			lastTimeoutErr = err
 			return false, nil
-		default:	// only retry on no response error. So return for all other errors
+		default: // only retry on no response error. So return for all other errors
 			return true, err
 		}
 	})

--- a/staging/src/k8s.io/client-go/util/retry/util_test.go
+++ b/staging/src/k8s.io/client-go/util/retry/util_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +19,7 @@ package retry
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/watch"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -67,5 +69,251 @@ func TestRetryOnConflict(t *testing.T) {
 	})
 	if err != nil || i != 2 {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRetryOnTimeout_Timeout(t *testing.T) {
+	opts := wait.Backoff{Factor: 1.0, Steps: 3}
+	timeoutErr := errors.NewTimeoutError("timeout", 1)
+	// never returns
+	err := RetryOnTimeout(opts, func() error {
+		return timeoutErr
+	})
+	if err != timeoutErr {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// returns immediately
+	i := 0
+	err = RetryOnTimeout(opts, func() error {
+		i++
+		return nil
+	})
+	if err != nil || i != 1 {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// returns immediately on error
+	testErr := fmt.Errorf("some other error")
+	err = RetryOnTimeout(opts, func() error {
+		return testErr
+	})
+	if err != testErr {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// keeps retrying
+	i = 0
+	err = RetryOnTimeout(opts, func() error {
+		if i < 2 {
+			i++
+			return errors.NewTimeoutError("timeout", 1)
+		}
+		return nil
+	})
+	if err != nil || i != 2 {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRetryOnTimeout_ServerTimeout(t *testing.T) {
+	opts := wait.Backoff{Factor: 1.0, Steps: 3}
+	timeoutErr := errors.NewServerTimeout(schema.GroupResource{Resource: "test"}, "other", 1)
+	// never returns
+	err := RetryOnTimeout(opts, func() error {
+		return timeoutErr
+	})
+	if err != timeoutErr {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// returns immediately
+	i := 0
+	err = RetryOnTimeout(opts, func() error {
+		i++
+		return nil
+	})
+	if err != nil || i != 1 {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// returns immediately on error
+	testErr := fmt.Errorf("some other error")
+	err = RetryOnTimeout(opts, func() error {
+		return testErr
+	})
+	if err != testErr {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// keeps retrying
+	i = 0
+	err = RetryOnTimeout(opts, func() error {
+		if i < 2 {
+			i++
+			return errors.NewServerTimeout(schema.GroupResource{Resource: "test"}, "other", 1)
+		}
+		return nil
+	})
+	if err != nil || i != 2 {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRetryOnTimeout_ServiceUnavailable(t *testing.T) {
+	opts := wait.Backoff{Factor: 1.0, Steps: 3}
+	timeoutErr := errors.NewServiceUnavailable("service unavailable")
+	// never returns
+	err := RetryOnTimeout(opts, func() error {
+		return timeoutErr
+	})
+	if err != timeoutErr {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// returns immediately
+	i := 0
+	err = RetryOnTimeout(opts, func() error {
+		i++
+		return nil
+	})
+	if err != nil || i != 1 {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// returns immediately on error
+	testErr := fmt.Errorf("some other error")
+	err = RetryOnTimeout(opts, func() error {
+		return testErr
+	})
+	if err != testErr {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// keeps retrying
+	i = 0
+	err = RetryOnTimeout(opts, func() error {
+		if i < 2 {
+			i++
+			return errors.NewServiceUnavailable("service unavailable")
+		}
+		return nil
+	})
+	if err != nil || i != 2 {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRetryOnNoResponse_InternalError(t *testing.T) {
+	opts := wait.Backoff{Factor: 1.0, Steps: 3}
+	internalError := errors.NewInternalError(fmt.Errorf("internal error"))
+	watcherMock := watch.NewAggregatedWatcher()
+	// never returns
+	watcher, err := RetryOnNoResponse(opts, func() (watch.Interface, error) {
+		return nil, internalError
+	})
+	if err != internalError {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if watcher != nil {
+		t.Errorf("Expected nil watcher at internal error but got not nil")
+	}
+
+	// returns immediately
+	i := 0
+	watcher, err = RetryOnNoResponse(opts, func() (watch.Interface, error) {
+		i++
+		return watcherMock, nil
+	})
+	if err != nil || i != 1 {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if watcher != watcherMock {
+		t.Errorf("Expecting not nill watcher but got nil")
+	}
+
+	// returns immediately on error
+	testErr := fmt.Errorf("some other error")
+	watcher, err = RetryOnNoResponse(opts, func() (watch.Interface, error) {
+		return nil, testErr
+	})
+	if err != testErr {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if watcher != nil {
+		t.Errorf("Expected nil watcher at internal error but got not nil")
+	}
+
+	// keeps retrying
+	i = 0
+	watcher, err = RetryOnNoResponse(opts, func() (watch.Interface, error) {
+		if i < 2 {
+			i++
+			return nil, errors.NewInternalError(fmt.Errorf("internal error"))
+		}
+		return watcher, nil
+	})
+	if err != nil || i != 2 {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if watcher != nil {
+		t.Errorf("Expected nil watcher at internal error but got not nil")
+	}
+}
+
+func TestRetryOnNoResponse__ServiceUnavailable(t *testing.T) {
+	opts := wait.Backoff{Factor: 1.0, Steps: 3}
+	internalError := errors.NewServiceUnavailable("service unavailable")
+	watcherMock := watch.NewAggregatedWatcher()
+	// never returns
+	watcher, err := RetryOnNoResponse(opts, func() (watch.Interface, error) {
+		return nil, internalError
+	})
+	if err != internalError {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if watcher != nil {
+		t.Errorf("Expected nil watcher at internal error but got not nil")
+	}
+
+	// returns immediately
+	i := 0
+	watcher, err = RetryOnNoResponse(opts, func() (watch.Interface, error) {
+		i++
+		return watcherMock, nil
+	})
+	if err != nil || i != 1 {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if watcher != watcherMock {
+		t.Errorf("Expecting not nill watcher but got nil")
+	}
+
+	// returns immediately on error
+	testErr := fmt.Errorf("some other error")
+	watcher, err = RetryOnNoResponse(opts, func() (watch.Interface, error) {
+		return nil, testErr
+	})
+	if err != testErr {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if watcher != nil {
+		t.Errorf("Expected nil watcher at internal error but got not nil")
+	}
+
+	// keeps retrying
+	i = 0
+	watcher, err = RetryOnNoResponse(opts, func() (watch.Interface, error) {
+		if i < 2 {
+			i++
+			return nil, errors.NewServiceUnavailable("service unavailable")
+		}
+		return watcher, nil
+	})
+	if err != nil || i != 2 {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if watcher != nil {
+		t.Errorf("Expected nil watcher at internal error but got not nil")
 	}
 }

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	v1 "k8s.io/code-generator/_examples/MixedCase/apis/example/v1"
 	scheme "k8s.io/code-generator/_examples/MixedCase/clientset/versioned/scheme"
 	klog "k8s.io/klog"
@@ -112,12 +113,14 @@ func (c *clusterTestTypes) List(opts metav1.ListOptions) (result *v1.ClusterTest
 		for i, client := range c.clients {
 			go func(c *clusterTestTypes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ClusterTestTypeList, errMap map[int]error) {
 				r := &v1.ClusterTestTypeList{}
-				err := ci.Get().
-					Resource("clustertesttypes").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("clustertesttypes").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -173,12 +176,14 @@ func (c *clusterTestTypes) List(opts metav1.ListOptions) (result *v1.ClusterTest
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("clustertesttypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("clustertesttypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -193,12 +198,14 @@ func (c *clusterTestTypes) List(opts metav1.ListOptions) (result *v1.ClusterTest
 			continue
 		}
 
-		err = client.Get().
-			Resource("clustertesttypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("clustertesttypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -224,11 +231,13 @@ func (c *clusterTestTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchI
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("clustertesttypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("clustertesttypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	v1 "k8s.io/code-generator/_examples/MixedCase/apis/example/v1"
 	scheme "k8s.io/code-generator/_examples/MixedCase/clientset/versioned/scheme"
 	klog "k8s.io/klog"
@@ -119,13 +120,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		for i, client := range c.clients {
 			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
 				r := &v1.TestTypeList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("testtypes").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("testtypes").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("testtypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("testtypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("testtypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfac
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("testtypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("testtypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	example "k8s.io/code-generator/_examples/apiserver/apis/example"
 	scheme "k8s.io/code-generator/_examples/apiserver/clientset/internalversion/scheme"
 	klog "k8s.io/klog"
@@ -119,13 +120,15 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example.TestTypeList, err
 		for i, client := range c.clients {
 			go func(c *testTypes, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*example.TestTypeList, errMap map[int]error) {
 				r := &example.TestTypeList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("testtypes").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("testtypes").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example.TestTypeList, err
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("testtypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example.TestTypeList, err
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("testtypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("testtypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *testTypes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("testtypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("testtypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	example2 "k8s.io/code-generator/_examples/apiserver/apis/example2"
 	scheme "k8s.io/code-generator/_examples/apiserver/clientset/internalversion/scheme"
 	klog "k8s.io/klog"
@@ -119,13 +120,15 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example2.TestTypeList, er
 		for i, client := range c.clients {
 			go func(c *testTypes, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*example2.TestTypeList, errMap map[int]error) {
 				r := &example2.TestTypeList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("testtypes").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("testtypes").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example2.TestTypeList, er
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("testtypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example2.TestTypeList, er
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("testtypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("testtypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *testTypes) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("testtypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("testtypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	v1 "k8s.io/code-generator/_examples/apiserver/apis/example/v1"
 	scheme "k8s.io/code-generator/_examples/apiserver/clientset/versioned/scheme"
 	klog "k8s.io/klog"
@@ -119,13 +120,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		for i, client := range c.clients {
 			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
 				r := &v1.TestTypeList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("testtypes").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("testtypes").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("testtypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("testtypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("testtypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfac
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("testtypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("testtypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	v1 "k8s.io/code-generator/_examples/apiserver/apis/example2/v1"
 	scheme "k8s.io/code-generator/_examples/apiserver/clientset/versioned/scheme"
 	klog "k8s.io/klog"
@@ -119,13 +120,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		for i, client := range c.clients {
 			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
 				r := &v1.TestTypeList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("testtypes").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("testtypes").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("testtypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("testtypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("testtypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfac
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("testtypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("testtypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	v1 "k8s.io/code-generator/_examples/crd/apis/example/v1"
 	scheme "k8s.io/code-generator/_examples/crd/clientset/versioned/scheme"
 	klog "k8s.io/klog"
@@ -112,12 +113,14 @@ func (c *clusterTestTypes) List(opts metav1.ListOptions) (result *v1.ClusterTest
 		for i, client := range c.clients {
 			go func(c *clusterTestTypes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.ClusterTestTypeList, errMap map[int]error) {
 				r := &v1.ClusterTestTypeList{}
-				err := ci.Get().
-					Resource("clustertesttypes").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("clustertesttypes").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -173,12 +176,14 @@ func (c *clusterTestTypes) List(opts metav1.ListOptions) (result *v1.ClusterTest
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("clustertesttypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("clustertesttypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -193,12 +198,14 @@ func (c *clusterTestTypes) List(opts metav1.ListOptions) (result *v1.ClusterTest
 			continue
 		}
 
-		err = client.Get().
-			Resource("clustertesttypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("clustertesttypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -224,11 +231,13 @@ func (c *clusterTestTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchI
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("clustertesttypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("clustertesttypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/testtype.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	v1 "k8s.io/code-generator/_examples/crd/apis/example/v1"
 	scheme "k8s.io/code-generator/_examples/crd/clientset/versioned/scheme"
 	klog "k8s.io/klog"
@@ -119,13 +120,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		for i, client := range c.clients {
 			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
 				r := &v1.TestTypeList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("testtypes").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("testtypes").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("testtypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("testtypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("testtypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfac
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("testtypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("testtypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/testtype.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	v1 "k8s.io/code-generator/_examples/crd/apis/example2/v1"
 	scheme "k8s.io/code-generator/_examples/crd/clientset/versioned/scheme"
 	klog "k8s.io/klog"
@@ -119,13 +120,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		for i, client := range c.clients {
 			go func(c *testTypes, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.TestTypeList, errMap map[int]error) {
 				r := &v1.TestTypeList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("testtypes").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("testtypes").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("testtypes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("testtypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("testtypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *testTypes) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterfac
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("testtypes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("testtypes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	scheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
@@ -116,13 +117,15 @@ func (c *aPIServices) List(opts metav1.ListOptions) (result *v1.APIServiceList, 
 		for i, client := range c.clients {
 			go func(c *aPIServices, ci rest.Interface, opts metav1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1.APIServiceList, errMap map[int]error) {
 				r := &v1.APIServiceList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("apiservices").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("apiservices").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -178,13 +181,15 @@ func (c *aPIServices) List(opts metav1.ListOptions) (result *v1.APIServiceList, 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("apiservices").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("apiservices").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -199,13 +204,15 @@ func (c *aPIServices) List(opts metav1.ListOptions) (result *v1.APIServiceList, 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("apiservices").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("apiservices").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -231,12 +238,14 @@ func (c *aPIServices) Watch(opts metav1.ListOptions) watch.AggregatedWatchInterf
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("apiservices").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("apiservices").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 	v1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	scheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
@@ -116,13 +117,15 @@ func (c *aPIServices) List(opts v1.ListOptions) (result *v1beta1.APIServiceList,
 		for i, client := range c.clients {
 			go func(c *aPIServices, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.APIServiceList, errMap map[int]error) {
 				r := &v1beta1.APIServiceList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("apiservices").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("apiservices").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -178,13 +181,15 @@ func (c *aPIServices) List(opts v1.ListOptions) (result *v1beta1.APIServiceList,
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("apiservices").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("apiservices").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -199,13 +204,15 @@ func (c *aPIServices) List(opts v1.ListOptions) (result *v1beta1.APIServiceList,
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("apiservices").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("apiservices").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -231,12 +238,14 @@ func (c *aPIServices) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface 
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("apiservices").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("apiservices").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/scheme:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/apiservice.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 	apiregistration "k8s.io/kube-aggregator/pkg/apis/apiregistration"
 	scheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/scheme"
@@ -116,13 +117,15 @@ func (c *aPIServices) List(opts v1.ListOptions) (result *apiregistration.APIServ
 		for i, client := range c.clients {
 			go func(c *aPIServices, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*apiregistration.APIServiceList, errMap map[int]error) {
 				r := &apiregistration.APIServiceList{}
-				err := ci.Get().
-					Tenant(c.te).
-					Resource("apiservices").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).
+						Resource("apiservices").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -178,13 +181,15 @@ func (c *aPIServices) List(opts v1.ListOptions) (result *apiregistration.APIServ
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).
-		Resource("apiservices").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).
+			Resource("apiservices").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -199,13 +204,15 @@ func (c *aPIServices) List(opts v1.ListOptions) (result *apiregistration.APIServ
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).
-			Resource("apiservices").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).
+				Resource("apiservices").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -231,12 +238,14 @@ func (c *aPIServices) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface 
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Resource("apiservices").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Resource("apiservices").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/client/clientset/versioned/scheme:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/nodemetrics.go
@@ -30,6 +30,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 	v1alpha1 "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
 	scheme "k8s.io/metrics/pkg/client/clientset/versioned/scheme"
@@ -101,12 +102,14 @@ func (c *nodeMetricses) List(opts v1.ListOptions) (result *v1alpha1.NodeMetricsL
 		for i, client := range c.clients {
 			go func(c *nodeMetricses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.NodeMetricsList, errMap map[int]error) {
 				r := &v1alpha1.NodeMetricsList{}
-				err := ci.Get().
-					Resource("nodes").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("nodes").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -162,12 +165,14 @@ func (c *nodeMetricses) List(opts v1.ListOptions) (result *v1alpha1.NodeMetricsL
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("nodes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("nodes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -182,12 +187,14 @@ func (c *nodeMetricses) List(opts v1.ListOptions) (result *v1alpha1.NodeMetricsL
 			continue
 		}
 
-		err = client.Get().
-			Resource("nodes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("nodes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -213,11 +220,13 @@ func (c *nodeMetricses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterfac
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("nodes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("nodes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
@@ -30,6 +30,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 	v1alpha1 "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
 	scheme "k8s.io/metrics/pkg/client/clientset/versioned/scheme"
@@ -112,13 +113,15 @@ func (c *podMetricses) List(opts v1.ListOptions) (result *v1alpha1.PodMetricsLis
 		for i, client := range c.clients {
 			go func(c *podMetricses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.PodMetricsList, errMap map[int]error) {
 				r := &v1alpha1.PodMetricsList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("pods").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("pods").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -174,13 +177,15 @@ func (c *podMetricses) List(opts v1.ListOptions) (result *v1alpha1.PodMetricsLis
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("pods").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("pods").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -195,13 +200,15 @@ func (c *podMetricses) List(opts v1.ListOptions) (result *v1alpha1.PodMetricsLis
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("pods").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("pods").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -227,13 +234,15 @@ func (c *podMetricses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("pods").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("pods").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/client/clientset/versioned/scheme:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/nodemetrics.go
@@ -30,6 +30,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 	v1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	scheme "k8s.io/metrics/pkg/client/clientset/versioned/scheme"
@@ -101,12 +102,14 @@ func (c *nodeMetricses) List(opts v1.ListOptions) (result *v1beta1.NodeMetricsLi
 		for i, client := range c.clients {
 			go func(c *nodeMetricses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.NodeMetricsList, errMap map[int]error) {
 				r := &v1beta1.NodeMetricsList{}
-				err := ci.Get().
-					Resource("nodes").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("nodes").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -162,12 +165,14 @@ func (c *nodeMetricses) List(opts v1.ListOptions) (result *v1beta1.NodeMetricsLi
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("nodes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("nodes").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -182,12 +187,14 @@ func (c *nodeMetricses) List(opts v1.ListOptions) (result *v1beta1.NodeMetricsLi
 			continue
 		}
 
-		err = client.Get().
-			Resource("nodes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("nodes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -213,11 +220,13 @@ func (c *nodeMetricses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterfac
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("nodes").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("nodes").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/podmetrics.go
@@ -30,6 +30,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 	v1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	scheme "k8s.io/metrics/pkg/client/clientset/versioned/scheme"
@@ -112,13 +113,15 @@ func (c *podMetricses) List(opts v1.ListOptions) (result *v1beta1.PodMetricsList
 		for i, client := range c.clients {
 			go func(c *podMetricses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.PodMetricsList, errMap map[int]error) {
 				r := &v1beta1.PodMetricsList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("pods").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("pods").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -174,13 +177,15 @@ func (c *podMetricses) List(opts v1.ListOptions) (result *v1beta1.PodMetricsList
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("pods").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("pods").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -195,13 +200,15 @@ func (c *podMetricses) List(opts v1.ListOptions) (result *v1beta1.PodMetricsList
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("pods").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("pods").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -227,13 +234,15 @@ func (c *podMetricses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("pods").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("pods").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/BUILD
+++ b/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//staging/src/k8s.io/node-api/pkg/apis/node/v1alpha1:go_default_library",
         "//staging/src/k8s.io/node-api/pkg/client/clientset/versioned/scheme:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/runtimeclass.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 	v1alpha1 "k8s.io/node-api/pkg/apis/node/v1alpha1"
 	scheme "k8s.io/node-api/pkg/client/clientset/versioned/scheme"
@@ -107,12 +108,14 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1alpha1.RuntimeClas
 		for i, client := range c.clients {
 			go func(c *runtimeClasses, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.RuntimeClassList, errMap map[int]error) {
 				r := &v1alpha1.RuntimeClassList{}
-				err := ci.Get().
-					Resource("runtimeclasses").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Resource("runtimeclasses").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -168,12 +171,14 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1alpha1.RuntimeClas
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Resource("runtimeclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Resource("runtimeclasses").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -188,12 +193,14 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1alpha1.RuntimeClas
 			continue
 		}
 
-		err = client.Get().
-			Resource("runtimeclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Resource("runtimeclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -219,11 +226,13 @@ func (c *runtimeClasses) Watch(opts v1.ListOptions) watch.AggregatedWatchInterfa
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Resource("runtimeclasses").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Resource("runtimeclasses").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1:go_default_library",
         "//staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 	v1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
 	scheme "k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme"
@@ -119,13 +120,15 @@ func (c *flunders) List(opts v1.ListOptions) (result *v1alpha1.FlunderList, err 
 		for i, client := range c.clients {
 			go func(c *flunders, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.FlunderList, errMap map[int]error) {
 				r := &v1alpha1.FlunderList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("flunders").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("flunders").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *flunders) List(opts v1.ListOptions) (result *v1alpha1.FlunderList, err 
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("flunders").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("flunders").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *flunders) List(opts v1.ListOptions) (result *v1alpha1.FlunderList, err 
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("flunders").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("flunders").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *flunders) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("flunders").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("flunders").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1:go_default_library",
         "//staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 	v1beta1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1"
 	scheme "k8s.io/sample-apiserver/pkg/generated/clientset/versioned/scheme"
@@ -119,13 +120,15 @@ func (c *flunders) List(opts v1.ListOptions) (result *v1beta1.FlunderList, err e
 		for i, client := range c.clients {
 			go func(c *flunders, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1beta1.FlunderList, errMap map[int]error) {
 				r := &v1beta1.FlunderList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("flunders").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("flunders").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *flunders) List(opts v1.ListOptions) (result *v1beta1.FlunderList, err e
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("flunders").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("flunders").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *flunders) List(opts v1.ListOptions) (result *v1beta1.FlunderList, err e
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("flunders").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("flunders").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *flunders) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("flunders").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("flunders").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/BUILD
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/apiserverupdate:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//staging/src/k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1:go_default_library",
         "//staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/scheme:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
@@ -31,6 +31,7 @@ import (
 	diff "k8s.io/apimachinery/pkg/util/diff"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
+	retry "k8s.io/client-go/util/retry"
 	klog "k8s.io/klog"
 	v1alpha1 "k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1"
 	scheme "k8s.io/sample-controller/pkg/generated/clientset/versioned/scheme"
@@ -119,13 +120,15 @@ func (c *foos) List(opts v1.ListOptions) (result *v1alpha1.FooList, err error) {
 		for i, client := range c.clients {
 			go func(c *foos, ci rest.Interface, opts v1.ListOptions, lock *sync.Mutex, pos int, resultMap map[int]*v1alpha1.FooList, errMap map[int]error) {
 				r := &v1alpha1.FooList{}
-				err := ci.Get().
-					Tenant(c.te).Namespace(c.ns).
-					Resource("foos").
-					VersionedParams(&opts, scheme.ParameterCodec).
-					Timeout(timeout).
-					Do().
-					Into(r)
+				err := retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+					return ci.Get().
+						Tenant(c.te).Namespace(c.ns).
+						Resource("foos").
+						VersionedParams(&opts, scheme.ParameterCodec).
+						Timeout(timeout).
+						Do().
+						Into(r)
+				})
 
 				lock.Lock()
 				resultMap[pos] = r
@@ -181,13 +184,15 @@ func (c *foos) List(opts v1.ListOptions) (result *v1alpha1.FooList, err error) {
 	// When resourceVersion is empty, objects are read from ETCD directly and will get full
 	// list of data if no permission issue. The list needs to done sequential to avoid increasing
 	// system load.
-	err = c.client.Get().
-		Tenant(c.te).Namespace(c.ns).
-		Resource("foos").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Timeout(timeout).
-		Do().
-		Into(result)
+	err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+		return c.client.Get().
+			Tenant(c.te).Namespace(c.ns).
+			Resource("foos").
+			VersionedParams(&opts, scheme.ParameterCodec).
+			Timeout(timeout).
+			Do().
+			Into(result)
+	})
 	if err == nil {
 		return
 	}
@@ -202,13 +207,15 @@ func (c *foos) List(opts v1.ListOptions) (result *v1alpha1.FooList, err error) {
 			continue
 		}
 
-		err = client.Get().
-			Tenant(c.te).Namespace(c.ns).
-			Resource("foos").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Do().
-			Into(result)
+		err = retry.RetryOnTimeout(retry.DefaultRetry, func() error {
+			return client.Get().
+				Tenant(c.te).Namespace(c.ns).
+				Resource("foos").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Do().
+				Into(result)
+		})
 
 		if err == nil {
 			c.client = client
@@ -234,13 +241,15 @@ func (c *foos) Watch(opts v1.ListOptions) watch.AggregatedWatchInterface {
 	opts.Watch = true
 	aggWatch := watch.NewAggregatedWatcher()
 	for _, client := range c.clients {
-		watcher, err := client.Get().
-			Tenant(c.te).
-			Namespace(c.ns).
-			Resource("foos").
-			VersionedParams(&opts, scheme.ParameterCodec).
-			Timeout(timeout).
-			Watch()
+		watcher, err := retry.RetryOnNoResponse(retry.DefaultRetry, func() (watch.Interface, error) {
+			return client.Get().
+				Tenant(c.te).
+				Namespace(c.ns).
+				Resource("foos").
+				VersionedParams(&opts, scheme.ParameterCodec).
+				Timeout(timeout).
+				Watch()
+		})
 		if err != nil && opts.AllowPartialWatch && errors.IsForbidden(err) {
 			// watch error was not returned properly in error message. Skip when partial watch is allowed
 			klog.V(6).Infof("Watch error for partial watch %v. options [%+v]", err, opts)


### PR DESCRIPTION
During perf test for partitioned api servers, when load is approaching limit, we saw panic "send on closed channel". Before the panic, we always got a lot of timeout. It is most likely caused by aggregated watch failed to build connection from some of the servers but succeed on other(s). Therefore, trying to add retry logic for list and watch.

For List, we added retry on timeout/server timeout/service unavailable.
For watch, we added retry on internal error/ service unavailable. 
We observed timeout error and 500 but not sure what is the exact error type that is returned to client when api servers are under stress.

Tested locally & 500 nodes 3 api server 2 wcm density test/no promethus