### PR TITLE
pod status update using multiple kube clients

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -597,7 +597,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	// podManager is also responsible for keeping secretManager and configMapManager contents up-to-date.
 	klet.podManager = kubepod.NewBasicPodManager(kubepod.NewBasicMirrorClient(klet.kubeClient[0]), secretManager, configMapManager, checkpointManager)
 
-	klet.statusManager = status.NewManager(klet.kubeClient[0], klet.podManager, klet)
+	klet.statusManager = status.NewManager(klet.kubeClient, klet.podManager, klet)
 
 	if remoteRuntimeEndpoint != "" {
 		// remoteImageEndpoint is same as remoteRuntimeEndpoint if not explicitly specified
@@ -1810,8 +1810,9 @@ func (kl *Kubelet) handlePodResourcesResize(pod *v1.Pod) {
 	defer kl.podResizeMutex.Unlock()
 	// TODO: arktos scale-out. patch POD should be per tenant partition
 	//
+	tenantClient := kl.getTPClient(pod.Tenant)
 	if fit, patchBytes := kl.canResizePod(pod); fit {
-		_, patchError := kl.kubeClient[0].CoreV1().PodsWithMultiTenancy(pod.Namespace, pod.Tenant).Patch(pod.Name, types.StrategicMergePatchType, patchBytes)
+		_, patchError := tenantClient.CoreV1().PodsWithMultiTenancy(pod.Namespace, pod.Tenant).Patch(pod.Name, types.StrategicMergePatchType, patchBytes)
 		if patchError != nil {
 			klog.Errorf("Failed to patch ResourcesAllocated values for pod %s: %+v\n", pod.Name, patchError)
 		}
@@ -2173,6 +2174,19 @@ func (kl *Kubelet) handleMirrorPod(mirrorPod *v1.Pod, start time.Time) {
 	}
 }
 
+func (kl *Kubelet) getTPClient(tenant string) clientset.Interface {
+	var client clientset.Interface
+        pick := 0
+	if tenant[0] <= 'm' {
+		client = kl.kubeClient[0]
+	} else {
+		client = kl.kubeClient[1]
+		pick = 1
+	}
+	klog.Infof("tenant %s using client # %d", tenant, pick)
+	return client
+}
+
 // HandlePodActions is the callback in SyncHandler for actions
 func (kl *Kubelet) HandlePodActions(update kubetypes.PodUpdate) {
 	start := kl.clock.Now()
@@ -2192,7 +2206,8 @@ func (kl *Kubelet) HandlePodActions(update kubetypes.PodUpdate) {
 			}
 			// TODO: arktos-scaleout. UpdateStatus of PodAction should be per Tenant partition, using desired clientset.
 			//
-			if _, err := kl.kubeClient[0].CoreV1().ActionsWithMultiTenancy(action.Namespace, action.Tenant).UpdateStatus(action); err != nil {
+			tenantClient := kl.getTPClient(action.Tenant)
+			if _, err := tenantClient.CoreV1().ActionsWithMultiTenancy(action.Namespace, action.Tenant).UpdateStatus(action); err != nil {
 				klog.Errorf("Update Action status for %s failed. Error: %+v", action.Name, err)
 			}
 			continue

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -61,7 +61,7 @@ type podStatusSyncRequest struct {
 // Updates pod statuses in apiserver. Writes only when new status has changed.
 // All methods are thread-safe.
 type manager struct {
-	kubeClient clientset.Interface
+	kubeClient []clientset.Interface
 	podManager kubepod.Manager
 	// Map from pod UID to sync status of the corresponding pod.
 	podStatuses      map[types.UID]versionedPodStatus
@@ -113,7 +113,7 @@ type Manager interface {
 
 const syncPeriod = 10 * time.Second
 
-func NewManager(kubeClient clientset.Interface, podManager kubepod.Manager, podDeletionSafety PodDeletionSafetyProvider) Manager {
+func NewManager(kubeClient []clientset.Interface, podManager kubepod.Manager, podDeletionSafety PodDeletionSafetyProvider) Manager {
 	return &manager{
 		kubeClient:        kubeClient,
 		podManager:        podManager,
@@ -146,7 +146,7 @@ func (m *manager) Start() {
 	// Don't start the status manager if we don't have a client. This will happen
 	// on the master, where the kubelet is responsible for bootstrapping the pods
 	// of the master components.
-	if m.kubeClient == nil {
+	if len(m.kubeClient) == 0 {
 		klog.Infof("Kubernetes client is nil, not starting status manager.")
 		return
 	}
@@ -471,6 +471,19 @@ func (m *manager) syncBatch() {
 	}
 }
 
+func (m *manager) getTPClient(tenant string) clientset.Interface {
+	var client clientset.Interface
+	pick := 0
+	if tenant[0] <= 'm' {
+		client = m.kubeClient[0]
+	} else {
+		client = m.kubeClient[1]
+		pick = 1
+	}
+	klog.Infof("tenant %s using kube client #%d", tenant, pick)
+	return client
+}
+
 // syncPod syncs the given status with the API server. The caller must not hold the lock.
 func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 	if !m.needsUpdate(uid, status) {
@@ -479,7 +492,8 @@ func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 	}
 
 	// TODO: make me easier to express from client code
-	pod, err := m.kubeClient.CoreV1().PodsWithMultiTenancy(status.podNamespace, status.podTenant).Get(status.podName, metav1.GetOptions{})
+	tenantClient := m.getTPClient(status.podTenant)
+	pod, err := tenantClient.CoreV1().PodsWithMultiTenancy(status.podNamespace, status.podTenant).Get(status.podName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		klog.V(3).Infof("Pod %q (%s) does not exist on the server", status.podName, uid)
 		// If the Pod is deleted the status will be cleared in
@@ -500,7 +514,7 @@ func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 	}
 
 	oldStatus := pod.Status.DeepCopy()
-	newPod, patchBytes, err := statusutil.PatchPodStatus(m.kubeClient, pod.Tenant, pod.Namespace, pod.Name, *oldStatus, mergePodStatus(*oldStatus, status.status))
+	newPod, patchBytes, err := statusutil.PatchPodStatus(tenantClient, pod.Tenant, pod.Namespace, pod.Name, *oldStatus, mergePodStatus(*oldStatus, status.status))
 	klog.V(3).Infof("Patch status for pod %q with %q", format.PodWithDeletionTimestampAndResourceVersion(pod), patchBytes)
 	if err != nil {
 		klog.Warningf("Failed to update status for pod %q: %v", format.PodWithDeletionTimestampAndResourceVersion(pod), err)
@@ -517,7 +531,7 @@ func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 		deleteOptions := metav1.NewDeleteOptions(0)
 		// Use the pod UID as the precondition for deletion to prevent deleting a newly created pod with the same name and namespace under the same tenant.
 		deleteOptions.Preconditions = metav1.NewUIDPreconditions(string(pod.UID))
-		err = m.kubeClient.CoreV1().PodsWithMultiTenancy(pod.Namespace, pod.Tenant).Delete(pod.Name, deleteOptions)
+		err = tenantClient.CoreV1().PodsWithMultiTenancy(pod.Namespace, pod.Tenant).Delete(pod.Name, deleteOptions)
 		if err != nil {
 			klog.Warningf("Failed to delete status for pod %q: %v", format.Pod(pod), err)
 			return


### PR DESCRIPTION
### Changes

Pod status update is changed to use the kube client based on the tenant. 

The switch logic is based on the current proxy setting

```
                location ~* ^/apis/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/tenants/[a-m0-9_.-]+/(.*) {
                    proxy_pass $tenant_api_one;
                }
                location ~* ^/apis/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/tenants/[n-z_.-]+/(.*) {
                    proxy_pass $tenant_api_two;
                }
```

Current only letter is used and will be updated later with numbers and other characters after pod is working end to end.


### Validation
On local 2t1p environment. Pod status is updated correctly to "ContainerCreating" in the correct tenant partition.

Issue: Pod is showing unintended deletion. Debugging this now, hence the #do-not-merge