### PR TITLE
set up 2T1R kubemark clusters with haproxy dynamic configured

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -90,6 +90,24 @@ function create-kubeconfig() {
   local cluster_args=(
       "--server=${KUBE_SERVER:-https://${KUBE_MASTER_IP}}"
   )
+
+  if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
+    if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+      if [[ "${PROXY_RESERVED_IP}" == "" ]]; then
+        echo "Fatal Error: proxy IP is empty!"
+        exit 1
+      fi
+      cluster_args=(
+          "--server=${KUBE_SERVER:-http://${PROXY_RESERVED_IP}}:8888"
+       )
+    fi
+    if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
+      cluster_args=(
+          "--server=${KUBE_SERVER:-http://${KUBE_MASTER_IP}}:8080"
+       )
+    fi
+  fi    
+
   if [[ -z "${CA_CERT:-}" ]]; then
     cluster_args+=("--insecure-skip-tls-verify=true")
   else
@@ -934,6 +952,11 @@ EOF
 ETCD_QUORUM_READ: $(yaml-quote ${ETCD_QUORUM_READ})
 EOF
     fi
+    if [ -n "${TENANT_SERVERS:-}" ]; then
+      cat >>$file <<EOF
+TENANT_SERVERS: $(yaml-quote ${TENANT_SERVERS})
+EOF
+    fi
 
   else
     # Node-only env vars.
@@ -1052,6 +1075,24 @@ function create-kubeconfig() {
   local cluster_args=(
       "--server=${KUBE_SERVER:-https://${KUBE_MASTER_IP}}"
   )
+
+  if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
+    if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+      if [[ "${PROXY_RESERVED_IP}" == "" ]]; then
+        echo "Fatal Error: proxy IP is empty!"
+        exit 1
+      fi
+      cluster_args=(
+          "--server=${KUBE_SERVER:-http://${PROXY_RESERVED_IP}}:8888"
+       )
+    fi
+    if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
+      cluster_args=(
+          "--server=${KUBE_SERVER:-http://${KUBE_MASTER_IP}}:8080"
+       )
+    fi
+  fi
+    
   if [[ -z "${CA_CERT:-}" ]]; then
     cluster_args+=("--insecure-skip-tls-verify=true")
   else

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -2208,6 +2208,11 @@ function start-kube-controller-manager {
     params+=" --controllers=${RUN_CONTROLLERS}"
   fi
 
+  if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
+    echo "DBG:Set tenant-servers parameters:  ${TENANT_SERVERS}"
+    params+=" --tenant-servers=${TENANT_SERVERS}"
+  fi
+
   local -r kube_rc_docker_tag=$(cat /home/kubernetes/kube-docker-files/kube-controller-manager.docker_tag)
   local container_env=""
   if [[ -n "${ENABLE_CACHE_MUTATION_DETECTOR:-}" ]]; then

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -137,7 +137,7 @@ function main() {
       start-kube-scheduler
     fi
     wait-till-apiserver-ready
-    start-workload-controller-manager
+    # start-workload-controller-manager
     start-kube-addons
     start-cluster-autoscaler
     start-lb-controller

--- a/cluster/gce/gci/partitionserver-configure-helper.sh
+++ b/cluster/gce/gci/partitionserver-configure-helper.sh
@@ -129,9 +129,9 @@ function main() {
   if [[ "${ENABLE_KUBESCHEDULER}" == "true" ]]; then
     start-kube-scheduler
   fi
-  if [[ "${ENABLE_WORKLOADCONTROLLER}" == "true" ]]; then
-    start-workload-controller-manager ${KUBERNETES_MASTER_INTERNAL_IP}
-  fi
+  #if [[ "${ENABLE_WORKLOADCONTROLLER}" == "true" ]]; then
+  # start-workload-controller-manager ${KUBERNETES_MASTER_INTERNAL_IP}
+  #fi
 
   reset-motd
   prepare-mounter-rootfs

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2362,12 +2362,6 @@ function kube-up() {
     cp -f ${KUBECONFIG} ${LOCAL_KUBECONFIG_TMP}
     grep -i "server:" ${LOCAL_KUBECONFIG_TMP}
 
-    if [[ "${KUBERNETES_SCALEOUT_PROXY:-false}" == "true" ]]; then
-      echo "Scaleout proxy public IP: ${PROXY_RESERVED_IP}:8888"
-      echo "Scaleout proxy internal IP: ${PROXY_RESERVED_INTERNAL_IP}:8888"
-      cp -f ${KUBECONFIG} ${LOCAL_KUBECONFIG}
-      sed -i "s/server: https:\/\/.*/server: http:\/\/${PROXY_RESERVED_IP}:8888/" ${LOCAL_KUBECONFIG}
-    fi
   fi
 }
 
@@ -2790,139 +2784,58 @@ function create-proxy-vm() {
   return 1
 }
 
+function init-proxy-cfg() {
+
+  if [[ "${KUBERNETES_SCALEOUT_PROXY_APP}" == "haproxy" ]]; then
+    cp -f "${KUBE_ROOT}/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg" "${PROXY_CONFIG_FILE_TMP}" 
+  else
+    cp -f "${KUBE_ROOT}/hack/scale_out_poc/two_TP/nginx.conf" "${PROXY_CONFIG_FILE_TMP}" 
+  fi
+    
+  sed -i -e "s@{{ *proxy_port *}}@8888@g" "${PROXY_CONFIG_FILE_TMP}" 
+
+  sed -i -e "s@{{ *arktos_api_protocol *}}@http@g" "${PROXY_CONFIG_FILE_TMP}" 
+  sed -i -e "s@{{ *arktos_api_port *}}@8080@g" "${PROXY_CONFIG_FILE_TMP}" 
+
+  sed -i -e "s@{{ *connection_timeout *}}@10m@g" "${PROXY_CONFIG_FILE_TMP}" 
+}
+
+function update-proxy() {
+  macro_name=$1
+  macro_value=$2
+
+  sed -i -e "s@{{ *${macro_name} *}}@${macro_value}@g" "${PROXY_CONFIG_FILE_TMP}"
+
+  cp -f "${PROXY_CONFIG_FILE_TMP}" "${PROXY_CONFIG_FILE_TMP}.interim"
+
+  # proxy config files do not know macros, so we trick it with the current master IP temporarily.
+  # real replacement will happen when the master of the partition happens
+  sed -i -e "s@{{ *resource_partition_ip *}}@${MASTER_RESERVED_IP}@g" "${PROXY_CONFIG_FILE_TMP}.interim"
+  sed -i -e "s@{{ *tenant_partition_one_ip *}}@${MASTER_RESERVED_IP}@g" "${PROXY_CONFIG_FILE_TMP}.interim"
+  sed -i -e "s@{{ *tenant_partition_two_ip *}}@${MASTER_RESERVED_IP}@g" "${PROXY_CONFIG_FILE_TMP}.interim"
+
+  load-proxy-cfg
+}
+
+function load-proxy-cfg {
+  gcloud compute scp --zone="${ZONE}" "${PROXY_CONFIG_FILE_TMP}.interim" "${PROXY_NAME}:~/${PROXY_CONFIG_FILE}"
+  ssh-to-node ${PROXY_NAME} "sudo rm -f /etc/${KUBERNETES_SCALEOUT_PROXY_APP}/${PROXY_CONFIG_FILE}"
+  ssh-to-node ${PROXY_NAME} "sudo mv ~/${PROXY_CONFIG_FILE} /etc/${KUBERNETES_SCALEOUT_PROXY_APP}/${PROXY_CONFIG_FILE}"
+  echo "VDBG ========================================"
+  cat ${PROXY_CONFIG_FILE_TMP}.interim
+  echo "VDBG ========================================"
+  ssh-to-node ${PROXY_NAME} "sudo systemctl restart ${KUBERNETES_SCALEOUT_PROXY_APP}"
+}
+
 function setup-proxy() {
+  init-proxy-cfg
+
   ssh-to-node ${PROXY_NAME} "sudo sed -i '\$afs.file-max = 1000000' /etc/sysctl.conf"
   ssh-to-node ${PROXY_NAME} "sudo sysctl -p"
   ssh-to-node ${PROXY_NAME} "sudo sed -i '\$a*       hard    nofile          1000000' /etc/security/limits.conf"
   ssh-to-node ${PROXY_NAME} "sudo sed -i '\$a*       soft    nofile          1000000' /etc/security/limits.conf"
   ssh-to-node ${PROXY_NAME} "sudo apt update -y"
-  ssh-to-node ${PROXY_NAME} "sudo apt install -y nginx"
-  ssh-to-node ${PROXY_NAME} "sudo rm -f /etc/nginx/nginx.conf"
-
-  RESOURCE_MASTER_IP=${1}
-
-  cat >"${KUBE_TEMP}/nginx.conf" << EOF
-user www-data;
-worker_processes auto;
-pid /run/nginx.pid;
-include /etc/nginx/modules-enabled/*.conf;
-
-events {
-    worker_connections 100000;
-    # multi_accept on;
-}
-
-http {
-
-    ##
-    # Basic Settings
-    ##
-
-    sendfile on;
-    tcp_nopush on;
-    tcp_nodelay on;
-    types_hash_max_size 2048;
-    proxy_http_version 1.1;
-
-    # server_tokens off;
-
-    # server_names_hash_bucket_size 64;
-    # server_name_in_redirect off;
-
-    include /etc/nginx/mime.types;
-    default_type application/octet-stream;
-
-    ##
-    # SSL Settings
-    ##
-
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
-    ssl_prefer_server_ciphers on;
-
-    ##
-    # Logging Settings
-    ##
-
-    access_log /var/log/nginx/access.log;
-    error_log /var/log/nginx/error.log;
-
-    ##
-    # Gzip Settings
-    ##
-
-    gzip on;
-
-    ##
-    # Virtual Host Configs
-    ##
-
-    include /etc/nginx/conf.d/*.conf;
-    include /etc/nginx/sites-enabled/*;
-
-    ##
-    # arktos cluster settings
-    #
-    keepalive_timeout 10m;
-    proxy_connect_timeout 600s;
-    proxy_send_timeout 600s;
-    proxy_read_timeout 600s;
-    fastcgi_send_timeout 600s;
-    fastcgi_read_timeout 600s;
-
-    server {
-        listen      8888;
-        server_name ${PROXY_NAME} ${PROXY_RESERVED_IP};
-
-        access_log /var/log/nginx/k8s_access.log;
-        error_log /var/log/nginx/k8s_error.log;
-
-        set \$RESOURCE_API http://${RESOURCE_MASTER_IP}:8080;
-        set \$TENANT_API http://${RESOURCE_MASTER_IP}:8080;
-
-        location ~ ^/[a-zA-Z0-9_.-]+$ {
-            proxy_read_timeout 3600;
-            proxy_pass http://\$remote_addr:8080;
-        }
-
-        location ~ ^/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$ {
-            proxy_read_timeout 3600;
-            proxy_pass http://\$remote_addr:8080;
-        }
-
-        location ~ ^/apis/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$ {
-            proxy_read_timeout 3600;
-            proxy_pass http://\$remote_addr:8080;
-        }
-
-        location ~ ^/api/([^/])*/nodes?(.*) {
-            proxy_read_timeout 3600;
-            proxy_pass \$RESOURCE_API;
-        }
-
-        location ~ ^/apis/coordination.k8s.io/([^/])*/leases?(.*) {
-            proxy_read_timeout 3600;
-            proxy_pass \$RESOURCE_API;
-        }
-
-        location ~ ^/apis/([^/])*/([^/])*/tenants/system/namespaces/kube-node-lease/leases?(.*) {
-            proxy_read_timeout 3600;
-            proxy_pass \$RESOURCE_API;
-        }
-
-        location / {
-            proxy_read_timeout 3600;
-            proxy_pass \$TENANT_API;
-        }
-    }
-}
-EOF
-
-  gcloud compute scp --zone="${ZONE}" "${KUBE_TEMP}/nginx.conf" "${PROXY_NAME}:~/nginx.conf"
-  ssh-to-node ${PROXY_NAME} "sudo mv ~/nginx.conf /etc/nginx/nginx.conf"
-  echo "VDBG ========================================"
-  cat ${KUBE_TEMP}/nginx.conf
-  echo "VDBG ========================================"
-  ssh-to-node ${PROXY_NAME} "sudo systemctl restart nginx"
+  ssh-to-node ${PROXY_NAME} "sudo apt install -y ${KUBERNETES_SCALEOUT_PROXY_APP}"
 }
 
 function create-master() {
@@ -3011,13 +2924,21 @@ function create-master() {
   create-etcd-apiserver-certs "etcd-${MASTER_NAME}" "${MASTER_NAME}" "" "" "${CREATE_CERT_SERVER_IP}"
 
   if [[ "${KUBERNETES_SCALEOUT_PROXY:-false}" == "true" ]]; then
-    setup-proxy ${MASTER_RESERVED_IP}
+    setup-proxy
   fi
-  if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-    local sedarg="s/set \\\$TENANT_API http:.*/set \\\$TENANT_API http:\/\/${MASTER_RESERVED_IP}:8080;/"
-    ssh-to-node ${PROXY_NAME} "sudo sed -i \"${sedarg}\" /etc/nginx/nginx.conf"
-    ssh-to-node ${PROXY_NAME} "sudo systemctl restart nginx"
+
+  if [[ "${PARTITION_TO_UPDATE}" == "resource_partition" ]]; then 
+    update-proxy "resource_partition_ip" "${MASTER_RESERVED_IP}"
   fi
+
+  if [[ "${PARTITION_TO_UPDATE}" == "tenant_partition_one" ]]; then 
+    update-proxy "tenant_partition_one_ip" "${MASTER_RESERVED_IP}"
+  fi
+
+  if [[ "${PARTITION_TO_UPDATE}" == "tenant_partition_two" ]]; then 
+    update-proxy "tenant_partition_two_ip" "${MASTER_RESERVED_IP}"
+  fi
+
 
   #if [[ "$(get-num-nodes)" -ge "50" ]]; then
     # We block on master creation for large clusters to avoid doing too much

--- a/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg
+++ b/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg
@@ -37,7 +37,7 @@ defaults
         errorfile 504 /etc/haproxy/errors/504.http
 
 frontend scale-out-proxy
-    bind *:8888 alpn h2,http/1.1
+    bind *:{{ proxy_port }} alpn h2,http/1.1
 
     acl tp_one_request_2 path_reg ^/api/[a-z0-9_.-]+/tenants/(?!(system$|system/.*$|all$|all/.*$))([a-m].*)$
     acl tp_one_request_1 path_reg ^/apis/[a-z0-9_.-]+/[a-z0-9_.-]+/tenants/(?!(system$|system/.*$|all$|all/.*$))([a-m].*)$

--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -40,20 +40,26 @@ function create-kubemark-master {
     kube::util::ensure-temp-dir
     export KUBE_TEMP="${KUBE_TEMP}"
     export LOCAL_KUBECONFIG_TMP
+    export LOCAL_KUBECONFIG
 
     KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark"
     KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX:-e2e-test-${USER}}-kubemark"
-    if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
-      SCALEOUT_PROXY_NAME="${KUBE_GCE_INSTANCE_PREFIX}-proxy"
+    SCALEOUT_PROXY_NAME="${KUBE_GCE_INSTANCE_PREFIX}-proxy"
+    if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then     
       KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-rp"
       KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-rp"
-      export LOCAL_KUBECONFIG
     fi
     if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-      SCALEOUT_PROXY_NAME="${KUBE_GCE_INSTANCE_PREFIX}-proxy"
-      KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp"
-      KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-tp"
+      if [[ "${PARTITION_TO_UPDATE}" == "tenant_partition_one" ]]; then 
+        KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp-1"
+        KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-tp-1"
+      fi
+      if [[ "${PARTITION_TO_UPDATE}" == "tenant_partition_two" ]]; then 
+        KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp-2"
+        KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-tp-2"
+      fi
     fi
+
     export SCALEOUT_PROXY_NAME
     export KUBECONFIG
     export KUBE_GCE_INSTANCE_PREFIX
@@ -113,8 +119,14 @@ function delete-kubemark-master {
       KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-rp"
     fi
     if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-      SCALEOUT_PROXY_NAME="${KUBE_GCE_INSTANCE_PREFIX}-proxy"
-      KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-tp"
+      if [[ "${PARTITION_TO_UPDATE}" == "tenant_partition_one" ]]; then 
+        KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp-1"
+        KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-tp-1"
+      fi
+      if [[ "${PARTITION_TO_UPDATE}" == "tenant_partition_two" ]]; then 
+        KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp-2"
+        KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-tp-2"
+      fi
     fi
     export SCALEOUT_PROXY_NAME
     export KUBE_GCE_INSTANCE_PREFIX

--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -63,7 +63,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - /kubemark --morph=kubelet --tenant-servers=${TENANT_SERVERS} --resource-server=${RESOURCE_SERVER} --name=$(NODE_NAME) {{hollow_kubelet_params}} --kubeconfig=/kubeconfig/kubelet.kubeconfig $(CONTENT_TYPE) --alsologtostderr 1>>/var/log/kubelet-$(NODE_NAME).log 2>&1
+        - /kubemark --morph=kubelet --tenant-servers={{tenant_servers}} --resource-server={{resource_server}} --name=$(NODE_NAME) {{hollow_kubelet_params}} --kubeconfig=/kubeconfig/kubelet.kubeconfig $(CONTENT_TYPE) --alsologtostderr 1>>/var/log/kubelet-$(NODE_NAME).log 2>&1
         volumeMounts:
         - name: kubeconfig-volume
           mountPath: /kubeconfig

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -40,6 +40,7 @@ KUBEMARK_DIRECTORY="${KUBE_ROOT}/test/kubemark"
 RESOURCE_DIRECTORY="${KUBEMARK_DIRECTORY}/resources"
 LOCAL_KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark"
 LOCAL_KUBECONFIG_TMP="${RESOURCE_DIRECTORY}/kubeconfig.kubemark.tmp"
+TP_ONE_KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp-1"
 
 export KUBERNETES_SCALEOUT_PROXY_APP=${KUBERNETES_SCALEOUT_PROXY_APP:-haproxy}
 
@@ -104,12 +105,6 @@ function create-kube-hollow-node-resources {
   # Create kubemark namespace.
   "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/kubemark-ns.json"
 
-  if [[ "${SCALEOUT_CLUSTER_TWO_TPS:-false}" == "true" ]]; then
-    export TENANT_SERVERS="${TENANT_SERVER_1},${TENANT_SERVER_2}"
-  else
-    export TENANT_SERVERS="${TENANT_SERVER_1}"
-  fi
-
   # Create configmap for configuring hollow- kubelet, proxy and npd.
   "${KUBECTL}" create configmap "node-configmap" --namespace="kubemark" \
     --from-literal=content.type="${TEST_CLUSTER_API_CONTENT_TYPE}" \
@@ -121,12 +116,12 @@ function create-kube-hollow-node-resources {
   # It's bad that all component shares the same kubeconfig.
   # TODO(https://github.com/kubernetes/kubernetes/issues/79883): Migrate all components to separate credentials.
   "${KUBECTL}" create secret generic "kubeconfig" --type=Opaque --namespace="kubemark" \
-    --from-file=kubelet.kubeconfig="${LOCAL_KUBECONFIG_TMP}" \
-    --from-file=kubeproxy.kubeconfig="${LOCAL_KUBECONFIG_TMP}" \
-    --from-file=npd.kubeconfig="${LOCAL_KUBECONFIG_TMP}" \
-    --from-file=heapster.kubeconfig="${LOCAL_KUBECONFIG_TMP}" \
-    --from-file=cluster_autoscaler.kubeconfig="${LOCAL_KUBECONFIG_TMP}" \
-    --from-file=dns.kubeconfig="${LOCAL_KUBECONFIG_TMP}"
+    --from-file=kubelet.kubeconfig="${TP_ONE_KUBECONFIG}" \
+    --from-file=kubeproxy.kubeconfig="${TP_ONE_KUBECONFIG}" \
+    --from-file=npd.kubeconfig="${TP_ONE_KUBECONFIG}" \
+    --from-file=heapster.kubeconfig="${TP_ONE_KUBECONFIG}" \
+    --from-file=cluster_autoscaler.kubeconfig="${TP_ONE_KUBECONFIG}" \
+    --from-file=dns.kubeconfig="${TP_ONE_KUBECONFIG}"
 
   # Create addon pods.
   # Heapster.
@@ -184,6 +179,8 @@ function create-kube-hollow-node-resources {
   sed -i'' -e "s@{{hollow_kubelet_params}}@${HOLLOW_KUBELET_TEST_ARGS}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
   sed -i'' -e "s@{{hollow_proxy_params}}@${HOLLOW_PROXY_TEST_ARGS}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
   sed -i'' -e "s@{{kubemark_mig_config}}@${KUBEMARK_MIG_CONFIG:-}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
+  sed -i'' -e "s@{{tenant_servers}}@${TENANT_SERVERS:-}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
+  sed -i'' -e "s@{{resource_server}}@${RESOURCE_SERVER:-}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
   "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/hollow-node.yaml" --namespace="kubemark"
 
   echo "Created secrets, configMaps, replication-controllers required for hollow-nodes."
@@ -193,7 +190,7 @@ function create-kube-hollow-node-resources {
 function wait-for-hollow-nodes-to-run-or-timeout {
   echo -n "Waiting for all hollow-nodes to become Running"
   start=$(date +%s)
-  nodes=$("${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG_TMP}" get node 2> /dev/null) || true
+  nodes=$("${KUBECTL}" --kubeconfig="${TP_ONE_KUBECONFIG}" get node 2> /dev/null) || true
   ready=$(($(echo "${nodes}" | grep -vc "NotReady") - 1))
 
   until [[ "${ready}" -ge "${NUM_REPLICAS}" ]]; do
@@ -206,7 +203,7 @@ function wait-for-hollow-nodes-to-run-or-timeout {
       # shellcheck disable=SC2154 # Color defined in sourced script
       echo -e "${color_red} Timeout waiting for all hollow-nodes to become Running. ${color_norm}"
       # Try listing nodes again - if it fails it means that API server is not responding
-      if "${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG_TMP}" get node &> /dev/null; then
+      if "${KUBECTL}" --kubeconfig="${TP_ONE_KUBECONFIG}" get node &> /dev/null; then
         echo "Found only ${ready} ready hollow-nodes while waiting for ${NUM_NODES}."
       else
         echo "Got error while trying to list hollow-nodes. Probably API server is down."
@@ -219,7 +216,7 @@ function wait-for-hollow-nodes-to-run-or-timeout {
       echo "${pods}" | grep -v Running
       exit 1
     fi
-    nodes=$("${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG_TMP}" get node 2> /dev/null) || true
+    nodes=$("${KUBECTL}" --kubeconfig="${TP_ONE_KUBECONFIG}" get node 2> /dev/null) || true
     ready=$(($(echo "${nodes}" | grep -vc "NotReady") - 1))
   done
   # shellcheck disable=SC2154 # Color defined in sourced script
@@ -246,39 +243,56 @@ function start-hollow-nodes {
 
 detect-project &> /dev/null
 
-if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
-  export ENABLE_APISERVER_INSECURE_PORT=true
-  export KUBERNETES_RESOURCE_PARTITION=true
-  export KUBERNETES_SCALEOUT_PROXY=true
-  export PARTITION_TO_UPDATE="resource_partition"
-  create-kubemark-master
-  export KUBERNETES_RESOURCE_PARTITION=false
-  export KUBERNETES_SCALEOUT_PROXY=false
-else
-  create-kubemark-master
-fi
-
-MASTER_IP=$(grep server "${LOCAL_KUBECONFIG_TMP}" | awk -F "/" '{print $3}')
-export RESOURCE_SERVER="http://"$(grep server "${LOCAL_KUBECONFIG_TMP}" | awk -F "/" '{print $3}'):8080
-
 # Start two tenant partition clusters and perseve their master url
 # Proxy server IP is the same as the first Tenant Cluster master IP, with port on 8888
 #
 if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
-  export PROXY_RESERVED_IP=$(echo ${MASTER_IP} | cut -d: -f1)
-echo "VDBGG: PROXY_RESERVED_IP=$PROXY_RESERVED_IP"
-  export KUBERNETES_TENANT_PARTITION=true
+  export ENABLE_APISERVER_INSECURE_PORT=true
+  export KUBERNETES_TENANT_PARTITION=true  
+  export KUBERNETES_SCALEOUT_PROXY=true
   export PARTITION_TO_UPDATE="tenant_partition_one"
   create-kubemark-master
-  export TENANT_SERVER_1="http://"$(grep server "${LOCAL_KUBECONFIG_TMP}" | awk -F "/" '{print $3}'):8080
 
+  MASTER_IP=$(grep server "${LOCAL_KUBECONFIG_TMP}" | awk -F "/" '{print $3}')
+  export PROXY_RESERVED_IP=$(echo ${MASTER_IP} | cut -d: -f1)
+  echo "VDBGG: PROXY_RESERVED_IP=$PROXY_RESERVED_IP"
+  export TENANT_SERVER_1="http://$(cat /tmp/master_reserved_ip.txt):8080"
+
+  export KUBERNETES_SCALEOUT_PROXY=false
 
   if [[ "${SCALEOUT_CLUSTER_TWO_TPS:-false}" == "true" ]]; then
     export PARTITION_TO_UPDATE="tenant_partition_two"
     create-kubemark-master
-    export TENANT_SERVER_2="http://"$(grep server "${LOCAL_KUBECONFIG_TMP}" | awk -F "/" '{print $3}'):8080
+    export TENANT_SERVER_2="http://$(cat /tmp/master_reserved_ip.txt):8080"
   fi
 fi
+
+echo "DBG: set tenant partition flag false"
+export KUBERNETES_TENANT_PARTITION=false
+
+## TODO: add validation of TP cluster here
+##
+
+if [[ "${SCALEOUT_CLUSTER_TWO_TPS:-false}" == "true" ]]; then
+  export TENANT_SERVERS="${TENANT_SERVER_1},${TENANT_SERVER_2}"
+else
+  export TENANT_SERVERS="${TENANT_SERVER_1}"
+fi
+
+echo "DBG: tenant-servers:  ${TENANT_SERVERS}"
+
+if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
+  export KUBERNETES_RESOURCE_PARTITION=true
+  export PARTITION_TO_UPDATE="resource_partition"
+  create-kubemark-master
+  export KUBERNETES_RESOURCE_PARTITION=false
+  export KUBERNETES_SCALEOUT_PROXY=false  
+else
+  create-kubemark-master
+fi
+
+export RESOURCE_SERVER="http://"$(grep server "${LOCAL_KUBECONFIG_TMP}" | awk -F "/" '{print $3}')
+echo "DBG: resource-server: " ${RESOURCE_SERVER}
 
 # start hollow nodes with multiple tenant partition parameters
 #
@@ -298,20 +312,20 @@ echo "Kubeconfig for kubemark master is written in ${LOCAL_KUBECONFIG_TMP}"
 sleep 5
 echo -e "\nListing kubeamrk cluster details:" >&2
 echo -e "Getting total nodes number:" >&2
-"${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG_TMP}" get node | wc -l
+"${KUBECTL}" --kubeconfig="${TP_ONE_KUBECONFIG}" get node | wc -l
 echo
 echo -e "Getting total hollow-nodes number:" >&2
-"${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG_TMP}" get node | grep "hollow-node" | wc -l
+"${KUBECTL}" --kubeconfig="${TP_ONE_KUBECONFIG}" get node | grep "hollow-node" | wc -l
 echo
 echo -e "Getting endpoints status:" >&2
-"${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG_TMP}" get endpoints -A
+"${KUBECTL}" --kubeconfig="${TP_ONE_KUBECONFIG}" get endpoints -A
 echo
 echo -e "Getting workload controller co status:" >&2
-"${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG_TMP}" get co
+"${KUBECTL}" --kubeconfig="${TP_ONE_KUBECONFIG}" get co
 echo
 echo -e "Getting apiserver data partition status:" >&2
-"${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG_TMP}" get datapartition
+"${KUBECTL}" --kubeconfig="${TP_ONE_KUBECONFIG}" get datapartition
 echo
 echo -e "Getting ETCD data partition status:" >&2
-"${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG_TMP}" get etcd
+"${KUBECTL}" --kubeconfig="${TP_ONE_KUBECONFIG}" get etcd
 echo

--- a/test/kubemark/stop-kubemark.sh
+++ b/test/kubemark/stop-kubemark.sh
@@ -47,13 +47,21 @@ rm -rf "${RESOURCE_DIRECTORY}/addons" \
 if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
   export ENABLE_APISERVER_INSECURE_PORT=true
   export KUBERNETES_TENANT_PARTITION=true
+  export PARTITION_TO_UPDATE="tenant_partition_one"
   delete-kubemark-master
+
+  if [[ "${SCALEOUT_CLUSTER_TWO_TPS:-false}" == "true" ]]; then
+    export PARTITION_TO_UPDATE="tenant_partition_two"
+    delete-kubemark-master
+  fi
+
   export KUBERNETES_TENANT_PARTITION=false
   export KUBERNETES_RESOURCE_PARTITION=true
   export KUBERNETES_SCALEOUT_PROXY=true
   delete-kubemark-master
   rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark-rp"
-  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp"
+  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp-1"
+  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp-2"
 else
   delete-kubemark-master
 fi


### PR DESCRIPTION
This PR enables the 2T1R kubemark test cluster setup. It includes the following work:
1. disable WCM (picking code change from Sonya)
2. the dynamic creation of haproxy config
3. Reorder cluster creation and add tenant-servers to RP controller starts up commandline (Yunwen's PR 849 was integrated)


### Verification
The code is verified e2e in gce with the following command lines:
```
export MASTER_ROOT_DISK_SIZE=100GB MASTER_DISK_SIZE=200GB KUBE_GCE_ZONE=us-west1-b MASTER_SIZE=n1-highmem-32 NODE_SIZE=n1-highmem-8 NUM_NODES=2 NODE_DISK_SIZE=200GB KUBE_GCE_NETWORK=qianc-arktos GOPATH=$HOME/go KUBE_GCE_ENABLE_IP_ALIASES=true KUBE_GCE_PRIVATE_CLUSTER=true CREATE_CUSTOM_NETWORK=true KUBE_GCE_INSTANCE_PREFIX=qianc-arktos APISERVERS_EXTRA_NUM=0 SCALEOUT_CLUSTER=true SCALEOUT_CLUSTER_TWO_TPS=true

./cluster/kube-up.sh

./test/kubemark/start-kubemark.sh
```

The Test Results
The VMs are created as expected:
![image](https://user-images.githubusercontent.com/51831990/101599910-6a468a80-39af-11eb-8f18-9102966a0e38.png)

The hollow nodes are up and running:
![image](https://user-images.githubusercontent.com/51831990/101599994-8ea26700-39af-11eb-8af4-f2389469b493.png)

The controller/kubelet in RP are running with correct "--tenant-servers" commandline options:
![image](https://user-images.githubusercontent.com/51831990/101600149-c01b3280-39af-11eb-8dc5-bc93ade3732f.png)

![image](https://user-images.githubusercontent.com/51831990/101600349-083a5500-39b0-11eb-97ec-7db9739cf45a.png)

