### PR TITLE
Enable Vertical Scaling feature-gate and add support for testing VM pods in E2E test

### DIFF
--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -31,8 +31,7 @@ import (
 const (
 
 	// CoreDNS is GA in v1.11
-	CoreDNS                   = "CoreDNS"
-	InPlacePodVerticalScaling = "InPlacePodVerticalScaling"
+	CoreDNS = "CoreDNS"
 )
 
 var coreDNSMessage = "featureGates:CoreDNS has been removed in v1.13\n" +
@@ -40,8 +39,7 @@ var coreDNSMessage = "featureGates:CoreDNS has been removed in v1.13\n" +
 
 // InitFeatureGates are the default feature gates for the init command
 var InitFeatureGates = FeatureList{
-	CoreDNS:                   {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Deprecated}, HiddenInHelpText: true, DeprecationMessage: coreDNSMessage},
-	InPlacePodVerticalScaling: {FeatureSpec: featuregate.FeatureSpec{Default: false}, HiddenInHelpText: true},
+	CoreDNS: {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Deprecated}, HiddenInHelpText: true, DeprecationMessage: coreDNSMessage},
 }
 
 // Feature represents a feature being gated

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -584,7 +584,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: false, PreRelease: featuregate.Alpha},
 	NonPreemptingPriority:                          {Default: false, PreRelease: featuregate.Alpha},
 	VolumePVCDataSource:                            {Default: false, PreRelease: featuregate.Alpha},
-	InPlacePodVerticalScaling:                      {Default: false, PreRelease: featuregate.Alpha},
+	InPlacePodVerticalScaling:                      {Default: true, PreRelease: featuregate.Beta},
 	PerNetworkServiceIPAlloc:                       {Default: false, PreRelease: featuregate.Alpha},
 	MandatoryArktosNetwork:                         {Default: false, PreRelease: featuregate.Alpha},
 	WorkloadInfoDefaulting:                         {Default: false, PreRelease: featuregate.Alpha},

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1496,8 +1496,11 @@ func LookForStringInPodExec(ns, podName string, command []string, expectedString
 // executed in a specific pod container.
 func LookForStringInPodExecToContainer(ns, podName, containerName string, command []string, expectedString string, timeout time.Duration) (result string, err error) {
 	return LookForString(expectedString, timeout, func() string {
-		// use the first container
-		args := []string{"exec", podName, "-c", containerName, fmt.Sprintf("--namespace=%v", ns), "--"}
+		args := []string{"exec", podName, fmt.Sprintf("--namespace=%v", ns)}
+		if len(containerName) > 0 {
+			args = append(args, fmt.Sprintf("--container=%s", containerName))
+		}
+		args = append(args, "--")
 		args = append(args, command...)
 		return RunKubectlOrDie(args...)
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
kind feature
> /kind flake

**What this PR does / why we need it**: This adds E2E test support for Vertical Scaling for VM pods, and enables the feature-gate to allow it to be tested in CI/CD.

**Which issue(s) this PR fixes**: #666 666
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
To run Vertical Scaling E2E test for container:
kubetest --test --provider=local --test_args="--ginkgo.focus=PodInPlaceResizeContainer"
To run Vertical Scaling E2E test for VM:
kubetest --test --provider=local --test_args="--ginkgo.focus=PodInPlaceResizeVM"
To run it for both:
kubetest --test --provider=local --test_args="--ginkgo.focus=PodInPlaceResize"
```
