### PR TITLE
Kubemark hollow-node to support multiple tenant partitions

### DIFF
--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -31,7 +31,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/klog"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	arktos "k8s.io/arktos-ext/pkg/generated/clientset/versioned"
@@ -69,6 +69,10 @@ type hollowNodeConfig struct {
 	ProxierSyncPeriod    time.Duration
 	ProxierMinSyncPeriod time.Duration
 	NodeLabels           map[string]string
+	// protocal://ip:port format, e.g.:
+	// http://172.31.8.177.8080
+	TenantServers  []string
+	ResourceServer string
 }
 
 const (
@@ -81,6 +85,8 @@ const (
 var knownMorphs = sets.NewString("kubelet", "proxy")
 
 func (c *hollowNodeConfig) addFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&c.ResourceServer, "resource-server", c.ResourceServer, "url to the resource partition master.")
+	fs.StringSliceVar(&c.TenantServers, "tenant-servers", c.TenantServers, "Comma separated string representing tenant api-server URLs.")
 	fs.StringVar(&c.KubeconfigPath, "kubeconfig", "/kubeconfig/kubeconfig", "Path to kubeconfig file.")
 	fs.IntVar(&c.KubeletPort, "kubelet-port", ports.KubeletPort, "Port on which HollowKubelet should be listening.")
 	fs.IntVar(&c.KubeletReadOnlyPort, "kubelet-read-only-port", ports.KubeletReadOnlyPort, "Read-only port on which Kubelet is listening.")
@@ -173,23 +179,29 @@ func run(config *hollowNodeConfig) {
 		klog.Fatalf("Failed to create a ClientConfig: %v. Exiting.", err)
 	}
 
-	//TODO: arktos-scale-out: hollowNode should have the same args for Tenant servers as well
-	//      fixme when moving to this step running in perf test env
-	client := make([]clientset.Interface, 2)
-	clientFromConfig, err := clientset.NewForConfig(clientConfigs)
-	if err != nil {
-		klog.Fatalf("Failed to create a ClientSet: %v. Exiting.", err)
+	if len(config.ResourceServer) == 0 {
+		klog.Fatalf("Missing TenantServers. Exiting.")
 	}
 
+	numberTenantPartitions := len(config.ResourceServer)
+	client := make([]clientset.Interface, numberTenantPartitions)
 	for i := 0; i < len(client); i++ {
+		tenantCfg := restclient.CopyConfigs(clientConfigs)
+		for _, cfg := range tenantCfg.GetAllConfigs() {
+			cfg.Host = config.TenantServers[i]
+		}
+		clientFromConfig, err := clientset.NewForConfig(tenantCfg)
+		if err != nil {
+			klog.Fatalf("Failed to create a ClientSet: %v. Exiting.", err)
+		}
 		client[i] = clientFromConfig
 	}
 
 	if config.Morph == "kubelet" {
 		// Start APIServerConfigManager
-		// TODO: Arktos-scale-out: evaluate this function and see if this needs to be done on all tenant partitions
-		//
-		go datapartition.StartAPIServerConfigManagerAndInformerFactory(client[0], wait.NeverStop)
+		for _, clt := range client {
+			go datapartition.StartAPIServerConfigManagerAndInformerFactory(clt, wait.NeverStop)
+		}
 
 		f, c := kubemark.GetHollowKubeletConfig(config.createHollowKubeletOptions())
 
@@ -204,6 +216,9 @@ func run(config *hollowNodeConfig) {
 				}
 			}
 			heartbeatClientConfig.QPS = float32(-1)
+			if heartbeatClientConfig.Host != config.ResourceServer {
+				heartbeatClientConfig.Host = config.ResourceServer
+			}
 		}
 		heartbeatClient, err := clientset.NewForConfig(heartbeatClientConfigs)
 		if err != nil {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"path"
 	"sort"
+        "strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -312,11 +313,9 @@ func makePodSourceConfig(kubeCfg *kubeletconfiginternal.KubeletConfiguration, ku
 		}
 	}
 
-	for _, client := range kubeDeps.KubeClient {
+	for i, client := range kubeDeps.KubeClient {
 		klog.Infof("Watching apiserver")
-		if updatechannel == nil {
-			updatechannel = cfg.Channel(kubetypes.ApiserverSource)
-		}
+		updatechannel = cfg.Channel(kubetypes.ApiserverSource + strconv.Itoa(i))
 		config.NewSourceApiserver(client, nodeName, updatechannel)
 	}
 

--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -50,10 +50,20 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: TENANT_SERVERS
+          valueFrom:
+            configMapKeyRef:
+              name: node-configmap
+              key: tenant.servers
+        - name: RESOURCE_SERVER
+          valueFrom:
+            configMapKeyRef:
+              name: node-configmap
+              key: resource.server
         command:
         - /bin/sh
         - -c
-        - /kubemark --morph=kubelet --name=$(NODE_NAME) {{hollow_kubelet_params}} --kubeconfig=/kubeconfig/kubelet.kubeconfig $(CONTENT_TYPE) --alsologtostderr 1>>/var/log/kubelet-$(NODE_NAME).log 2>&1
+        - /kubemark --morph=kubelet --tenant-servers=${TENANT_SERVERS} --resource-server=${RESOURCE_SERVER} --name=$(NODE_NAME) {{hollow_kubelet_params}} --kubeconfig=/kubeconfig/kubelet.kubeconfig $(CONTENT_TYPE) --alsologtostderr 1>>/var/log/kubelet-$(NODE_NAME).log 2>&1
         volumeMounts:
         - name: kubeconfig-volume
           mountPath: /kubeconfig


### PR DESCRIPTION
support two tenant partitions in kubemark hollow-node type. currently hardcoded with two tenant partition in scripts.

In Testing...

-->
```release-note

```
