### PR TITLE
add fallback to kubeclient 0 if only one is provided

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2176,7 +2176,7 @@ func (kl *Kubelet) handleMirrorPod(mirrorPod *v1.Pod, start time.Time) {
 func (kl *Kubelet) getTPClient(tenant string) clientset.Interface {
 	var client clientset.Interface
         pick := 0
-	if tenant[0] <= 'm' {
+	if len(kl.kubeClient)==1 || tenant[0] <= 'm' {
 		client = kl.kubeClient[0]
 	} else {
 		client = kl.kubeClient[1]

--- a/pkg/kubelet/secret/secret_manager.go
+++ b/pkg/kubelet/secret/secret_manager.go
@@ -115,7 +115,7 @@ const (
 func getTPClient(kubeClients []clientset.Interface, tenant string) clientset.Interface {
 	var client clientset.Interface
 	pick := 0
-	if tenant[0] <= 'm' {
+	if len(kubeClients)==1 || tenant[0] <= 'm' {
 		client = kubeClients[0]
 	} else {
 		client = kubeClients[1]

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -474,7 +474,7 @@ func (m *manager) syncBatch() {
 func (m *manager) getTPClient(tenant string) clientset.Interface {
 	var client clientset.Interface
 	pick := 0
-	if tenant[0] <= 'm' {
+	if len(m.kubeClient)==1 || tenant[0] <= 'm' {
 		client = m.kubeClient[0]
 	} else {
 		client = m.kubeClient[1]


### PR DESCRIPTION
## Changes
if only one kubeclient is provided (most likely for a phase one merge), switch kubelet to use it. 

## Validation
Validate on local environment with
1. 2 tp 1 rp, 2 endpoints in TENANT_SERVERS
2. 1 tp 1 rp, 1 endpoint in TENANT_SERVERS

Pod goes into running into both cases.