### PR TITLE
backwards compatible node controller

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -129,7 +129,16 @@ func startNodeIpamController(ctx ControllerContext) (http.Handler, bool, error) 
 
 func startNodeLifecycleController(ctx ControllerContext) (http.Handler, bool, error) {
 
-	tpAccessors, err := lifecyclecontroller.GetTenantPartitionManagers(ctx.ComponentConfig.NodeLifecycleController.TenantServers, ctx.Stop)
+	var tpAccessors []*lifecyclecontroller.TenantPartitionManager
+	var err error
+	var kubeclient clientset.Interface
+	if len(ctx.ComponentConfig.NodeLifecycleController.TenantServers) > 0 {
+		tpAccessors, err = lifecyclecontroller.GetTenantPartitionManagersFromServerNames(ctx.ComponentConfig.NodeLifecycleController.TenantServers, ctx.Stop)
+	} else {
+		kubeclient = ctx.ClientBuilder.ClientOrDie("node-controller")
+		tpAccessors, err = lifecyclecontroller.GetTenantPartitionManagersFromKubeClients([]clientset.Interface{kubeclient}, ctx.Stop)
+	}
+
 	if err != nil {
 		return nil, true, err
 	}
@@ -141,7 +150,7 @@ func startNodeLifecycleController(ctx ControllerContext) (http.Handler, bool, er
 		ctx.InformerFactory.Core().V1().Nodes(),
 		//ctx.InformerFactory.Apps().V1().DaemonSets(),
 		// node lifecycle controller uses existing cluster role from node-controller
-		ctx.ClientBuilder.ClientOrDie("node-controller"),
+		kubeclient,
 		ctx.ComponentConfig.KubeCloudShared.NodeMonitorPeriod.Duration,
 		ctx.ComponentConfig.NodeLifecycleController.NodeStartupGracePeriod.Duration,
 		ctx.ComponentConfig.NodeLifecycleController.NodeMonitorGracePeriod.Duration,

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -129,13 +129,13 @@ func startNodeIpamController(ctx ControllerContext) (http.Handler, bool, error) 
 
 func startNodeLifecycleController(ctx ControllerContext) (http.Handler, bool, error) {
 
+	kubeclient := ctx.ClientBuilder.ClientOrDie("node-controller")
+	
 	var tpAccessors []*lifecyclecontroller.TenantPartitionManager
-	var err error
-	var kubeclient clientset.Interface
+	var err error	
 	if len(ctx.ComponentConfig.NodeLifecycleController.TenantServers) > 0 {
 		tpAccessors, err = lifecyclecontroller.GetTenantPartitionManagersFromServerNames(ctx.ComponentConfig.NodeLifecycleController.TenantServers, ctx.Stop)
 	} else {
-		kubeclient = ctx.ClientBuilder.ClientOrDie("node-controller")
 		tpAccessors, err = lifecyclecontroller.GetTenantPartitionManagersFromKubeClients([]clientset.Interface{kubeclient}, ctx.Stop)
 	}
 


### PR DESCRIPTION
Make node-controller backwards compatible. When "tenant-servers" in the CLI option is empty, use the apiserver specified in the kubeconfig. 

Verified in gce, the issue that nodelifecycle controller crash issue in kube-up.sh is solved.