### PR TITLE
fix NodeNotReady issue

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2883,11 +2883,11 @@ http {
             proxy_pass \$RESOURCE_API;
         }
 
-        location ~ ^/api/v1/nodes?(.*) {
+        location ~ ^/api/([^/])*/nodes?(.*) {
             proxy_pass \$RESOURCE_API;
         }
 
-        location ~ ^/apis/coordination.k8s.io/v1/leases?(.*) {
+        location ~ ^/apis/coordination.k8s.io/([^/])*/leases?(.*) {
             proxy_pass \$RESOURCE_API;
         }
 

--- a/hack/scale_out_poc/nginx.conf
+++ b/hack/scale_out_poc/nginx.conf
@@ -71,11 +71,11 @@ http {
                     proxy_pass {{ arktos_api_protocol }}://$remote_addr:{{ arktos_api_port }};
                 }
 
-                location ~ ^/api/v1/nodes?(.*) {
+                location ~ ^/api/([^/])*/nodes?(.*) {
                     proxy_pass $resource_api;
                 }
 
-                location ~ ^/apis/coordination.k8s.io/v1/leases?(.*) {
+                location ~ ^/apis/coordination.k8s.io/([^/])*/leases?(.*) {
                     proxy_pass $resource_api;
                 }
 


### PR DESCRIPTION
This PR fixes the issue that the node lifecycle controller cannot get the node-lease from the lister when connecting to nginx proxy.

### Explanation
The cause is due to the following forward logic in nginx.conf:
        location ~ ^/apis/coordination.k8s.io/**v1**/leases?(.*) {
            proxy_pass $RESOURCE_API;
        }

Yet, arktos use version V1beta1 for node-lease requests. As a result, node-leases are not correctly forwarded.

### Verification:

Tested in my dev env, the NodeNotReady issue was gone.