### PR TITLE
Fix proxy rules, disable workload controller

### DIFF
--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -1075,7 +1075,11 @@ function create-master-kubelet-auth {
   if [[ -n "${KUBELET_APISERVER:-}" && -n "${KUBELET_CERT:-}" && -n "${KUBELET_KEY:-}" ]]; then
     REGISTER_MASTER_KUBELET="true"
     if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" == "true" ]]; then
-      create-kubelet-kubeconfig ${KUBELET_APISERVER} "8080" "http"
+      if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+        create-kubelet-kubeconfig ${PROXY_RESERVED_IP} "8888" "http"
+      else
+        create-kubelet-kubeconfig ${KUBELET_APISERVER} "8080" "http"
+      fi
     else
       create-kubelet-kubeconfig ${KUBELET_APISERVER}
     fi

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -137,7 +137,7 @@ function main() {
       start-kube-scheduler
     fi
     wait-till-apiserver-ready
-    start-workload-controller-manager
+    #start-workload-controller-manager
     start-kube-addons
     start-cluster-autoscaler
     start-lb-controller

--- a/cluster/gce/gci/partitionserver-configure-helper.sh
+++ b/cluster/gce/gci/partitionserver-configure-helper.sh
@@ -129,9 +129,9 @@ function main() {
   if [[ "${ENABLE_KUBESCHEDULER}" == "true" ]]; then
     start-kube-scheduler
   fi
-  if [[ "${ENABLE_WORKLOADCONTROLLER}" == "true" ]]; then
-    start-workload-controller-manager ${KUBERNETES_MASTER_INTERNAL_IP}
-  fi
+  #if [[ "${ENABLE_WORKLOADCONTROLLER}" == "true" ]]; then
+  #  start-workload-controller-manager ${KUBERNETES_MASTER_INTERNAL_IP}
+  #fi
 
   reset-motd
   prepare-mounter-rootfs

--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -133,6 +133,9 @@ while true; do
   # Use grep || true so that empty result doesn't return nonzero exit code.
   ready=$(echo -n "${node}" | grep -c -v "NotReady" || true)
 
+  if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+    EXPECTED_NUM_NODES=0
+  fi
   if (( "${found}" == "${EXPECTED_NUM_NODES}" )) && (( "${ready}" == "${EXPECTED_NUM_NODES}")); then
     break
   elif (( "${found}" > "${EXPECTED_NUM_NODES}" )); then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: This fixes the proxy rules to correctly direct traffic between RP and TP, and disables workload controller.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
