### PR TITLE
Expand kubelet's clientset to support multiple tenant partitions

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -55,6 +55,7 @@ const defaultRootDir = "/var/lib/kubelet"
 // In general, please try to avoid adding flags or configuration fields,
 // we already have a confusingly large amount of them.
 type KubeletFlags struct {
+	TenantServers       []string
 	KubeConfig          string
 	BootstrapKubeconfig string
 
@@ -359,6 +360,9 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 	f.ContainerRuntimeOptions.AddFlags(fs)
 	f.addOSFlags(fs)
 
+	//TODO: post POC, move this to a separated kubeconfig file dedicated for tenant servers
+	//
+	fs.StringSliceVar(&f.TenantServers, "tenant-servers", f.TenantServers, "Comma separated string representing tenant api-server URLs.")
 	fs.StringVar(&f.KubeletConfigFile, "config", f.KubeletConfigFile, "The Kubelet will load its initial configuration from this file. The path may be absolute or relative; relative paths start at the Kubelet's current working directory. Omit this flag to use the built-in default configuration values. Command-line flags override configuration from this file.")
 	fs.StringVar(&f.KubeConfig, "kubeconfig", f.KubeConfig, "Path to kubeconfig files, specifying how to connect to  API servers. Providing --kubeconfig enables API server mode, omitting --kubeconfig enables standalone mode.")
 

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -578,13 +578,13 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 		clientConfigTenantAPI := *clientConfigs
 		for _, cfg := range clientConfigTenantAPI.GetAllConfigs() {
 			cfg.Host = "http://127.0.0.1:8080"
-			klog.Infof("debug: clientConfig.Host: %v, clientConfigTenantAPI.Host: %v", cfg.Host, cfg.Host)
+			klog.Infof("debug: clientConfigTenantAPI.Host: %v", cfg.Host)
 		}
 
 		clientConfigTenantAPI2 := *clientConfigs
 		for _, cfg := range clientConfigTenantAPI.GetAllConfigs() {
 			cfg.Host = "http://127.0.0.1:8081"
-			klog.Infof("debug: clientConfig2.Host: %v, clientConfigTenantAPI2.Host: %v", cfg.Host, cfg.Host)
+			klog.Infof("debug: clientConfigTenantAPI2.Host: %v", cfg.Host)
 		}
 
 		if err != nil {
@@ -638,6 +638,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 				}
 			}
 			heartbeatClientConfig.QPS = float32(-1)
+			klog.Infof("debug: heartbeatClientConfig.Host: %v", cfg.Host)
 		}
 		kubeDeps.HeartbeatClient, err = clientset.NewForConfig(&heartbeatClientConfigs)
 		if err != nil {

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -578,7 +578,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 			return errors.New("closeAllConns must be a valid function other than nil")
 		}
 		kubeDeps.OnHeartbeatFailure = closeAllConns
-		
+
 		// make a separate client for heartbeat with throttling disabled and a timeout attached
 		heartbeatClientConfigs := *clientConfigs
 		for _, heartbeatClientConfig := range heartbeatClientConfigs.GetAllConfigs() {

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -577,13 +577,13 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 		// hack: arktos-scaleout: different client config for tenant api server
 		clientConfigTenantAPI := *clientConfigs
 		for _, cfg := range clientConfigTenantAPI.GetAllConfigs() {
-			cfg.Host = "http://127.0.0.1:8080"
+			cfg.Host = "http://172.31.10.155:8080"
 			klog.Infof("debug: clientConfigTenantAPI.Host: %v", cfg.Host)
 		}
 
 		clientConfigTenantAPI2 := *clientConfigs
 		for _, cfg := range clientConfigTenantAPI.GetAllConfigs() {
-			cfg.Host = "http://127.0.0.1:8081"
+			cfg.Host = "http://172.31.14.52:8080"
 			klog.Infof("debug: clientConfigTenantAPI2.Host: %v", cfg.Host)
 		}
 
@@ -638,7 +638,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 				}
 			}
 			heartbeatClientConfig.QPS = float32(-1)
-			heartbeatClientConfig.Host = "http://127.0.0.1:9091"
+			heartbeatClientConfig.Host = "http://172.31.8.177:8080"
 			klog.Infof("debug: heartbeatClientConfig.Host: %v", heartbeatClientConfig.Host)
 		}
 		kubeDeps.HeartbeatClient, err = clientset.NewForConfig(&heartbeatClientConfigs)

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -638,7 +638,8 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 				}
 			}
 			heartbeatClientConfig.QPS = float32(-1)
-			klog.Infof("debug: heartbeatClientConfig.Host: %v", cfg.Host)
+			heartbeatClientConfig.Host = "http://127.0.0.1:9091"
+			klog.Infof("debug: heartbeatClientConfig.Host: %v", heartbeatClientConfig.Host)
 		}
 		kubeDeps.HeartbeatClient, err = clientset.NewForConfig(&heartbeatClientConfigs)
 		if err != nil {

--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -173,14 +173,23 @@ func run(config *hollowNodeConfig) {
 		klog.Fatalf("Failed to create a ClientConfig: %v. Exiting.", err)
 	}
 
-	client, err := clientset.NewForConfig(clientConfigs)
+	//TODO: arktos-scale-out: hollowNode should have the same args for Tenant servers as well
+	//      fixme when moving to this step running in perf test env
+	client := make([]clientset.Interface, 2)
+	clientFromConfig, err := clientset.NewForConfig(clientConfigs)
 	if err != nil {
 		klog.Fatalf("Failed to create a ClientSet: %v. Exiting.", err)
 	}
 
+	for i := 0; i < len(client); i++ {
+		client[i] = clientFromConfig
+	}
+
 	if config.Morph == "kubelet" {
 		// Start APIServerConfigManager
-		go datapartition.StartAPIServerConfigManagerAndInformerFactory(client, wait.NeverStop)
+		// TODO: Arktos-scale-out: evaluate this function and see if this needs to be done on all tenant partitions
+		//
+		go datapartition.StartAPIServerConfigManagerAndInformerFactory(client[0], wait.NeverStop)
 
 		f, c := kubemark.GetHollowKubeletConfig(config.createHollowKubeletOptions())
 

--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -19,6 +19,16 @@ if [[ -z "${SCALE_OUT_PROXY_ENDPOINT}" ]]; then
   exit 1
 fi
 
+if [[ -z "${TENANT_SERVERS}" ]]; then
+  TENANT_SERVERS=${SCALE_OUT_PROXY_ENDPOINT}
+fi
+
+# for POC, the kubelet_flags is used or the new temporary kubelet commandline args
+KUBELET_FLAGS="--tenant-servers="${TENANT_SERVERS}
+
+echo KUBELET_FLAGS for new kubelet commandline --tenant-servers
+echo ${KUBELET_FLAGS}
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 source "${KUBE_ROOT}/hack/lib/common-var-init.sh"

--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -23,7 +23,7 @@ if [[ -z "${TENANT_SERVERS}" ]]; then
   TENANT_SERVERS=${SCALE_OUT_PROXY_ENDPOINT}
 fi
 
-# for POC, the kubelet_flags is used or the new temporary kubelet commandline args
+# for POC, the kubelet_flags is used for the new temporary kubelet commandline args
 KUBELET_FLAGS="--tenant-servers="${TENANT_SERVERS}
 
 echo KUBELET_FLAGS for new kubelet commandline --tenant-servers

--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -457,7 +457,7 @@ function kube::common::start_workload_controller_manager {
 function kube::common::start_controller_manager {
     local controller_opts="*,-nodelifecycle,-nodeipam"
     if [ "${IS_RESOURCE_PARTITION}" == "true" ]; then
-       controller_opts="nodelifecycle,nodeipam"
+       controller_opts="nodelifecycle"
     fi
 
     CONTROLPLANE_SUDO=$(test -w "${CERT_DIR}" || echo "sudo -E")

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -248,11 +248,11 @@ type Dependencies struct {
 	Options []Option
 
 	// Injected Dependencies
-	Auth                    server.AuthInterface
-	CAdvisorInterface       cadvisor.Interface
-	Cloud                   cloudprovider.Interface
-	ContainerManager        cm.ContainerManager
-	DockerClientConfig      *dockershim.ClientConfig
+	Auth               server.AuthInterface
+	CAdvisorInterface  cadvisor.Interface
+	Cloud              cloudprovider.Interface
+	ContainerManager   cm.ContainerManager
+	DockerClientConfig *dockershim.ClientConfig
 	//TODO: Arktos-scale-out: event should be per Tenant partition and per Resource parition
 	EventClient             v1core.EventsGetter
 	HeartbeatClient         clientset.Interface
@@ -791,7 +791,6 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		klet.runner,
 		containerRefManager,
 		kubeDeps.Recorder)
-
 
 	// TODO: tokenManager to support multiple tenant partitions
 	//

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -257,8 +257,7 @@ type Dependencies struct {
 	HeartbeatClient         clientset.Interface
 	NodeStatusClient        clientset.Interface
 	OnHeartbeatFailure      []func()
-	KubeClient              clientset.Interface
-	KubeClient2             clientset.Interface
+	KubeClient              []clientset.Interface
 	ArktosExtClient         arktos.Interface
 	Mounter                 mount.Interface
 	OOMAdjuster             *oom.OOMAdjuster
@@ -313,20 +312,12 @@ func makePodSourceConfig(kubeCfg *kubeletconfiginternal.KubeletConfiguration, ku
 		}
 	}
 
-	if kubeDeps.KubeClient != nil {
+	for _, client := range kubeDeps.KubeClient {
 		klog.Infof("Watching apiserver")
 		if updatechannel == nil {
 			updatechannel = cfg.Channel(kubetypes.ApiserverSource)
 		}
-		config.NewSourceApiserver(kubeDeps.KubeClient, nodeName, updatechannel)
-	}
-
-	if kubeDeps.KubeClient2 != nil {
-		klog.Infof("Watching apiserver2")
-		if updatechannel == nil {
-			updatechannel = cfg.Channel(kubetypes.ApiserverSource)
-		}
-		config.NewSourceApiserver(kubeDeps.KubeClient2, nodeName, updatechannel)
+		config.NewSourceApiserver(client, nodeName, updatechannel)
 	}
 
 	return cfg, nil
@@ -450,14 +441,14 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	//
 	serviceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	if kubeDeps.KubeClient != nil {
-		serviceLW := cache.NewListWatchFromClient(kubeDeps.KubeClient.CoreV1(), "services", metav1.NamespaceAll, fields.Everything())
+		serviceLW := cache.NewListWatchFromClient(kubeDeps.KubeClient[0].CoreV1(), "services", metav1.NamespaceAll, fields.Everything())
 		r := cache.NewReflector(serviceLW, &v1.Service{}, serviceIndexer, 0)
 		go r.Run(wait.NeverStop)
 	}
 	serviceLister := corelisters.NewServiceLister(serviceIndexer)
 
 	nodeIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-	if kubeDeps.KubeClient != nil {
+	if kubeDeps.HeartbeatClient != nil {
 		fieldSelector := fields.Set{api.ObjectNameField: string(nodeName)}.AsSelector()
 		nodeLW := cache.NewListWatchFromClient(kubeDeps.HeartbeatClient.CoreV1(), "nodes", metav1.NamespaceAll, fieldSelector)
 		r := cache.NewReflector(nodeLW, &v1.Node{}, nodeIndexer, 0)
@@ -502,7 +493,6 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		hostnameOverridden:                      len(hostnameOverride) > 0,
 		nodeName:                                nodeName,
 		kubeClient:                              kubeDeps.KubeClient,
-		kubeClient2:                             kubeDeps.KubeClient2,
 		heartbeatClient:                         kubeDeps.HeartbeatClient,
 		onRepeatedHeartbeatFailure:              kubeDeps.OnHeartbeatFailure,
 		rootDirectory:                           rootDirectory,
@@ -562,16 +552,16 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	var configMapManager configmap.Manager
 	switch kubeCfg.ConfigMapAndSecretChangeDetectionStrategy {
 	case kubeletconfiginternal.WatchChangeDetectionStrategy:
-		secretManager = secret.NewWatchingSecretManager(kubeDeps.KubeClient)
-		configMapManager = configmap.NewWatchingConfigMapManager(kubeDeps.KubeClient)
+		secretManager = secret.NewWatchingSecretManager(kubeDeps.KubeClient[0])
+		configMapManager = configmap.NewWatchingConfigMapManager(kubeDeps.KubeClient[0])
 	case kubeletconfiginternal.TTLCacheChangeDetectionStrategy:
 		secretManager = secret.NewCachingSecretManager(
-			kubeDeps.KubeClient, manager.GetObjectTTLFromNodeFunc(klet.GetNode))
+			kubeDeps.KubeClient[0], manager.GetObjectTTLFromNodeFunc(klet.GetNode))
 		configMapManager = configmap.NewCachingConfigMapManager(
-			kubeDeps.KubeClient, manager.GetObjectTTLFromNodeFunc(klet.GetNode))
+			kubeDeps.KubeClient[0], manager.GetObjectTTLFromNodeFunc(klet.GetNode))
 	case kubeletconfiginternal.GetChangeDetectionStrategy:
-		secretManager = secret.NewSimpleSecretManager(kubeDeps.KubeClient)
-		configMapManager = configmap.NewSimpleConfigMapManager(kubeDeps.KubeClient)
+		secretManager = secret.NewSimpleSecretManager(kubeDeps.KubeClient[0])
+		configMapManager = configmap.NewSimpleConfigMapManager(kubeDeps.KubeClient[0])
 	default:
 		return nil, fmt.Errorf("unknown configmap and secret manager mode: %v", kubeCfg.ConfigMapAndSecretChangeDetectionStrategy)
 	}
@@ -601,10 +591,13 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 			return nil, fmt.Errorf("failed to initialize checkpoint manager: %+v", err)
 		}
 	}
-	// podManager is also responsible for keeping secretManager and configMapManager contents up-to-date.
-	klet.podManager = kubepod.NewBasicPodManager(kubepod.NewBasicMirrorClient(klet.kubeClient), secretManager, configMapManager, checkpointManager)
 
-	klet.statusManager = status.NewManager(klet.kubeClient, klet.podManager, klet)
+	// TODO: pod manager associated with each tenant partitions
+	//
+	// podManager is also responsible for keeping secretManager and configMapManager contents up-to-date.
+	klet.podManager = kubepod.NewBasicPodManager(kubepod.NewBasicMirrorClient(klet.kubeClient[0]), secretManager, configMapManager, checkpointManager)
+
+	klet.statusManager = status.NewManager(klet.kubeClient[0], klet.podManager, klet)
 
 	if remoteRuntimeEndpoint != "" {
 		// remoteImageEndpoint is same as remoteRuntimeEndpoint if not explicitly specified
@@ -670,7 +663,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	// TODO: runtimeClassManager to support multiple tenant partitions
 	//
 	if utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClass) && kubeDeps.KubeClient != nil {
-		klet.runtimeClassManager = runtimeclass.NewManager(kubeDeps.KubeClient)
+		klet.runtimeClassManager = runtimeclass.NewManager(kubeDeps.KubeClient[0])
 	}
 
 	runtimeRegistry, err := runtimeregistry.NewKubeRuntimeRegistry(remoteRuntimeEndpoint)
@@ -776,8 +769,10 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		klet.containerLogManager = logs.NewStubContainerLogManager()
 	}
 
+	// TODO: arktos-scaleout: cert manager should be per Tenant partition
+	//
 	if kubeCfg.ServerTLSBootstrap && kubeDeps.TLSOptions != nil && utilfeature.DefaultFeatureGate.Enabled(features.RotateKubeletServerCertificate) {
-		klet.serverCertificateManager, err = kubeletcertificate.NewKubeletServerCertificateManager(klet.kubeClient, kubeCfg, klet.nodeName, klet.getLastObservedNodeAddresses, certDirectory)
+		klet.serverCertificateManager, err = kubeletcertificate.NewKubeletServerCertificateManager(klet.kubeClient[0], kubeCfg, klet.nodeName, klet.getLastObservedNodeAddresses, certDirectory)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize certificate manager: %v", err)
 		}
@@ -800,7 +795,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 
 	// TODO: tokenManager to support multiple tenant partitions
 	//
-	tokenManager := token.NewManager(kubeDeps.KubeClient)
+	tokenManager := token.NewManager(kubeDeps.KubeClient[0])
 
 	// NewInitializedVolumePluginMgr intializes some storageErrors on the Kubelet runtimeState (in csi_plugin.go init)
 	// which affects node ready status. This function must be called before Kubelet is initialized so that the Node
@@ -833,7 +828,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		nodeName,
 		klet.podManager,
 		klet.statusManager,
-		klet.kubeClient,
+		klet.kubeClient[0],
 		klet.volumePluginMgr,
 		klet.containerRuntime,
 		kubeDeps.Mounter,
@@ -924,8 +919,7 @@ type Kubelet struct {
 
 	nodeName        types.NodeName
 	runtimeCache    kubecontainer.RuntimeCache
-	kubeClient      clientset.Interface
-	kubeClient2     clientset.Interface
+	kubeClient      []clientset.Interface
 	heartbeatClient clientset.Interface
 	iptClient       utilipt.Interface
 	rootDirectory   string
@@ -1815,8 +1809,10 @@ func (kl *Kubelet) handlePodResourcesResize(pod *v1.Pod) {
 
 	kl.podResizeMutex.Lock()
 	defer kl.podResizeMutex.Unlock()
+	// TODO: arktos scale-out. patch POD should be per tenant partition
+	//
 	if fit, patchBytes := kl.canResizePod(pod); fit {
-		_, patchError := kl.kubeClient.CoreV1().PodsWithMultiTenancy(pod.Namespace, pod.Tenant).Patch(pod.Name, types.StrategicMergePatchType, patchBytes)
+		_, patchError := kl.kubeClient[0].CoreV1().PodsWithMultiTenancy(pod.Namespace, pod.Tenant).Patch(pod.Name, types.StrategicMergePatchType, patchBytes)
 		if patchError != nil {
 			klog.Errorf("Failed to patch ResourcesAllocated values for pod %s: %+v\n", pod.Name, patchError)
 		}
@@ -2195,7 +2191,9 @@ func (kl *Kubelet) HandlePodActions(update kubetypes.PodUpdate) {
 				PodName:  action.Spec.PodName,
 				Error:    errStr,
 			}
-			if _, err := kl.kubeClient.CoreV1().ActionsWithMultiTenancy(action.Namespace, action.Tenant).UpdateStatus(action); err != nil {
+			// TODO: arktos-scaleout. UpdateStatus of PodAction should be per Tenant partition, using desired clientset.
+			//
+			if _, err := kl.kubeClient[0].CoreV1().ActionsWithMultiTenancy(action.Namespace, action.Tenant).UpdateStatus(action); err != nil {
 				klog.Errorf("Update Action status for %s failed. Error: %+v", action.Name, err)
 			}
 			continue

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -255,6 +255,7 @@ type Dependencies struct {
 	DockerClientConfig      *dockershim.ClientConfig
 	EventClient             v1core.EventsGetter
 	HeartbeatClient         clientset.Interface
+	NodeStatusClient        clientset.Interface
 	OnHeartbeatFailure      []func()
 	KubeClient              clientset.Interface
 	ArktosExtClient         arktos.Interface

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -253,9 +253,9 @@ type Dependencies struct {
 	Cloud                   cloudprovider.Interface
 	ContainerManager        cm.ContainerManager
 	DockerClientConfig      *dockershim.ClientConfig
+	//TODO: Arktos-scale-out: event should be per Tenant partition and per Resource parition
 	EventClient             v1core.EventsGetter
 	HeartbeatClient         clientset.Interface
-	NodeStatusClient        clientset.Interface
 	OnHeartbeatFailure      []func()
 	KubeClient              []clientset.Interface
 	ArktosExtClient         arktos.Interface

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -230,6 +230,8 @@ func (kl *Kubelet) getRuntime() kubecontainer.Runtime {
 
 // GetNode returns the node info for the configured node name of this Kubelet.
 func (kl *Kubelet) GetNode() (*v1.Node, error) {
+	// arktos scale-out. it is correct to use the tenant partition client here. since the kl.nodeInfo.GetNodeInfo() goes
+	//                   to the scheduler predicate functions
 	if kl.kubeClient == nil {
 		return kl.initialNode()
 	}

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -86,7 +86,7 @@ func (kl *Kubelet) registerWithAPIServer() {
 // value of the annotation for controller-managed attach-detach of attachable
 // persistent volumes for the node.
 func (kl *Kubelet) tryRegisterWithAPIServer(node *v1.Node) bool {
-	_, err := kl.kubeClient.CoreV1().Nodes().Create(node)
+	_, err := kl.heartbeatClient.CoreV1().Nodes().Create(node)
 	if err == nil {
 		return true
 	}
@@ -96,7 +96,7 @@ func (kl *Kubelet) tryRegisterWithAPIServer(node *v1.Node) bool {
 		return false
 	}
 
-	existingNode, err := kl.kubeClient.CoreV1().Nodes().Get(string(kl.nodeName), metav1.GetOptions{})
+	existingNode, err := kl.heartbeatClient.CoreV1().Nodes().Get(string(kl.nodeName), metav1.GetOptions{})
 	if err != nil {
 		klog.Errorf("Unable to register node %q with API server: error getting existing node: %v", kl.nodeName, err)
 		return false
@@ -121,7 +121,7 @@ func (kl *Kubelet) tryRegisterWithAPIServer(node *v1.Node) bool {
 	requiresUpdate = kl.updateDefaultLabels(node, existingNode) || requiresUpdate
 	requiresUpdate = kl.reconcileExtendedResource(node, existingNode) || requiresUpdate
 	if requiresUpdate {
-		if _, _, err := nodeutil.PatchNodeStatus(kl.kubeClient.CoreV1(), types.NodeName(kl.nodeName), originalNode, existingNode); err != nil {
+		if _, _, err := nodeutil.PatchNodeStatus(kl.heartbeatClient.CoreV1(), types.NodeName(kl.nodeName), originalNode, existingNode); err != nil {
 			klog.Errorf("Unable to reconcile node %q with API server: error updating node: %v", kl.nodeName, err)
 			return false
 		}

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -581,6 +581,8 @@ func (kl *Kubelet) makeEnvironmentVariables(pod *v1.Pod, container *v1.Container
 			name := cm.Name
 			configMap, ok := configMaps[name]
 			if !ok {
+				// TODO: arktos-scale-out: this check ( and the 3 more below in the file) should be pod specific clientset check
+				//
 				if kl.kubeClient == nil {
 					return result, fmt.Errorf("Couldn't get configMap %v/%v, no kubeClient defined", pod.Namespace, name)
 				}
@@ -1951,13 +1953,13 @@ func hasHostNamespace(pod *v1.Pod) bool {
 func (kl *Kubelet) hasHostMountPVC(pod *v1.Pod) bool {
 	for _, volume := range pod.Spec.Volumes {
 		if volume.PersistentVolumeClaim != nil {
-			pvc, err := kl.kubeClient.CoreV1().PersistentVolumeClaims(pod.Namespace).Get(volume.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+			pvc, err := kl.kubeClient[0].CoreV1().PersistentVolumeClaims(pod.Namespace).Get(volume.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
 			if err != nil {
 				klog.Warningf("unable to retrieve pvc %s:%s - %v", pod.Namespace, volume.PersistentVolumeClaim.ClaimName, err)
 				continue
 			}
 			if pvc != nil {
-				referencedVolume, err := kl.kubeClient.CoreV1().PersistentVolumes().Get(pvc.Spec.VolumeName, metav1.GetOptions{})
+				referencedVolume, err := kl.kubeClient[0].CoreV1().PersistentVolumes().Get(pvc.Spec.VolumeName, metav1.GetOptions{})
 				if err != nil {
 					klog.Warningf("unable to retrieve pv %s - %v", pvc.Spec.VolumeName, err)
 					continue

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -236,9 +236,9 @@ func newTestKubeletWithImageList(
 	kubelet.machineInfo = machineInfo
 
 	fakeMirrorClient := podtest.NewFakeMirrorClient()
-	secretManager := secret.NewSimpleSecretManager(kubelet.kubeClient)
+	secretManager := secret.NewSimpleSecretManager(kubelet.kubeClient[0])
 	kubelet.secretManager = secretManager
-	configMapManager := configmap.NewSimpleConfigMapManager(kubelet.kubeClient)
+	configMapManager := configmap.NewSimpleConfigMapManager(kubelet.kubeClient[0])
 	kubelet.configMapManager = configMapManager
 	kubelet.podManager = kubepod.NewBasicPodManager(fakeMirrorClient, kubelet.secretManager, kubelet.configMapManager, podtest.NewMockCheckpointManager())
 	kubelet.statusManager = status.NewManager(fakeKubeClient, kubelet.podManager, &statustest.FakePodDeletionSafetyProvider{})
@@ -330,7 +330,7 @@ func newTestKubeletWithImageList(
 
 	var prober volume.DynamicPluginProber // TODO (#51147) inject mock
 	kubelet.volumePluginMgr, err =
-		NewInitializedVolumePluginMgr(kubelet, kubelet.secretManager, kubelet.configMapManager, token.NewManager(kubelet.kubeClient), allPlugins, prober)
+		NewInitializedVolumePluginMgr(kubelet, kubelet.secretManager, kubelet.configMapManager, token.NewManager(kubelet.kubeClient[0]), allPlugins, prober)
 	require.NoError(t, err, "Failed to initialize VolumePluginMgr")
 
 	kubelet.mounter = &mount.FakeMounter{}

--- a/pkg/kubelet/pod_actions.go
+++ b/pkg/kubelet/pod_actions.go
@@ -105,7 +105,9 @@ func (kl *Kubelet) DoPodAction(action *v1.Action, pod *v1.Pod) {
 	}
 	actionStatus.Error = errStr
 	action.Status = actionStatus
-	if _, err := kl.kubeClient.CoreV1().Actions(action.Namespace).UpdateStatus(action); err != nil {
+	// TODO: akrtos-scale-out: this should be pod specific clientset
+	//
+	if _, err := kl.kubeClient[0].CoreV1().Actions(action.Namespace).UpdateStatus(action); err != nil {
 		klog.Errorf("Update Action status for %s failed. Error: %+v", action.Name, err)
 	}
 }

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -99,7 +99,7 @@ func TestRunOnce(t *testing.T) {
 		kb.nodeName,
 		kb.podManager,
 		kb.statusManager,
-		kb.kubeClient,
+		kb.kubeClient[0],
 		kb.volumePluginMgr,
 		fakeRuntime,
 		kb.mounter,

--- a/pkg/kubelet/volume_host.go
+++ b/pkg/kubelet/volume_host.go
@@ -69,8 +69,10 @@ func NewInitializedVolumePluginMgr(
 	const resyncPeriod = 0
 	if utilfeature.DefaultFeatureGate.Enabled(features.CSIDriverRegistry) {
 		// Don't initialize if kubeClient is nil
+		// TODO: arktos-scale-out: use volume specific clientset
+		//
 		if kubelet.kubeClient != nil {
-			informerFactory = informers.NewSharedInformerFactory(kubelet.kubeClient, resyncPeriod)
+			informerFactory = informers.NewSharedInformerFactory(kubelet.kubeClient[0], resyncPeriod)
 			csiDriverInformer := informerFactory.Storage().V1beta1().CSIDrivers()
 			csiDriverLister = csiDriverInformer.Lister()
 			csiDriversSynced = csiDriverInformer.Informer().HasSynced
@@ -154,7 +156,8 @@ func (kvh *kubeletVolumeHost) GetPodPluginDir(podUID types.UID, pluginName strin
 }
 
 func (kvh *kubeletVolumeHost) GetKubeClient() clientset.Interface {
-	return kvh.kubelet.kubeClient
+	//TODO: arktos-scale-out: get volume specific clientset
+	return kvh.kubelet.kubeClient[0]
 }
 
 func (kvh *kubeletVolumeHost) GetSubpather() subpath.Interface {

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -52,7 +52,7 @@ type HollowKubelet struct {
 func NewHollowKubelet(
 	flags *options.KubeletFlags,
 	config *kubeletconfig.KubeletConfiguration,
-	client *clientset.Clientset,
+	client []clientset.Interface,
 	arktosClient arktosCientset.Interface,
 	heartbeatClient *clientset.Clientset,
 	cadvisorInterface cadvisor.Interface,


### PR DESCRIPTION
Initial code change to expand kubelet to support multiple Tenant partitions and separation of Resource and Tenant partition clientsets.

make and run:

run it with new args:
/kubelet --kubeconfig=/testconfig/kubeconfig1 --tenant-servers="http://10.1.1.1:8080,http://10.1.1.2:8080" > kubelet.log 2>&1 &
OR to set up the resource cluster with:
export TENANT_SERVERS="http://172.31.10.115:8080,http://172.31.14.52:8080" && export SCALE_OUT_PROXY_ENDPOINT="http://172.31.10.115:8888" && LOG_LEVEL=3 KUBE_CONTROLLERS=nodelifecycle IS_RESOURCE_PARTITION=true ./hack/arktos-up-scale-out-poc.sh
 
Noted that it uses a new cmdline args for now. add new entries to kubecofig will involved in the client-go config update which currently i incline to not change.

```
Below is a quick testing with them. Issue #1 and #2 are debatable if we by-design or treat them as bugs. I am looking into issue 3.
 
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=kubeconfig1 get nodes
No resources found.
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=kubeconfig2 get nodes
No resources found.
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=proxkubeconfig get nodes
error: stat proxkubeconfig: no such file or directory
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=proxykubeconfig get nodes
NAME              STATUS   ROLES    AGE     VERSION
ip-172-31-8-177   Ready    <none>   5m47s   v0.0.0-master+$Format:%h$
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=resourcekubeconfig get nodes
NAME              STATUS   ROLES    AGE     VERSION
ip-172-31-8-177   Ready    <none>   5m59s   v0.0.0-master+$Format:%h$
root@ip-172-31-10-115:/testconfig# 
 
issue 1: tenant creation should be directed to desired partition
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=proxykubeconfig create -f /yamls/tenant1.yaml 
tenant/a created
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=proxykubeconfig create -f /yamls/tenant2.yaml 
tenant/x created
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=proxykubeconfig get tenants
NAME     STORAGEID   STATUS   AGE
a        1           Active   20s
system   0           Active   8m54s
x        1           Active   12s
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=kubeconfig1 get tenants
NAME     STORAGEID   STATUS   AGE
a        1           Active   34s
system   0           Active   9m8s
x        1           Active   26s
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=kubeconfig2 get tenants
NAME     STORAGEID   STATUS   AGE
system   0           Active   6m31s
root@ip-172-31-10-115:/testconfig# 
 
issue 2: get tenant from proxy should return all, currently return the first partition’s tenant
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=kubeconfig2 create -f /yamls/tenant2.yaml 
tenant/x created
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=kubeconfig1 create -f /yamls/tenant1.yaml 
tenant/a created
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=proxykubeconfig get tenants
NAME     STORAGEID   STATUS   AGE
a        1           Active   4s
system   0           Active   11m
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=kubeconfig1 get tenants
NAME     STORAGEID   STATUS   AGE
a        1           Active   13s
system   0           Active   11m
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=kubeconfig2 get tenants
NAME     STORAGEID   STATUS   AGE
system   0           Active   8m48s
x        1           Active   25s
root@ip-172-31-10-115:/testconfig# 
 
issue 3: pods from second partition remains in scheduled and pending:
root@ip-172-31-10-115:/testconfig# vi /yamls/condefault.yaml 
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=kubeconfig2 create -f /yamls/condefault2.yaml 
pod/condefault2 created
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=kubeconfig1 create -f /yamls/condefault1.yaml 
pod/condefault created
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=kubeconfig1 get pods
No resources found.
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=kubeconfig1 get pods -AT
TENANT   NAMESPACE     NAME                        HASHKEY               READY   STATUS             RESTARTS   AGE
a        default       condefault                  3123577652425193689   1/1     Running            0          11s
system   kube-system   kube-dns-6fdcc959b4-wz5p6   1151037929471017490   0/3     CrashLoopBackOff   0          15m
system   kube-system   virtlet-568zj               5227541762739606200   0/3     CrashLoopBackOff   0          14m
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=kubeconfig2 get pods -AT
TENANT   NAMESPACE     NAME                        HASHKEY               READY   STATUS    RESTARTS   AGE
system   kube-system   kube-dns-6fdcc959b4-htp2h   1585220668317444351   0/3     Pending   0          12m
system   kube-system   virtlet-kc9dg               6279963007203658651   0/3     Pending   0          12m
x        default       condefault2                 2135629449184201393   0/1     Pending   0          30s
 
 
  status:
    conditions:
    - lastProbeTime: null
      lastTransitionTime: "2020-11-12T22:06:58Z"
      status: "True"
      type: PodScheduled
    phase: Pending
    qosClass: Guaranteed
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
root@ip-172-31-10-115:/testconfig# 

 
235767 I1112 22:45:25.109715   28480 kubelet_pods.go:1336] Generating status for "condefault3_default_x(e7a816c5-4094-4f6a-95ff-99d6dcd8f220)"
235768 I1112 22:45:25.109767   28480 kubelet_pods.go:1435] pod not found in the status manager map
235769 I1112 22:45:25.112077   28480 status_manager.go:484] Pod "condefault3" (e7a816c5-4094-4f6a-95ff-99d6dcd8f220) does not exist on the server
235770 I1112 22:45:25.129183   28480 factory.go:173] Using factory "raw" for container "/kubepods/pode7a816c5-4094-4f6a-95ff-99d6dcd8f220"
 
Issue #4: pod from first partition, which should have the status etc as we default to first partition, crashed after running a while.
root@ip-172-31-10-115:/testconfig# kubectl --kubeconfig=kubeconfig1 get pods -AT
TENANT   NAMESPACE     NAME                        HASHKEY               READY   STATUS             RESTARTS   AGE
a        default       condefault                  3123577652425193689   0/1     CrashLoopBackOff   4          45m
system   kube-system   kube-dns-6fdcc959b4-wz5p6   1151037929471017490   1/3     CrashLoopBackOff   15         60m
system   kube-system   virtlet-568zj               5227541762739606200   0/3     CrashLoopBackOff   18         59m
root@ip-172-31-10-115:/testconfig#

Issue 5. Event is tied with tenant:
10757 E1113 17:19:34.716840   10490 event.go:241] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"condefault.164720e8640b21c9", GenerateName:"", Tenant:"a", Namespace:"default", SelfLink:""      , UID:"", HashKey:0, ResourceVersion:"", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(n      il), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kin      d:"Pod", Namespace:"default", Name:"condefault", UID:"cb7b71f9-b86a-4157-93a0-e67e80f7a554", APIVersion:"v1", ResourceVersion:"841633221399019521", FieldPath:"spec.containers{nginx}", Tenant:"a"}, Reason:"Pulled", Message:"Container image \"ngin      x\" already present on machine", Source:v1.EventSource{Component:"kubelet", Host:"ip-172-31-8-177"}, FirstTimestamp:v1.Time{Time:time.Time{wall:0xbfe3cde9a79125c9, ext:270625226321, loc:(*time.Location)(0xc99ba20)}}, LastTimestamp:v1.Time{Time:t      ime.Time{wall:0xbfe3cde9a79125c9, ext:270625226321, loc:(*time.Location)(0xc99ba20)}}, Count:1, Type:"Normal", EventTime:v1.MicroTime{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:"", Related:      (*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'tenants "a" not found' (will not retry!)

```