### PR TITLE
convert kubeclient to support multiple tenant partition 

### DIFF
--- a/pkg/kubelet/configmap/configmap_manager.go
+++ b/pkg/kubelet/configmap/configmap_manager.go
@@ -19,6 +19,7 @@ package configmap
 
 import (
 	"fmt"
+	"k8s.io/klog"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -53,16 +54,17 @@ type Manager interface {
 // simpleConfigMapManager implements ConfigMap Manager interface with
 // simple operations to apiserver.
 type simpleConfigMapManager struct {
-	kubeClient clientset.Interface
+	kubeClients []clientset.Interface
 }
 
 // NewSimpleConfigMapManager creates a new ConfigMapManager instance.
-func NewSimpleConfigMapManager(kubeClient clientset.Interface) Manager {
-	return &simpleConfigMapManager{kubeClient: kubeClient}
+func NewSimpleConfigMapManager(kubeClients []clientset.Interface) Manager {
+	return &simpleConfigMapManager{kubeClients: kubeClients}
 }
 
 func (s *simpleConfigMapManager) GetConfigMap(tenant, namespace, name string) (*v1.ConfigMap, error) {
-	return s.kubeClient.CoreV1().ConfigMapsWithMultiTenancy(namespace, tenant).Get(name, metav1.GetOptions{})
+	client := getTPClient(s.kubeClients, tenant)
+	return client.CoreV1().ConfigMapsWithMultiTenancy(namespace, tenant).Get(name, metav1.GetOptions{})
 }
 
 func (s *simpleConfigMapManager) RegisterPod(pod *v1.Pod) {
@@ -111,6 +113,19 @@ const (
 	defaultTTL = time.Minute
 )
 
+func getTPClient(kubeClients []clientset.Interface, tenant string) clientset.Interface {
+	var client clientset.Interface
+	pick := 0
+	if len(kubeClients)==1 || tenant[0] <= 'm' {
+		client = kubeClients[0]
+	} else {
+		client = kubeClients[1]
+		pick = 1
+	}
+	klog.Infof("tenant %s using client # %d", tenant, pick)
+	return client
+}
+
 // NewCachingConfigMapManager creates a manager that keeps a cache of all configmaps
 // necessary for registered pods.
 // It implement the following logic:
@@ -119,9 +134,10 @@ const (
 // - every GetObject() call tries to fetch the value from local cache; if it is
 //   not there, invalidated or too old, we fetch it from apiserver and refresh the
 //   value in cache; otherwise it is just fetched from cache
-func NewCachingConfigMapManager(kubeClient clientset.Interface, getTTL manager.GetObjectTTLFunc) Manager {
+func NewCachingConfigMapManager(kubeClient []clientset.Interface, getTTL manager.GetObjectTTLFunc) Manager {
 	getConfigMap := func(tenant, namespace, name string, opts metav1.GetOptions) (runtime.Object, error) {
-		return kubeClient.CoreV1().ConfigMapsWithMultiTenancy(namespace, tenant).Get(name, opts)
+		client := getTPClient(kubeClient, tenant)
+		return client.CoreV1().ConfigMapsWithMultiTenancy(namespace, tenant).Get(name, opts)
 	}
 	configMapStore := manager.NewObjectStore(getConfigMap, clock.RealClock{}, getTTL, defaultTTL)
 	return &configMapManager{
@@ -132,15 +148,17 @@ func NewCachingConfigMapManager(kubeClient clientset.Interface, getTTL manager.G
 // NewWatchingConfigMapManager creates a manager that keeps a cache of all configmaps
 // necessary for registered pods.
 // It implements the following logic:
-// - whenever a pod is created or updated, we start inidvidual watches for all
+// - whenever a pod is created or updated, we start individual watches for all
 //   referenced objects that aren't referenced from other registered pods
 // - every GetObject() returns a value from local cache propagated via watches
-func NewWatchingConfigMapManager(kubeClient clientset.Interface) Manager {
+func NewWatchingConfigMapManager(kubeClients []clientset.Interface) Manager {
 	listConfigMap := func(tenant, namespace string, opts metav1.ListOptions) (runtime.Object, error) {
-		return kubeClient.CoreV1().ConfigMapsWithMultiTenancy(namespace, tenant).List(opts)
+		client := getTPClient(kubeClients, tenant)
+		return client.CoreV1().ConfigMapsWithMultiTenancy(namespace, tenant).List(opts)
 	}
 	watchConfigMap := func(tenant, namespace string, opts metav1.ListOptions) (watch.Interface, error) {
-		return kubeClient.CoreV1().ConfigMapsWithMultiTenancy(namespace, tenant).Watch(opts)
+		client := getTPClient(kubeClients, tenant)
+		return client.CoreV1().ConfigMapsWithMultiTenancy(namespace, tenant).Watch(opts)
 	}
 	newConfigMap := func() runtime.Object {
 		return &v1.ConfigMap{}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -29,7 +29,7 @@ import (
 	"os"
 	"path"
 	"sort"
-        "strconv"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -255,20 +255,20 @@ type Dependencies struct {
 	ContainerManager   cm.ContainerManager
 	DockerClientConfig *dockershim.ClientConfig
 	//TODO: Arktos-scale-out: event should be per Tenant partition and per Resource parition
-	EventClient             v1core.EventsGetter
-	HeartbeatClient         clientset.Interface
-	OnHeartbeatFailure      []func()
-	KubeClient              []clientset.Interface
-	ArktosExtClient         arktos.Interface
-	Mounter                 mount.Interface
-	OOMAdjuster             *oom.OOMAdjuster
-	OSInterface             kubecontainer.OSInterface
-	PodConfig               *config.PodConfig
-	Recorder                record.EventRecorder
-	Subpather               subpath.Interface
-	VolumePlugins           []volume.VolumePlugin
-	DynamicPluginProber     volume.DynamicPluginProber
-	TLSOptions              *server.TLSOptions
+	EventClient         v1core.EventsGetter
+	HeartbeatClient     clientset.Interface
+	OnHeartbeatFailure  []func()
+	KubeClients         []clientset.Interface
+	ArktosExtClient     arktos.Interface
+	Mounter             mount.Interface
+	OOMAdjuster         *oom.OOMAdjuster
+	OSInterface         kubecontainer.OSInterface
+	PodConfig           *config.PodConfig
+	Recorder            record.EventRecorder
+	Subpather           subpath.Interface
+	VolumePlugins       []volume.VolumePlugin
+	DynamicPluginProber volume.DynamicPluginProber
+	TLSOptions          *server.TLSOptions
 	KubeletConfigController *kubeletconfig.Controller
 }
 
@@ -313,7 +313,7 @@ func makePodSourceConfig(kubeCfg *kubeletconfiginternal.KubeletConfiguration, ku
 		}
 	}
 
-	for i, client := range kubeDeps.KubeClient {
+	for i, client := range kubeDeps.KubeClients {
 		klog.Infof("Watching apiserver")
 		updatechannel = cfg.Channel(kubetypes.ApiserverSource + strconv.Itoa(i))
 		config.NewSourceApiserver(client, nodeName, updatechannel)
@@ -439,8 +439,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	// TODO: arktos-scale-out: serviceIndexer for multiple tenant partitions
 	//
 	serviceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	if kubeDeps.KubeClient != nil {
-		serviceLW := cache.NewListWatchFromClient(kubeDeps.KubeClient[0].CoreV1(), "services", metav1.NamespaceAll, fields.Everything())
+	if kubeDeps.KubeClients != nil {
+		serviceLW := cache.NewListWatchFromClient(kubeDeps.KubeClients[0].CoreV1(), "services", metav1.NamespaceAll, fields.Everything())
 		r := cache.NewReflector(serviceLW, &v1.Service{}, serviceIndexer, 0)
 		go r.Run(wait.NeverStop)
 	}
@@ -491,7 +491,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		hostname:                                hostname,
 		hostnameOverridden:                      len(hostnameOverride) > 0,
 		nodeName:                                nodeName,
-		kubeClient:                              kubeDeps.KubeClient,
+		kubeClient:                              kubeDeps.KubeClients,
 		heartbeatClient:                         kubeDeps.HeartbeatClient,
 		onRepeatedHeartbeatFailure:              kubeDeps.OnHeartbeatFailure,
 		rootDirectory:                           rootDirectory,
@@ -551,16 +551,16 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	var configMapManager configmap.Manager
 	switch kubeCfg.ConfigMapAndSecretChangeDetectionStrategy {
 	case kubeletconfiginternal.WatchChangeDetectionStrategy:
-		secretManager = secret.NewWatchingSecretManager(kubeDeps.KubeClient)
-		configMapManager = configmap.NewWatchingConfigMapManager(kubeDeps.KubeClient[0])
+		secretManager = secret.NewWatchingSecretManager(kubeDeps.KubeClients)
+		configMapManager = configmap.NewWatchingConfigMapManager(kubeDeps.KubeClients)
 	case kubeletconfiginternal.TTLCacheChangeDetectionStrategy:
 		secretManager = secret.NewCachingSecretManager(
-			kubeDeps.KubeClient[0], manager.GetObjectTTLFromNodeFunc(klet.GetNode))
+			kubeDeps.KubeClients, manager.GetObjectTTLFromNodeFunc(klet.GetNode))
 		configMapManager = configmap.NewCachingConfigMapManager(
-			kubeDeps.KubeClient[0], manager.GetObjectTTLFromNodeFunc(klet.GetNode))
+			kubeDeps.KubeClients, manager.GetObjectTTLFromNodeFunc(klet.GetNode))
 	case kubeletconfiginternal.GetChangeDetectionStrategy:
-		secretManager = secret.NewSimpleSecretManager(kubeDeps.KubeClient[0])
-		configMapManager = configmap.NewSimpleConfigMapManager(kubeDeps.KubeClient[0])
+		secretManager = secret.NewSimpleSecretManager(kubeDeps.KubeClients)
+		configMapManager = configmap.NewSimpleConfigMapManager(kubeDeps.KubeClients)
 	default:
 		return nil, fmt.Errorf("unknown configmap and secret manager mode: %v", kubeCfg.ConfigMapAndSecretChangeDetectionStrategy)
 	}
@@ -594,7 +594,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	// TODO: pod manager associated with each tenant partitions
 	//
 	// podManager is also responsible for keeping secretManager and configMapManager contents up-to-date.
-       klet.podManager = kubepod.NewBasicPodManager(kubepod.NewBasicMirrorClient(klet.kubeClient), secretManager, configMapManager, checkpointManager)
+	klet.podManager = kubepod.NewBasicPodManager(kubepod.NewBasicMirrorClient(klet.kubeClient), secretManager, configMapManager, checkpointManager)
 
 	klet.statusManager = status.NewManager(klet.kubeClient, klet.podManager, klet)
 
@@ -661,8 +661,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 
 	// TODO: runtimeClassManager to support multiple tenant partitions
 	//
-	if utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClass) && kubeDeps.KubeClient != nil {
-		klet.runtimeClassManager = runtimeclass.NewManager(kubeDeps.KubeClient[0])
+	if utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClass) && kubeDeps.KubeClients != nil {
+		klet.runtimeClassManager = runtimeclass.NewManager(kubeDeps.KubeClients[0])
 	}
 
 	runtimeRegistry, err := runtimeregistry.NewKubeRuntimeRegistry(remoteRuntimeEndpoint)
@@ -793,7 +793,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 
 	// TODO: tokenManager to support multiple tenant partitions
 	//
-	tokenManager := token.NewManager(kubeDeps.KubeClient[0])
+	tokenManager := token.NewManager(kubeDeps.KubeClients[0])
 
 	// NewInitializedVolumePluginMgr intializes some storageErrors on the Kubelet runtimeState (in csi_plugin.go init)
 	// which affects node ready status. This function must be called before Kubelet is initialized so that the Node
@@ -2175,7 +2175,7 @@ func (kl *Kubelet) handleMirrorPod(mirrorPod *v1.Pod, start time.Time) {
 
 func (kl *Kubelet) getTPClient(tenant string) clientset.Interface {
 	var client clientset.Interface
-        pick := 0
+	pick := 0
 	if len(kl.kubeClient)==1 || tenant[0] <= 'm' {
 		client = kl.kubeClient[0]
 	} else {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -594,7 +594,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	// TODO: pod manager associated with each tenant partitions
 	//
 	// podManager is also responsible for keeping secretManager and configMapManager contents up-to-date.
-	klet.podManager = kubepod.NewBasicPodManager(kubepod.NewBasicMirrorClient(klet.kubeClient[0]), secretManager, configMapManager, checkpointManager)
+       klet.podManager = kubepod.NewBasicPodManager(kubepod.NewBasicMirrorClient(klet.kubeClient), secretManager, configMapManager, checkpointManager)
 
 	klet.statusManager = status.NewManager(klet.kubeClient, klet.podManager, klet)
 

--- a/pkg/kubelet/pod/mirror_client.go
+++ b/pkg/kubelet/pod/mirror_client.go
@@ -43,16 +43,16 @@ type MirrorClient interface {
 // the kubelet directly because they need to be in sync with the internal
 // pods.
 type basicMirrorClient struct {
-       apiserverClients []clientset.Interface
+	apiserverClients []clientset.Interface
 }
 
 // NewBasicMirrorClient returns a new MirrorClient.
 func NewBasicMirrorClient(apiserverClients []clientset.Interface) MirrorClient {
-       return &basicMirrorClient{apiserverClients: apiserverClients}
+	return &basicMirrorClient{apiserverClients: apiserverClients}
 }
 
 func (mc *basicMirrorClient) CreateMirrorPod(pod *v1.Pod) error {
-       if mc.apiserverClients == nil {
+	if mc.apiserverClients == nil {
 		return nil
 	}
 	// Make a copy of the pod.
@@ -64,8 +64,8 @@ func (mc *basicMirrorClient) CreateMirrorPod(pod *v1.Pod) error {
 	}
 	hash := getPodHash(pod)
 	copyPod.Annotations[kubetypes.ConfigMirrorAnnotationKey] = hash
-       client := getTPClient(mc.apiserverClients, copyPod.Tenant)
-       apiPod, err := client.CoreV1().PodsWithMultiTenancy(copyPod.Namespace, copyPod.Tenant).Create(&copyPod)
+	client := getTPClient(mc.apiserverClients, copyPod.Tenant)
+	apiPod, err := client.CoreV1().PodsWithMultiTenancy(copyPod.Namespace, copyPod.Tenant).Create(&copyPod)
 	if err != nil && errors.IsAlreadyExists(err) {
 		// Check if the existing pod is the same as the pod we want to create.
 		if h, ok := apiPod.Annotations[kubetypes.ConfigMirrorAnnotationKey]; ok && h == hash {
@@ -76,20 +76,20 @@ func (mc *basicMirrorClient) CreateMirrorPod(pod *v1.Pod) error {
 }
 
 func getTPClient(kubeClients []clientset.Interface, tenant string) clientset.Interface {
-       var client clientset.Interface
-       pick := 0
-       if tenant[0] <= 'm' {
-               client = kubeClients[0]
-       } else {
-               client = kubeClients[1]
-               pick = 1
-       }
-       klog.Infof("tenant %s using client # %d", tenant, pick)
-       return client
+	var client clientset.Interface
+	pick := 0
+	if len(kubeClients)==1 || tenant[0] <= 'm' {
+		client = kubeClients[0]
+	} else {
+		client = kubeClients[1]
+		pick = 1
+	}
+	klog.Infof("tenant %s using client # %d", tenant, pick)
+	return client
 }
 
 func (mc *basicMirrorClient) DeleteMirrorPod(podFullName string) error {
-       if mc.apiserverClients == nil {
+	if mc.apiserverClients == nil {
 		return nil
 	}
 	name, namespace, tenant, err := kubecontainer.ParsePodFullName(podFullName)
@@ -99,8 +99,8 @@ func (mc *basicMirrorClient) DeleteMirrorPod(podFullName string) error {
 	}
 	klog.V(2).Infof("Deleting a mirror pod %q", podFullName)
 	// TODO(random-liu): Delete the mirror pod with uid precondition in mirror pod manager
-       client := getTPClient(mc.apiserverClients, tenant)
-       if err := client.CoreV1().PodsWithMultiTenancy(namespace, tenant).Delete(name, metav1.NewDeleteOptions(0)); err != nil && !errors.IsNotFound(err) {
+	client := getTPClient(mc.apiserverClients, tenant)
+	if err := client.CoreV1().PodsWithMultiTenancy(namespace, tenant).Delete(name, metav1.NewDeleteOptions(0)); err != nil && !errors.IsNotFound(err) {
 		klog.Errorf("Failed deleting a mirror pod %q: %v", podFullName, err)
 	}
 	return nil

--- a/pkg/kubelet/pod/mirror_client.go
+++ b/pkg/kubelet/pod/mirror_client.go
@@ -43,16 +43,16 @@ type MirrorClient interface {
 // the kubelet directly because they need to be in sync with the internal
 // pods.
 type basicMirrorClient struct {
-	apiserverClient clientset.Interface
+       apiserverClients []clientset.Interface
 }
 
 // NewBasicMirrorClient returns a new MirrorClient.
-func NewBasicMirrorClient(apiserverClient clientset.Interface) MirrorClient {
-	return &basicMirrorClient{apiserverClient: apiserverClient}
+func NewBasicMirrorClient(apiserverClients []clientset.Interface) MirrorClient {
+       return &basicMirrorClient{apiserverClients: apiserverClients}
 }
 
 func (mc *basicMirrorClient) CreateMirrorPod(pod *v1.Pod) error {
-	if mc.apiserverClient == nil {
+       if mc.apiserverClients == nil {
 		return nil
 	}
 	// Make a copy of the pod.
@@ -64,7 +64,8 @@ func (mc *basicMirrorClient) CreateMirrorPod(pod *v1.Pod) error {
 	}
 	hash := getPodHash(pod)
 	copyPod.Annotations[kubetypes.ConfigMirrorAnnotationKey] = hash
-	apiPod, err := mc.apiserverClient.CoreV1().PodsWithMultiTenancy(copyPod.Namespace, copyPod.Tenant).Create(&copyPod)
+       client := getTPClient(mc.apiserverClients, copyPod.Tenant)
+       apiPod, err := client.CoreV1().PodsWithMultiTenancy(copyPod.Namespace, copyPod.Tenant).Create(&copyPod)
 	if err != nil && errors.IsAlreadyExists(err) {
 		// Check if the existing pod is the same as the pod we want to create.
 		if h, ok := apiPod.Annotations[kubetypes.ConfigMirrorAnnotationKey]; ok && h == hash {
@@ -74,8 +75,21 @@ func (mc *basicMirrorClient) CreateMirrorPod(pod *v1.Pod) error {
 	return err
 }
 
+func getTPClient(kubeClients []clientset.Interface, tenant string) clientset.Interface {
+       var client clientset.Interface
+       pick := 0
+       if tenant[0] <= 'm' {
+               client = kubeClients[0]
+       } else {
+               client = kubeClients[1]
+               pick = 1
+       }
+       klog.Infof("tenant %s using client # %d", tenant, pick)
+       return client
+}
+
 func (mc *basicMirrorClient) DeleteMirrorPod(podFullName string) error {
-	if mc.apiserverClient == nil {
+       if mc.apiserverClients == nil {
 		return nil
 	}
 	name, namespace, tenant, err := kubecontainer.ParsePodFullName(podFullName)
@@ -85,7 +99,8 @@ func (mc *basicMirrorClient) DeleteMirrorPod(podFullName string) error {
 	}
 	klog.V(2).Infof("Deleting a mirror pod %q", podFullName)
 	// TODO(random-liu): Delete the mirror pod with uid precondition in mirror pod manager
-	if err := mc.apiserverClient.CoreV1().PodsWithMultiTenancy(namespace, tenant).Delete(name, metav1.NewDeleteOptions(0)); err != nil && !errors.IsNotFound(err) {
+       client := getTPClient(mc.apiserverClients, tenant)
+       if err := client.CoreV1().PodsWithMultiTenancy(namespace, tenant).Delete(name, metav1.NewDeleteOptions(0)); err != nil && !errors.IsNotFound(err) {
 		klog.Errorf("Failed deleting a mirror pod %q: %v", podFullName, err)
 	}
 	return nil

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
+	clientset "k8s.io/client-go/kubernetes"
 )
 
 func TestRunOnce(t *testing.T) {
@@ -82,7 +83,7 @@ func TestRunOnce(t *testing.T) {
 		containerRuntime: fakeRuntime,
 		reasonCache:      NewReasonCache(),
 		clock:            clock.RealClock{},
-		kubeClient:       &fake.Clientset{},
+		kubeClient:       []clientset.Interface{&fake.Clientset{}, &fake.Clientset{}},	// scale out poc hacking
 		hostname:         testKubeletHostname,
 		nodeName:         testKubeletHostname,
 		runtimeState:     newRuntimeState(time.Second),

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -65,7 +65,7 @@ func NewHollowKubelet(
 	volumePlugins = append(volumePlugins, secret.ProbeVolumePlugins()...)
 	volumePlugins = append(volumePlugins, projected.ProbeVolumePlugins()...)
 	d := &kubelet.Dependencies{
-		KubeClient:         client,
+		KubeClients:        client,
 		ArktosExtClient:    arktosClient,
 		HeartbeatClient:    heartbeatClient,
 		DockerClientConfig: dockerClientConfig,


### PR DESCRIPTION
### Changes

Converted a few more kubeclient usage to using correct tenant partition

### Validation

deployment and pod started up and then deleted correctly on local 2TP1RP environment.

### Know issues

getTPClient is being repeated. ugly. will refactor likely after the next PR (pv, volume, etc) is done. 