### PR TITLE
update nginx.conf

### DIFF
--- a/hack/scale_out_poc/two_TP/nginx.conf
+++ b/hack/scale_out_poc/two_TP/nginx.conf
@@ -50,70 +50,59 @@ http {
         #
 
         server {
-                listen      {{ proxy_port }};
-                server_name {{ proxy_host_name }} {{ proxy_ip }};
+            listen      8888;
+            server_name ip-172-31-26-146 172.31.26.146;
 
-                access_log /var/log/nginx/arktos_access.log;
-                error_log /var/log/nginx/arktos_error.log;
+            access_log /var/log/nginx/arktos_access.log;
+            error_log /var/log/nginx/arktos_error.log;
 
-                set $resource_api {{ arktos_api_protocol }}://{{ resource_partition_ip }}:{{ arktos_api_port }};
-                set $tenant_api_one {{ arktos_api_protocol }}://{{ tenant_partition_one_ip }}:{{ arktos_api_port }};
-                set $tenant_api_two {{ arktos_api_protocol }}://{{ tenant_partition_two_ip }}:{{ arktos_api_port }};
+            set $resource_api http://172.31.23.48:8080;
+            set $tenant_api_one http://172.31.26.146:8080;
+            set $tenant_api_two http://172.31.26.99:8080;
 
-                #################################################################
-                # forward nodes related requests to resource partition
-                #################################################################
+            #################################################################
+            # forward nodes related requests to resource partition
+            #################################################################
 
-                location ~ ^/api/v1/nodes?(.*) {
-                    proxy_pass $resource_api;
-                }
+            location ~ ^/api/[a-z0-9_.-]+/nodes?(.*) {
+                proxy_pass $resource_api;
+            }
 
-                location ~ ^/apis/coordination.k8s.io/v1/leases?(.*) {
-                    proxy_pass $resource_api;
-                }
+            location ~ ^/apis/coordination.k8s.io/[a-z0-9_.-]+/leases?(.*) {
+                proxy_pass $resource_api;
+            }
 
-                location ~ ^/apis/([^/])*/([^/])*/tenants/system/namespaces/kube-node-lease/leases?(.*) {
-                    proxy_pass $resource_api;
-                }
+            location ~ ^/apis/[a-z0-9_.-]+/[a-z0-9_.-]+/tenants/system/namespaces/kube-node-lease/leases?(.*) {
+                proxy_pass $resource_api;
+            }
+            
+            #################################################################
+            # forward the tenant-specific requests to its own tenant-partition
+            # Note: the system-tenant/all-tenants/non-tenant-scope requests will be forwarded to the source IP
+            #################################################################
 
-                #################################################################
-                # forward the request of system-tenants or no tenants specificed back to its source partition
-                #################################################################
+            location ~* ^/apis/[a-z0-9_.-]+/[a-z0-9_.-]+/tenants/(?!(system$|system/.*$|all$|all/.*$))([a-m].*)$ {
+                proxy_pass $tenant_api_one;
+            }
 
-                location ~* ^/apis/([^/])*/([^/])*/(!tenants)?(.*) {
-                    proxy_pass http://$remote_addr:8080;
-                }
+            location ~* ^/api/[a-z0-9_.-]+/tenants/(?!(system$|system/.*$|all$|all/.*$))([a-m].*)$ {
+                proxy_pass $tenant_api_one;
+            }
 
-                location ~* ^/api/([^/])*/(!tenants)?(.*) {
-                    proxy_pass http://$remote_addr:8080;
-                }
+            location ~* ^/apis/[a-z0-9_.-]+/[a-z0-9_.-]+/tenants/(?!(system$|system/.*$|all$|all/.*$))([n-z].*)$ {
+                proxy_pass $tenant_api_two;
+            }
+            location ~* ^/api/[a-z0-9_.-]+/tenants/(?!(system$|system/.*$|all$|all/.*$))([n-z].*)$ {
+                proxy_pass $tenant_api_two;
+            }
 
-                location ~ ^/apis/[a-z0-9_.-]+/[a-z0-9_.-]+/tenants/system?(.*) {
-                    proxy_pass http://$remote_addr:8080;
-                }
-
-                location ~ ^/api/[a-z0-9_.-]+/tenants/system?(.*) {
-                    proxy_pass http://$remote_addr:8080;
-                }
-
-                #################################################################
-                # forward the tenant-specific requests to its own tenant-partition
-                #################################################################
-
-                location ~* ^/apis/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/tenants/[a-m0-9_.-]+/(.*) {
-                    proxy_pass $tenant_api_one;
-                }
-                location ~* ^/apis/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/tenants/[n-z_.-]+/(.*) {
-                    proxy_pass $tenant_api_two;
-                }
-
-                #################################################################
-                # should not hit here. if here, send the request back
-                #################################################################
-                location / {
-                    proxy_pass http://$remote_addr:8080;
-                }
-        } 
+            #################################################################
+            # should not hit here. if here, send the request back
+            #################################################################
+            location / {
+                proxy_pass http://$remote_addr:8080;
+            }
+        }
 
     ##
     # Gzip Settings


### PR DESCRIPTION
This PR fixes the forwarding logic in nginx.conf.
1. made all-tenants request go back to the source partition
2. make requests from tenant named all#### ( but not all) to TP-1, equests from tenant named system#### ( but not system) to TP-2. There was a bug that will treat tenants named system### like system.
3. Simplify the logic a bit.

Verification:
In https://nginx.viraptor.info/, I verified the following url are forwarded to correct locations:
```
http://{{ proxy_ip }}:8888/api/v1/nodes
http://{{ proxy_ip }}:8888/api/v1/nodes/a
http://{{ proxy_ip }}:8888/apis/coordination.k8s.io/v1/leases
http://{{ proxy_ip }}:8888/apis/coordination.k8s.io/v1/leases/a
http://{{ proxy_ip }}:8888/apis/coordination.k8s.io/v1/tenants/system/namespaces/kube-node-lease/leases
http://{{ proxy_ip }}:8888/apis/coordination.k8s.io/v1/tenants/system/namespaces/kube-node-lease/leases/a

http://{{ proxy_ip }}:8888/api/v1/nontenants
http://{{ proxy_ip }}:8888/api/v1/nontenants/a
http://{{ proxy_ip }}:8888/apis/group/v1/non-tenants
http://{{ proxy_ip }}:8888/apis/group/v1/non-tenants/a

http://{{ proxy_ip }}:8888/api/v1/tenants/mummy
http://{{ proxy_ip }}:8888/api/v1/tenants/mummy/sth
http://{{ proxy_ip }}:8888/apis/group/v1/tenants/mummy
http://{{ proxy_ip }}:8888/apis/group/v1/tenants/mummy/sth
http://{{ proxy_ip }}:8888/api/v1/tenants/zeth
http://{{ proxy_ip }}:8888/api/v1/tenants/zeth/sth
http://{{ proxy_ip }}:8888/apis/group/v1/tenants/zeth
http://{{ proxy_ip }}:8888/apis/group/v1/tenants/zeth/sth

http://{{ proxy_ip }}:8888/api/v1/tenants/all
http://{{ proxy_ip }}:8888/api/v1/tenants/all/sth
http://{{ proxy_ip }}:8888/api/v1/tenants/allfake
http://{{ proxy_ip }}:8888/api/v1/tenants/allfake/sth

http://{{ proxy_ip }}:8888/api/v1/tenants/system
http://{{ proxy_ip }}:8888/api/v1/tenants/system/sth
http://{{ proxy_ip }}:8888/api/v1/tenants/systemfake
http://{{ proxy_ip }}:8888/api/v1/tenants/systemfake/sth

http://{{ proxy_ip }}:8888/apis/group/v1/tenants/all
http://{{ proxy_ip }}:8888/apis/group/v1/tenants/all/sth
http://{{ proxy_ip }}:8888/apis/group/v1/tenants/allfake
http://{{ proxy_ip }}:8888/apis/group/v1/tenants/allfake/sth

http://{{ proxy_ip }}:8888/apis/group/v1/tenants/system
http://{{ proxy_ip }}:8888/apis/group/v1/tenants/system/sth
http://{{ proxy_ip }}:8888/apis/group/v1/tenants/systemfake
http://{{ proxy_ip }}:8888/apis/group/v1/tenants/systemfake/sth
```
