### PR TITLE
nginx proxy setting with two TPs

### DIFF
--- a/hack/scale_out_poc/two_TP/nginx.conf
+++ b/hack/scale_out_poc/two_TP/nginx.conf
@@ -75,22 +75,6 @@ http {
                 }
 
                 #################################################################
-                # forward non-resource requests back to its source partition
-                #################################################################
-
-                location ~ ^/[a-zA-Z0-9_.-]+$ {
-                    proxy_pass http://$remote_addr:8080;
-                }
-
-                location ~ ^/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$ {
-                    proxy_pass http://$remote_addr:8080;
-                }
-
-                location ~ ^/apis/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$ {
-                    proxy_pass http://$remote_addr:8080;
-                }
-
-                #################################################################
                 # forward the request of system-tenants or no tenants specificed back to its source partition
                 #################################################################
 

--- a/hack/scale_out_poc/two_TP/nginx.conf
+++ b/hack/scale_out_poc/two_TP/nginx.conf
@@ -1,0 +1,144 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+    worker_connections 768;
+    # multi_accept on;
+}
+
+http {
+
+    ##
+    # Basic Settings
+    ##
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048; 
+    proxy_http_version 1.1; 
+
+    # server_tokens off;
+
+    # server_names_hash_bucket_size 64;
+    # server_name_in_redirect off;
+
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    ##
+    # SSL Settings
+    ##
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+    ssl_prefer_server_ciphers on;
+
+    ##
+    # Logging Settings
+    ##
+
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
+
+        ##
+        # arktos cluster settings
+        #
+
+        server {
+                listen      {{ proxy_port }};
+                server_name {{ proxy_host_name }} {{ proxy_ip }};
+
+                access_log /var/log/nginx/arktos_access.log;
+                error_log /var/log/nginx/arktos_error.log;
+
+                set $resource_api {{ arktos_api_protocol }}://{{ resource_partition_ip }}:{{ arktos_api_port }};
+                set $tenant_api_one {{ arktos_api_protocol }}://{{ tenant_partition_one_ip }}:{{ arktos_api_port }};
+                set $tenant_api_two {{ arktos_api_protocol }}://{{ tenant_partition_two_ip }}:{{ arktos_api_port }};
+
+                #################################################################
+                # forward nodes related requests to resource partition
+                #################################################################
+
+                location ~ ^/api/v1/nodes?(.*) {
+                    proxy_pass $resource_api;
+                }
+
+                location ~ ^/apis/coordination.k8s.io/v1/leases?(.*) {
+                    proxy_pass $resource_api;
+                }
+
+                location ~ ^/apis/([^/])*/([^/])*/tenants/system/namespaces/kube-node-lease/leases?(.*) {
+                    proxy_pass $resource_api;
+                }
+
+                #################################################################
+                # forward non-resource requests back to its source partition
+                #################################################################
+
+                location ~ ^/[a-zA-Z0-9_.-]+$ {
+                    proxy_pass http://$remote_addr:8080;
+                }
+
+                location ~ ^/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$ {
+                    proxy_pass http://$remote_addr:8080;
+                }
+
+                location ~ ^/apis/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$ {
+                    proxy_pass http://$remote_addr:8080;
+                }
+
+                #################################################################
+                # forward the request of system-tenants or no tenants specificed back to its source partition
+                #################################################################
+
+                location ~* ^/apis/([^/])*/([^/])*/(!tenants)?(.*) {
+                    proxy_pass http://$remote_addr:8080;
+                }
+
+                location ~* ^/api/([^/])*/(!tenants)?(.*) {
+                    proxy_pass http://$remote_addr:8080;
+                }
+
+                location ~ ^/apis/[a-z0-9_.-]+/[a-z0-9_.-]+/tenants/system?(.*) {
+                    proxy_pass http://$remote_addr:8080;
+                }
+
+                location ~ ^/api/[a-z0-9_.-]+/tenants/system?(.*) {
+                    proxy_pass http://$remote_addr:8080;
+                }
+
+                #################################################################
+                # forward the tenant-specific requests to its own tenant-partition
+                #################################################################
+
+                location ~* ^/apis/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/tenants/[a-m0-9_.-]+/(.*) {
+                    proxy_pass $tenant_api_one;
+                }
+                location ~* ^/apis/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/tenants/[n-z_.-]+/(.*) {
+                    proxy_pass $tenant_api_two;
+                }
+
+                #################################################################
+                # should not hit here. if here, send the request back
+                #################################################################
+                location / {
+                    proxy_pass http://$remote_addr:8080;
+                }
+        } 
+
+    ##
+    # Gzip Settings
+    ##
+
+    gzip on;
+
+    ##
+    # Virtual Host Configs
+    ##
+
+    include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/sites-enabled/*;
+}

--- a/hack/scale_out_poc/two_TP/setup_nginx_proxy.sh
+++ b/hack/scale_out_poc/two_TP/setup_nginx_proxy.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Copyright 2020 Authors of Arktos.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+print_help() {
+        echo "This is a tool to set up nginx proxy for Arktos scale-out tests in the local host."
+        echo 
+        echo "To run it: "
+        echo "    TENANT_PARTITION_ONE_IP=##.##.##.##  TENANT_PARTITION_TWO_IP=##.##.##.## RESOURCE_PARTITION_IP=##.##.##.## setup_nginx_proxy.sh"
+}
+
+validate_ip_exit_if_invalid() {
+        local var_name=$1
+        local ip_addr=$2
+        if ! [[ ${ip_addr} =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]
+        then
+                printf "\033[0;31m${var_name} (${ip_addr}) is not a valid ip address. Exit. \033[0m\n"
+                exit 1
+        fi
+}
+
+validate_params() {
+        validate_ip_exit_if_invalid "proxy_ip" "${proxy_ip}"
+        validate_ip_exit_if_invalid "tenant_partition_one_ip" "${tenant_partition_one_ip}"
+        validate_ip_exit_if_invalid "resource_partition_ip" "${resource_partition_ip}"
+}
+
+run_command_exit_if_failed() {
+        command="$@"
+        $command 
+        if [[ $? != 0 ]] 
+        then 
+                printf "\033[0;31mFailed: ${command}\n"
+                printf "Exit. \033[0m\n"
+                exit 1
+        fi
+}
+
+install_nginx_if_needed() {
+        nginx -v > /dev/null 2>&1
+        if [[ $? != 0 ]] 
+        then 
+                printf "\033[0;31mNginx does not exist, installing nginx...\033[0m\n"
+                run_command_exit_if_failed sudo apt-get update && sudo apt-get -y upgrade
+                run_command_exit_if_failed sudo apt --assume-yes install nginx
+        fi
+}
+
+
+config_nginx_proxy() {
+        script_root=$(dirname "${BASH_SOURCE}")
+        local -r temp_file="/tmp/nginx.conf"
+        run_command_exit_if_failed  cp "${script_root}/nginx.conf" "${temp_file}"
+        
+        sed -i -e "s@{{ *proxy_port *}}@${proxy_port}@g" "${temp_file}"
+        sed -i -e "s@{{ *proxy_host_name *}}@${proxy_host_name}@g" "${temp_file}"
+        sed -i -e "s@{{ *proxy_ip *}}@${proxy_ip}@g" "${temp_file}"
+        sed -i -e "s@{{ *arktos_api_protocol *}}@${arktos_api_protocol}@g" "${temp_file}"
+  
+        sed -i -e "s@{{ *arktos_api_port *}}@${arktos_api_port}@g" "${temp_file}"
+        sed -i -e "s@{{ *resource_partition_ip *}}@${resource_partition_ip}@g" "${temp_file}"
+        sed -i -e "s@{{ *tenant_partition_one_ip *}}@${tenant_partition_one_ip}@g" "${temp_file}"
+        sed -i -e "s@{{ *tenant_partition_two_ip *}}@${tenant_partition_two_ip}@g" "${temp_file}"
+
+        run_command_exit_if_failed sudo cp "${temp_file}" "/etc/nginx/nginx.conf"
+}
+
+if [ "$1" == "-h" ] || [ "$1" == "--help" ]
+then
+        print_help
+        exit
+fi
+
+proxy_port=${SCALE_OUT_PROXY_PORT:-8888}
+proxy_host_name=${SCALE_OUT_PROXY_HOST_NAME:-${HOSTNAME}}
+proxy_ip=${SCALE_OUT_PROXY_IP:-$(/bin/hostname -i)}
+
+arktos_api_protocol=${ARKTOS_API_PROTOCOL:-http}
+arktos_api_port=${ARKTOS_API_port:-8080}
+
+tenant_partition_one_ip=${TENANT_PARTITION_ONE_IP}
+tenant_partition_two_ip=${TENANT_PARTITION_TWO_IP}
+resource_partition_ip=${RESOURCE_PARTITION_IP}
+
+validate_params
+
+install_nginx_if_needed
+
+config_nginx_proxy
+
+run_command_exit_if_failed sudo systemctl restart nginx
+
+printf "\033[0;32mNginx Proxy was configured and started. Please check out /var/logs/nginx/ for logs. \033[0m\n"
+
+sudo systemctl status nginx


### PR DESCRIPTION
This change add scripts to config the nginx proxy for two TPs & one RP.

Run:

TENANT_PARTITION_ONE_IP=172.31.26.146  TENANT_PARTITION_TWO_IP=172.31.26.99  RESOURCE_PARTITION_IP=172.31.23.48 hack/scale_out_poc/two_TP/setup_nginx_proxy.sh

