### PR TITLE
Pickup changes in M1 branch into M2 branch

### DIFF
--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -2199,7 +2199,10 @@ function start-kube-controller-manager {
     params+=" --pv-recycler-pod-template-filepath-hostpath=$PV_RECYCLER_OVERRIDE_TEMPLATE"
   fi
   if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
-    RUN_CONTROLLERS="nodeipam,nodelifecycle"
+    RUN_CONTROLLERS="nodelifecycle"
+  fi
+  if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+    RUN_CONTROLLERS="*,-nodeipam,-nodelifecycle"
   fi
   if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
     RUN_CONTROLLERS="*,-nodeipam,-nodelifecycle"

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -2204,9 +2204,6 @@ function start-kube-controller-manager {
   if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
     RUN_CONTROLLERS="*,-nodeipam,-nodelifecycle"
   fi
-  if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-    RUN_CONTROLLERS="*,-nodeipam,-nodelifecycle"
-  fi
   if [[ -n "${RUN_CONTROLLERS:-}" ]]; then
     params+=" --controllers=${RUN_CONTROLLERS}"
   fi

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2359,6 +2359,9 @@ function kube-up() {
       create-linux-nodes
     fi
     check-cluster
+    cp -f ${KUBECONFIG} ${LOCAL_KUBECONFIG_TMP}
+    grep -i "server:" ${LOCAL_KUBECONFIG_TMP}
+
     if [[ "${KUBERNETES_SCALEOUT_PROXY:-false}" == "true" ]]; then
       echo "Scaleout proxy public IP: ${PROXY_RESERVED_IP}:8888"
       echo "Scaleout proxy internal IP: ${PROXY_RESERVED_INTERNAL_IP}:8888"

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2893,12 +2893,12 @@ http {
             proxy_pass http://\$remote_addr:8080;
         }
 
-        location ~ ^/api/v1/nodes?(.*) {
+        location ~ ^/api/([^/])*/nodes?(.*) {
             proxy_read_timeout 3600;
             proxy_pass \$RESOURCE_API;
         }
 
-        location ~ ^/apis/coordination.k8s.io/v1/leases?(.*) {
+        location ~ ^/apis/coordination.k8s.io/([^/])*/leases?(.*) {
             proxy_read_timeout 3600;
             proxy_pass \$RESOURCE_API;
         }

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2365,7 +2365,8 @@ function kube-up() {
     if [[ "${KUBERNETES_SCALEOUT_PROXY:-false}" == "true" ]]; then
       echo "Scaleout proxy public IP: ${PROXY_RESERVED_IP}:8888"
       echo "Scaleout proxy internal IP: ${PROXY_RESERVED_INTERNAL_IP}:8888"
-      sed -i "s/server: https:\/\/.*/server: http:\/\/${PROXY_RESERVED_IP}:8888/" ${KUBECONFIG}
+      cp -f ${KUBECONFIG} ${LOCAL_KUBECONFIG}
+      sed -i "s/server: https:\/\/.*/server: http:\/\/${PROXY_RESERVED_IP}:8888/" ${LOCAL_KUBECONFIG}
     fi
   fi
 }

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -602,7 +602,10 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 		//
 		klog.V(6).Infof("make kubeDeps.KubeClients based on TenantServers args: %v", s.TenantServers)
 		if s.TenantServers == nil || len(s.TenantServers) == 0 {
-			return errors.New("invalid TenantServers")
+			klog.V(3).Infof("TenantServers is not set. Default to single tenant partition and clientConfig setting")
+			s.TenantServers = make ([]string, 1)
+			s.TenantServers[0] = clientConfigs.GetConfig().Host
+
 		}
 
 		kubeDeps.KubeClient = make([]clientset.Interface, len(s.TenantServers))

--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -179,11 +179,11 @@ func run(config *hollowNodeConfig) {
 		klog.Fatalf("Failed to create a ClientConfig: %v. Exiting.", err)
 	}
 
-	if len(config.ResourceServer) == 0 {
+	if len(config.TenantServers) == 0 {
 		klog.Fatalf("Missing TenantServers. Exiting.")
 	}
 
-	numberTenantPartitions := len(config.ResourceServer)
+	numberTenantPartitions := len(config.TenantServers)
 	client := make([]clientset.Interface, numberTenantPartitions)
 	for i := 0; i < len(client); i++ {
 		tenantCfg := restclient.CopyConfigs(clientConfigs)

--- a/hack/scale_out_poc/nginx.conf
+++ b/hack/scale_out_poc/nginx.conf
@@ -71,11 +71,11 @@ http {
                     proxy_pass {{ arktos_api_protocol }}://$remote_addr:{{ arktos_api_port }};
                 }
 
-                location ~ ^/api/v1/nodes?(.*) {
+                location ~ ^/api/([^/])*/nodes?(.*) {
                     proxy_pass $resource_api;
                 }
 
-                location ~ ^/apis/coordination.k8s.io/v1/leases?(.*) {
+                location ~ ^/apis/coordination.k8s.io/([^/])*/leases?(.*) {
                     proxy_pass $resource_api;
                 }
 

--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -39,6 +39,7 @@ function create-kubemark-master {
     # All calls to e2e-grow-cluster must share temp dir with initial e2e-up.sh.
     kube::util::ensure-temp-dir
     export KUBE_TEMP="${KUBE_TEMP}"
+    export LOCAL_KUBECONFIG_TMP
 
     KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark"
     KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX:-e2e-test-${USER}}-kubemark"

--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -47,6 +47,7 @@ function create-kubemark-master {
       SCALEOUT_PROXY_NAME="${KUBE_GCE_INSTANCE_PREFIX}-proxy"
       KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-rp"
       KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-rp"
+      export LOCAL_KUBECONFIG
     fi
     if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
       SCALEOUT_PROXY_NAME="${KUBE_GCE_INSTANCE_PREFIX}-proxy"
@@ -92,17 +93,6 @@ function create-kubemark-master {
       export "${dst_var}"="${val}"
     done
     "${KUBE_ROOT}/hack/e2e-internal/e2e-up.sh"
-    if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
-      cp -f $KUBECONFIG $LOCAL_KUBECONFIG
-    fi
-    #if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" == "true" ]]; then
-    #  if [[ "${KUBERNETES_SCALEOUT_PROXY:-false}" == "true" ]]; then
-    #    sed -i "s/server: https:*/server: http://${PROXY_RESERVED_IP}:8888/" ${KUBECONFIG}
-    #  else
-    #    sed -i "s/server: https:.*/&:8080/" ${KUBECONFIG}
-    #    sed -i "s/server: https:*/server: http:/" ${KUBECONFIG}
-    #  fi
-    #fi
     if [[ "${KUBEMARK_HA_MASTER:-}" == "true" && -n "${KUBEMARK_MASTER_ADDITIONAL_ZONES:-}" ]]; then
         for KUBE_GCE_ZONE in ${KUBEMARK_MASTER_ADDITIONAL_ZONES}; do
           KUBE_GCE_ZONE="${KUBE_GCE_ZONE}" KUBE_REPLICATE_EXISTING_MASTER=true \

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -89,7 +89,7 @@ function create-kube-hollow-node-resources {
   # Create kubemark namespace.
   "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/kubemark-ns.json"
 
-  if [[ "${SCALEOUT_CLUSTER_TWO_TPS}" == "true" ]]; then
+  if [[ "${SCALEOUT_CLUSTER_TWO_TPS:-false}" == "true" ]]; then
     export TENANT_SERVERS="${TENANT_SERVER_1},${TENANT_SERVER_2}"
   else
     export TENANT_SERVERS="${TENANT_SERVER_1}"

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -39,6 +39,7 @@ KUBECTL="${KUBE_ROOT}/cluster/kubectl.sh"
 KUBEMARK_DIRECTORY="${KUBE_ROOT}/test/kubemark"
 RESOURCE_DIRECTORY="${KUBEMARK_DIRECTORY}/resources"
 LOCAL_KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark"
+LOCAL_KUBECONFIG_TMP="${RESOURCE_DIRECTORY}/kubeconfig.kubemark.tmp"
 
 # Generate a random 6-digit alphanumeric tag for the kubemark image.
 # Used to uniquify image builds across different invocations of this script.
@@ -241,8 +242,8 @@ else
   create-kubemark-master
 fi
 
-MASTER_IP=$(grep server "$LOCAL_KUBECONFIG" | awk -F "/" '{print $3}')
-export RESOURCE_SERVER="http://"${MASTER_IP}
+MASTER_IP=$(grep server "${LOCAL_KUBECONFIG}" | awk -F "/" '{print $3}')
+export RESOURCE_SERVER="http://"$(grep server "${LOCAL_KUBECONFIG_TMP}" | awk -F "/" '{print $3}'):8080
 
 # Start two tenant partition clusters and perseve their master url
 # Proxy server IP is the same as the first Tenant Cluster master IP, with port on 8888
@@ -252,11 +253,11 @@ if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
 echo "VDBGG: PROXY_RESERVED_IP=$PROXY_RESERVED_IP"
   export KUBERNETES_TENANT_PARTITION=true
   create-kubemark-master
-  export TENANT_SERVER_1="http://"$(grep server "$LOCAL_KUBECONFIG" | awk -F "/" '{print $3}')
+  export TENANT_SERVER_1="http://"$(grep server "${LOCAL_KUBECONFIG_TMP}" | awk -F "/" '{print $3}'):8080
 
   if [[ "${SCALEOUT_CLUSTER_TWO_TPS:-false}" == "true" ]]; then
     create-kubemark-master
-    export TENANT_SERVER_2="http://"$(grep server "$LOCAL_KUBECONFIG" | awk -F "/" '{print $3}')
+    export TENANT_SERVER_2="http://"$(grep server "${LOCAL_KUBECONFIG_TMP}" | awk -F "/" '{print $3}'):8080
   fi
 fi
 


### PR DESCRIPTION
In testing, but sharing the code changes in case one is interested in knowing what they are.
the issue with kube-up.sh is understood. it is due to the kube-controller-manager failed to start at the m2 branch with the tenant-server parameter is missing. Qian is working on a fix at the nodelifecycle controller to bring back compat in place.

remove the WIP to get this PR going forward.

Testing is being done in perf test run env as:
1. kube-up.sh to bring up the admin cluster
2. start-kubemark.sh to start the perf test cluster
3. (optional) run end to end load test.
```
export MASTER_DISK_SIZE=200GB MASTER_ROOT_DISK_SIZE=200GB KUBE_GCE_ZONE=us-central1-a MASTER_SIZE=n1-highmem-32 NODE_SIZE=n1-highmem-16 NUM_NODES=1 NODE_DISK_SIZE=200GB GOPATH=$HOME/go KUBE_GCE_ENABLE_IP_ALIASES=true KUBE_GCE_PRIVATE_CLUSTER=true CREATE_CUSTOM_NETWORK=true KUBE_GCE_INSTANCE_PREFIX=new-yb01-k8s-scaleout KUBE_GCE_NETWORK=new-yb01-k8s-scaleout ENABLE_KCM_LEADER_ELECT=false SHARE_PARTITIONSERVER=false LOGROTATE_FILES_MAX_COUNT=10 LOGROTATE_MAX_SIZE=200M TEST_CLUSTER_LOG_LEVEL=--v=2 APISERVERS_EXTRA_NUM=0 WORKLOADCONTROLLER_EXTRA_NUM=0 ETCD_EXTRA_NUM=0 KUBEMARK_NUM_NODES=2

./cluster/kube-up.sh
SCALEOUT_CLUSTER=true SCALEOUT_CLUSTER_TWO_TPS=false ./test/kubemark/start-kubemark.sh
```
