### PR TITLE
statefulset fix and kubeclient switch

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -605,7 +605,6 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 			klog.V(3).Infof("TenantServers is not set. Default to single tenant partition and clientConfig setting")
 			s.TenantServers = make ([]string, 1)
 			s.TenantServers[0] = clientConfigs.GetConfig().Host
-
 		}
 
 		kubeDeps.KubeClients = make([]clientset.Interface, len(s.TenantServers))

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -1501,6 +1501,7 @@ func (ctrl *PersistentVolumeController) provisionClaimOperation(
 	volume.Spec.ClaimRef = claimRef
 	volume.Status.Phase = v1.VolumeBound
 	volume.Spec.StorageClassName = claimClass
+	volume.Tenant = claim.Tenant
 
 	// Add AnnBoundByController (used in deleting the volume)
 	metav1.SetMetaDataAnnotation(&volume.ObjectMeta, pvutil.AnnBoundByController, "yes")

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -255,20 +255,20 @@ type Dependencies struct {
 	ContainerManager   cm.ContainerManager
 	DockerClientConfig *dockershim.ClientConfig
 	//TODO: Arktos-scale-out: event should be per Tenant partition and per Resource parition
-	EventClient         v1core.EventsGetter
-	HeartbeatClient     clientset.Interface
-	OnHeartbeatFailure  []func()
-	KubeClients         []clientset.Interface
-	ArktosExtClient     arktos.Interface
-	Mounter             mount.Interface
-	OOMAdjuster         *oom.OOMAdjuster
-	OSInterface         kubecontainer.OSInterface
-	PodConfig           *config.PodConfig
-	Recorder            record.EventRecorder
-	Subpather           subpath.Interface
-	VolumePlugins       []volume.VolumePlugin
-	DynamicPluginProber volume.DynamicPluginProber
-	TLSOptions          *server.TLSOptions
+	EventClient             v1core.EventsGetter
+	HeartbeatClient         clientset.Interface
+	OnHeartbeatFailure      []func()
+	KubeClients             []clientset.Interface
+	ArktosExtClient         arktos.Interface
+	Mounter                 mount.Interface
+	OOMAdjuster             *oom.OOMAdjuster
+	OSInterface             kubecontainer.OSInterface
+	PodConfig               *config.PodConfig
+	Recorder                record.EventRecorder
+	Subpather               subpath.Interface
+	VolumePlugins           []volume.VolumePlugin
+	DynamicPluginProber     volume.DynamicPluginProber
+	TLSOptions              *server.TLSOptions
 	KubeletConfigController *kubeletconfig.Controller
 }
 
@@ -826,7 +826,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		nodeName,
 		klet.podManager,
 		klet.statusManager,
-		klet.kubeClient[0],
+		klet.kubeClient,
 		klet.volumePluginMgr,
 		klet.containerRuntime,
 		kubeDeps.Mounter,
@@ -2176,7 +2176,7 @@ func (kl *Kubelet) handleMirrorPod(mirrorPod *v1.Pod, start time.Time) {
 func (kl *Kubelet) getTPClient(tenant string) clientset.Interface {
 	var client clientset.Interface
 	pick := 0
-	if len(kl.kubeClient)==1 || tenant[0] <= 'm' {
+	if len(kl.kubeClient) == 1 || tenant[0] <= 'm' {
 		client = kl.kubeClient[0]
 	} else {
 		client = kl.kubeClient[1]

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1953,13 +1953,14 @@ func hasHostNamespace(pod *v1.Pod) bool {
 func (kl *Kubelet) hasHostMountPVC(pod *v1.Pod) bool {
 	for _, volume := range pod.Spec.Volumes {
 		if volume.PersistentVolumeClaim != nil {
-			pvc, err := kl.kubeClient[0].CoreV1().PersistentVolumeClaims(pod.Namespace).Get(volume.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
+			tenantClient := kl.getTPClient(pod.Tenant)
+			pvc, err := tenantClient.CoreV1().PersistentVolumeClaimsWithMultiTenancy(pod.Namespace, pod.Tenant).Get(volume.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
 			if err != nil {
 				klog.Warningf("unable to retrieve pvc %s:%s - %v", pod.Namespace, volume.PersistentVolumeClaim.ClaimName, err)
 				continue
 			}
 			if pvc != nil {
-				referencedVolume, err := kl.kubeClient[0].CoreV1().PersistentVolumes().Get(pvc.Spec.VolumeName, metav1.GetOptions{})
+				referencedVolume, err := tenantClient.CoreV1().PersistentVolumesWithMultiTenancy(pod.Tenant).Get(pvc.Spec.VolumeName, metav1.GetOptions{})
 				if err != nil {
 					klog.Warningf("unable to retrieve pv %s - %v", pvc.Spec.VolumeName, err)
 					continue

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -474,7 +474,7 @@ func (m *manager) syncBatch() {
 func (m *manager) getTPClient(tenant string) clientset.Interface {
 	var client clientset.Interface
 	pick := 0
-	if len(m.kubeClient)==1 || tenant[0] <= 'm' {
+	if len(m.kubeClient) == 1 || tenant[0] <= 'm' {
 		client = m.kubeClient[0]
 	} else {
 		client = m.kubeClient[1]

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
@@ -785,7 +785,7 @@ func createDswpWithVolume(t *testing.T, pv *v1.PersistentVolume, pvc *v1.Persist
 	fakeStatusManager := status.NewManager(fakeClient, fakePodManager, &statustest.FakePodDeletionSafetyProvider{})
 
 	dswp := &desiredStateOfWorldPopulator{
-		kubeClient:                fakeClient,
+               kubeClients:               fakeClient,
 		loopSleepDuration:         100 * time.Millisecond,
 		getPodStatusRetryDuration: 2 * time.Second,
 		podManager:                fakePodManager,

--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -91,7 +91,7 @@ type Reconciler interface {
 // mounter - mounter passed in from kubelet, passed down unmount path
 // volumePluginMgr - volume plugin manager passed from kubelet
 func NewReconciler(
-	kubeClient clientset.Interface,
+	kubeClients []clientset.Interface,
 	controllerAttachDetachEnabled bool,
 	loopSleepDuration time.Duration,
 	waitForAttachTimeout time.Duration,
@@ -104,7 +104,7 @@ func NewReconciler(
 	volumePluginMgr *volumepkg.VolumePluginMgr,
 	kubeletPodsDir string) Reconciler {
 	return &reconciler{
-		kubeClient:                    kubeClient,
+		kubeClients:                   kubeClients,
 		controllerAttachDetachEnabled: controllerAttachDetachEnabled,
 		loopSleepDuration:             loopSleepDuration,
 		waitForAttachTimeout:          waitForAttachTimeout,
@@ -121,7 +121,7 @@ func NewReconciler(
 }
 
 type reconciler struct {
-	kubeClient                    clientset.Interface
+	kubeClients                   []clientset.Interface
 	controllerAttachDetachEnabled bool
 	loopSleepDuration             time.Duration
 	syncDuration                  time.Duration
@@ -560,7 +560,7 @@ func (rc *reconciler) reconstructVolume(volume podVolume) (*reconstructedVolume,
 
 // updateDevicePath gets the node status to retrieve volume device path information.
 func (rc *reconciler) updateDevicePath(volumesNeedUpdate map[v1.UniqueVolumeName]*reconstructedVolume) {
-	node, fetchErr := rc.kubeClient.CoreV1().Nodes().Get(string(rc.nodeName), metav1.GetOptions{})
+	node, fetchErr := rc.kubeClients[0].CoreV1().Nodes().Get(string(rc.nodeName), metav1.GetOptions{})
 	if fetchErr != nil {
 		klog.Errorf("updateStates in reconciler: could not get node status with error %v", fetchErr)
 	} else {

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -813,7 +814,7 @@ func Test_GenerateMapVolumeFunc_Plugin_Not_Found(t *testing.T) {
 			volumePluginMgr.InitPlugins(tc.volumePlugins, nil, nil)
 			asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
 			oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
-				nil, /* kubeClient */
+                               nil, /* kubeClients */
 				volumePluginMgr,
 				nil,   /* fakeRecorder */
 				false, /* checkNodeCapabilitiesBeforeMount */
@@ -867,7 +868,7 @@ func Test_GenerateUnmapVolumeFunc_Plugin_Not_Found(t *testing.T) {
 			volumePluginMgr.InitPlugins(tc.volumePlugins, nil, nil)
 			asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
 			oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
-				nil, /* kubeClient */
+                               nil, /* kubeClients */
 				volumePluginMgr,
 				nil,   /* fakeRecorder */
 				false, /* checkNodeCapabilitiesBeforeMount */
@@ -913,7 +914,7 @@ func Test_GenerateUnmapDeviceFunc_Plugin_Not_Found(t *testing.T) {
 			volumePluginMgr.InitPlugins(tc.volumePlugins, nil, nil)
 			asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
 			oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
-				nil, /* kubeClient */
+                               nil, /* kubeClients */
 				volumePluginMgr,
 				nil,   /* fakeRecorder */
 				false, /* checkNodeCapabilitiesBeforeMount */

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -147,7 +148,7 @@ func NewVolumeManager(
 	nodeName k8stypes.NodeName,
 	podManager pod.Manager,
 	podStatusProvider status.PodStatusProvider,
-	kubeClient clientset.Interface,
+	kubeClient []clientset.Interface,
 	volumePluginMgr *volume.VolumePluginMgr,
 	kubeContainerRuntime container.Runtime,
 	mounter mount.Interface,
@@ -162,7 +163,7 @@ func NewVolumeManager(
 		desiredStateOfWorld: cache.NewDesiredStateOfWorld(volumePluginMgr),
 		actualStateOfWorld:  cache.NewActualStateOfWorld(nodeName, volumePluginMgr),
 		operationExecutor: operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
-			kubeClient,
+			kubeClient[0],
 			volumePluginMgr,
 			recorder,
 			checkNodeCapabilitiesBeforeMount,
@@ -200,7 +201,7 @@ func NewVolumeManager(
 type volumeManager struct {
 	// kubeClient is the kube API client used by DesiredStateOfWorldPopulator to
 	// communicate with the API server to fetch PV and PVC objects
-	kubeClient clientset.Interface
+	kubeClient []clientset.Interface
 
 	// volumePluginMgr is the volume plugin manager used to access volume
 	// plugins. It must be pre-initialized.


### PR DESCRIPTION
### Changes

1. fix a bug that causes statefulset to fail for non-system tenant
2. add kubeclient selection based on tenant 

### Validation
- statefulset with hostpath pvc created and deleted correctly on both tenant partitions
- no regression with pod and deployment creation and deletion

### Notes
- TP kubeclient is still duplcated
- add this in tenant partition to allow host path pv: export ENABLE_HOSTPATH_PROVISIONER=true
- need further code on node status update