### PR TITLE
fix secret list and watch

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -591,7 +591,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 				}
 			}
 			heartbeatClientConfig.QPS = float32(-1)
-			klog.V(6).Infof("heartbeatClientConfig.Host: %v", heartbeatClientConfig.Host)
+		        klog.V(6).Infof("heartbeatClientConfig.Host: %v", heartbeatClientConfig.Host)
 		}
 		kubeDeps.HeartbeatClient, err = clientset.NewForConfig(&heartbeatClientConfigs)
 		if err != nil {

--- a/hack/scale_out_poc/two_TP/nginx.conf
+++ b/hack/scale_out_poc/two_TP/nginx.conf
@@ -20,6 +20,8 @@ http {
     keepalive_timeout 65;
     types_hash_max_size 2048; 
     proxy_http_version 1.1; 
+    proxy_read_timeout     1200;
+    proxy_connect_timeout  1200;
 
     # server_tokens off;
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -551,7 +551,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	var configMapManager configmap.Manager
 	switch kubeCfg.ConfigMapAndSecretChangeDetectionStrategy {
 	case kubeletconfiginternal.WatchChangeDetectionStrategy:
-		secretManager = secret.NewWatchingSecretManager(kubeDeps.KubeClient[0])
+		secretManager = secret.NewWatchingSecretManager(kubeDeps.KubeClient)
 		configMapManager = configmap.NewWatchingConfigMapManager(kubeDeps.KubeClient[0])
 	case kubeletconfiginternal.TTLCacheChangeDetectionStrategy:
 		secretManager = secret.NewCachingSecretManager(


### PR DESCRIPTION
## Changes
 This fix sets kubelet to use the correct kube client for secrets list and watch. Without it, pod creation was failing on the 2nd tenant partition during volume mounting. 

## Validation

Validated end to end on local environment. 

On tenant partition 1
```bash
root@goose-t:~/code/src/k8s.io/arktos/test/yaml# kubectl get pods --tenant alex -o wide
NAME              HASHKEY               READY   STATUS    RESTARTS   AGE   IP            NODE      NOMINATED NODE   READINESS GATES
k8s-vanilla-pod   3683182769778565890   1/1     Running   0          32s   10.88.3.108   goose-r   <none>           <none>
```

On tenant partition 2
```bash
root@goose-3:~/code/src/k8s.io/arktos/test/yaml# kubectl get pod --tenant oxygen -o wide
NAME              HASHKEY               READY   STATUS    RESTARTS   AGE   IP            NODE      NOMINATED NODE   READINESS GATES
k8s-vanilla-pod   3367483529165770237   1/1     Running   0          16s   10.88.3.107   goose-r   <none>           <none>
```

## Notes to reviewers
The *getTPClient* function is now being repeated in a few places. Ugly, yes. For now please consider this a makeshift solution for the POC. As more conversion goes in, it will be refactored into a common place. 