### PR TITLE
config haproxy for scale-out m2

### DIFF
--- a/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg
+++ b/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg
@@ -1,0 +1,74 @@
+global
+        log /dev/log    local0
+        log /dev/log    local1 notice
+        chroot /var/lib/haproxy
+        stats socket /run/haproxy/admin.sock mode 660 level admin expose-fd listeners
+        stats timeout 30s
+        user haproxy
+        group haproxy
+        daemon
+
+        # Default SSL material locations
+        ca-base /etc/ssl/certs
+        crt-base /etc/ssl/private
+
+        # Default ciphers to use on SSL-enabled listening sockets.
+        # For more information, see ciphers(1SSL). This list is from:
+        #  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+        # An alternative list with additional directives can be obtained from
+        #  https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=haproxy
+        ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS
+        ssl-default-bind-options no-sslv3
+
+defaults
+        log     global
+        mode    http
+        option  httplog
+        option  dontlognull
+        timeout connect 5000
+        timeout client  {{ connection_timeout }}
+        timeout server  {{ connection_timeout }}
+        errorfile 400 /etc/haproxy/errors/400.http
+        errorfile 403 /etc/haproxy/errors/403.http
+        errorfile 408 /etc/haproxy/errors/408.http
+        errorfile 500 /etc/haproxy/errors/500.http
+        errorfile 502 /etc/haproxy/errors/502.http
+        errorfile 503 /etc/haproxy/errors/503.http
+        errorfile 504 /etc/haproxy/errors/504.http
+
+frontend scale-out-proxy
+    bind *:8888 alpn h2,http/1.1
+
+    acl tp_one_request_1 path_reg ^/apis/([^/])*/([^/])*/tenants/(?!system|all)([a-m]([^/])*)/.*$
+    acl tp_one_request_2 path_reg ^/api/([^/])*/(?!system|all)([a-m]([^/])*)/.*$
+
+    acl tp_two_request_1 path_reg ^/apis/([^/])*/([^/])*/tenants/(?!system|all)([n-z]([^/])*)/.*$
+    acl tp_two_request_2 path_reg ^/api/([^/])*/tenants/(?!system|all)([n-z]([^/])*)/.*$
+
+    acl node_request path_reg ^/api/([^/])*/nodes.*$
+    acl lease_request path_reg ^/apis/coordination.k8s.io/([^/])*/leases.*$
+    acl individual_lease_request path_reg ^/apis/([^/])*/([^/])*/tenants/system/namespaces/kube-node-lease/leases.*$
+
+    acl from_tenant_api_one src {{ tenant_partition_one_ip }}
+    acl from_tenant_api_two src {{ tenant_partition_two_ip }}
+    acl from_resource_api src {{ resource_partition_ip }}
+
+    # Note: the order of backend search rules matters. The first matching rule will be used. 
+    use_backend resource_api if node_request OR lease_request OR individual_lease_request
+    use_backend tenant_api_one if tp_one_request_1 OR tp_one_request_2    
+    use_backend tenant_api_two if tp_two_request_1 OR tp_two_request_2
+
+    use_backend tenant_api_one if from_tenant_api_one
+    use_backend tenant_api_two if from_tenant_api_two
+    use_backend resource_api if from_resource_api
+    
+    default_backend tenant_api_one
+
+backend tenant_api_one
+    server tp_one {{ tenant_partition_one_ip }}:{{ arktos_api_port }} maxconn 2048
+
+backend tenant_api_two
+    server tp_two {{ tenant_partition_two_ip }}:{{ arktos_api_port }} maxconn 2048
+
+backend resource_api
+    server rp {{ resource_partition_ip }}:{{ arktos_api_port }} maxconn 2048

--- a/hack/scale_out_poc/haproxy_2T1R/setup_haproxy.sh
+++ b/hack/scale_out_poc/haproxy_2T1R/setup_haproxy.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Copyright 2020 Authors of Arktos.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+print_help() {
+        echo "This is a tool to set up haproxy for Arktos scale-out tests in the local host."
+        echo 
+        echo "To run it: "
+        echo "    TENANT_PARTITION_ONE_IP=##.##.##.##  TENANT_PARTITION_TWO_IP=##.##.##.## RESOURCE_PARTITION_IP=##.##.##.## setup_haproxy.sh"
+}
+
+validate_ip_exit_if_invalid() {
+        local var_name=$1
+        local ip_addr=$2
+        if ! [[ ${ip_addr} =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]
+        then
+                printf "\033[0;31m${var_name} (${ip_addr}) is not a valid ip address. Exit. \033[0m\n"
+                exit 1
+        fi
+}
+
+validate_params() {
+        validate_ip_exit_if_invalid "tenant_partition_one_ip" "${tenant_partition_one_ip}"
+        validate_ip_exit_if_invalid "tenant_partition_two_ip" "${tenant_partition_two_ip}"
+        validate_ip_exit_if_invalid "resource_partition_ip" "${resource_partition_ip}"
+}
+
+run_command_exit_if_failed() {
+        command="$@"
+        $command 
+        if [[ $? != 0 ]] 
+        then 
+                printf "\033[0;31mFailed: ${command}\n"
+                printf "Exit. \033[0m\n"
+                exit 1
+        fi
+}
+
+install_haproxy_if_needed() {
+        haproxy -v > /dev/null 2>&1
+        if [[ $? != 0 ]] 
+        then 
+                printf "\033[0;31mHaproxy does not exist, installing haproxy...\033[0m\n"
+                run_command_exit_if_failed sudo apt-get update && sudo apt-get -y upgrade
+                run_command_exit_if_failed sudo apt --assume-yes install haproxy
+        fi
+}
+
+config_haproxy() {
+        script_root=$(dirname "${BASH_SOURCE}")
+        local -r temp_file="/tmp/haproxy.cfg"
+        run_command_exit_if_failed  cp "${script_root}/haproxy.cfg" "${temp_file}"
+        
+        sed -i -e "s@{{ *proxy_port *}}@${proxy_port}@g" "${temp_file}"
+
+        sed -i -e "s@{{ *arktos_api_protocol *}}@${arktos_api_protocol}@g" "${temp_file}"  
+        sed -i -e "s@{{ *arktos_api_port *}}@${arktos_api_port}@g" "${temp_file}"
+
+        sed -i -e "s@{{ *resource_partition_ip *}}@${resource_partition_ip}@g" "${temp_file}"
+        sed -i -e "s@{{ *tenant_partition_one_ip *}}@${tenant_partition_one_ip}@g" "${temp_file}"
+        sed -i -e "s@{{ *tenant_partition_two_ip *}}@${tenant_partition_two_ip}@g" "${temp_file}"
+
+        sed -i -e "s@{{ *connection_timeout *}}@${connection_timeout}@g" "${temp_file}"
+
+        run_command_exit_if_failed sudo cp "${temp_file}" "/etc/haproxy/haproxy.cfg"
+}
+
+if [ "$1" == "-h" ] || [ "$1" == "--help" ]
+then
+        print_help
+        exit
+fi
+
+proxy_port=${SCALE_OUT_PROXY_PORT:-8888}
+connection_timeout=${CONN_TIMEOUT:-10m}
+
+arktos_api_protocol=${ARKTOS_API_PROTOCOL:-http}
+arktos_api_port=${ARKTOS_API_port:-8080}
+
+resource_partition_ip=${RESOURCE_PARTITION_IP}
+tenant_partition_one_ip=${TENANT_PARTITION_ONE_IP}
+tenant_partition_two_ip=${TENANT_PARTITION_TWO_IP}
+
+validate_params
+
+install_haproxy_if_needed
+
+config_haproxy
+
+run_command_exit_if_failed sudo systemctl restart haproxy
+
+printf "\033[0;32mHaproxy was configured and started. Please check out /var/log/haproxy.log for logs. \033[0m\n"
+
+sudo systemctl status haproxy


### PR DESCRIPTION
HaProxy config for m2. 

To run it:
```
TENANT_PARTITION_ONE_IP=##.##.##.##  TENANT_PARTITION_TWO_IP=##.##.##.## RESOURCE_PARTITION_IP=##.##.##.## setup_haproxy.sh
```