### PR TITLE
multi-tenancy perf-test

### DIFF
--- a/perf-tests/clusterloader2/pkg/execservice/exec_service.go
+++ b/perf-tests/clusterloader2/pkg/execservice/exec_service.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/perf-tests/clusterloader2/pkg/framework"
 	"k8s.io/kubernetes/perf-tests/clusterloader2/pkg/framework/client"
 	measurementutil "k8s.io/kubernetes/perf-tests/clusterloader2/pkg/measurement/util"
+	perfutil "k8s.io/kubernetes/perf-tests/clusterloader2/pkg/util"
 )
 
 const (
@@ -64,7 +65,7 @@ func SetUpExecService(f *framework.Framework) error {
 	mapping["Name"] = execDeploymentName
 	mapping["Namespace"] = execDeploymentNamespace
 	mapping["Replicas"] = execPodReplicas
-	if err = client.CreateNamespace(f.GetClientSets().GetClient(), execDeploymentNamespace); err != nil {
+	if err = client.CreateNamespace(f.GetClientSets().GetClient(), execDeploymentNamespace, perfutil.GetTenant()); err != nil {
 		return fmt.Errorf("namespace %s creation error: %v", execDeploymentNamespace, err)
 	}
 	if err = f.ApplyTemplatedManifests(
@@ -110,10 +111,10 @@ func TearDownExecService(f *framework.Framework) error {
 		podStore.Stop()
 		podStore = nil
 	}
-	if err := client.DeleteNamespace(f.GetClientSets().GetClient(), execDeploymentNamespace); err != nil {
+	if err := client.DeleteNamespace(f.GetClientSets().GetClient(), execDeploymentNamespace, perfutil.GetTenant()); err != nil {
 		return fmt.Errorf("deleting %s namespace error: %v", execDeploymentNamespace, err)
 	}
-	if err := client.WaitForDeleteNamespace(f.GetClientSets().GetClient(), execDeploymentNamespace); err != nil {
+	if err := client.WaitForDeleteNamespace(f.GetClientSets().GetClient(), execDeploymentNamespace, perfutil.GetTenant()); err != nil {
 		return err
 	}
 	return nil

--- a/perf-tests/clusterloader2/pkg/framework/client/objects.go
+++ b/perf-tests/clusterloader2/pkg/framework/client/objects.go
@@ -186,27 +186,27 @@ func ListNodesWithOptions(c clientset.Interface, listOpts metav1.ListOptions) ([
 }
 
 // CreateNamespace creates a single namespace with given name.
-func CreateNamespace(c clientset.Interface, namespace string) error {
+func CreateNamespace(c clientset.Interface, namespace string, tenant string) error {
 	createFunc := func() error {
-		_, err := c.CoreV1().Namespaces().Create(&apiv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+		_, err := c.CoreV1().NamespacesWithMultiTenancy(tenant).Create(&apiv1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
 		return err
 	}
 	return RetryWithExponentialBackOff(RetryFunction(createFunc, Allow(apierrs.IsAlreadyExists)))
 }
 
 // DeleteNamespace deletes namespace with given name.
-func DeleteNamespace(c clientset.Interface, namespace string) error {
+func DeleteNamespace(c clientset.Interface, namespace string, tenant string) error {
 	deleteFunc := func() error {
-		return c.CoreV1().Namespaces().Delete(namespace, nil)
+		return c.CoreV1().NamespacesWithMultiTenancy(tenant).Delete(namespace, nil)
 	}
 	return RetryWithExponentialBackOff(RetryFunction(deleteFunc, Allow(apierrs.IsNotFound)))
 }
 
 // ListNamespaces returns list of existing namespace names.
-func ListNamespaces(c clientset.Interface) ([]apiv1.Namespace, error) {
+func ListNamespaces(c clientset.Interface, tenant string) ([]apiv1.Namespace, error) {
 	var namespaces []apiv1.Namespace
 	listFunc := func() error {
-		namespacesList, err := c.CoreV1().Namespaces().List(metav1.ListOptions{})
+		namespacesList, err := c.CoreV1().NamespacesWithMultiTenancy(tenant).List(metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -220,9 +220,9 @@ func ListNamespaces(c clientset.Interface) ([]apiv1.Namespace, error) {
 }
 
 // WaitForDeleteNamespace waits untils namespace is terminated.
-func WaitForDeleteNamespace(c clientset.Interface, namespace string) error {
+func WaitForDeleteNamespace(c clientset.Interface, namespace string, tenant string) error {
 	retryWaitFunc := func() (bool, error) {
-		_, err := c.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
+		_, err := c.CoreV1().NamespacesWithMultiTenancy(tenant).Get(namespace, metav1.GetOptions{})
 		if err != nil {
 			if apierrs.IsNotFound(err) {
 				return true, nil
@@ -237,9 +237,9 @@ func WaitForDeleteNamespace(c clientset.Interface, namespace string) error {
 }
 
 // ListEvents retrieves events for the object with the given name.
-func ListEvents(c clientset.Interface, namespace string, name string, options ...*ApiCallOptions) (obj *apiv1.EventList, err error) {
+func ListEvents(c clientset.Interface, tenant string, namespace string, name string, options ...*ApiCallOptions) (obj *apiv1.EventList, err error) {
 	getFunc := func() error {
-		obj, err = c.CoreV1().Events(namespace).List(metav1.ListOptions{
+		obj, err = c.CoreV1().EventsWithMultiTenancy(namespace, tenant).List(metav1.ListOptions{
 			FieldSelector: "involvedObject.name=" + name,
 		})
 		return err
@@ -251,12 +251,12 @@ func ListEvents(c clientset.Interface, namespace string, name string, options ..
 }
 
 // CreateObject creates object based on given object description.
-func CreateObject(dynamicClient dynamic.Interface, namespace string, name string, obj *unstructured.Unstructured, options ...*ApiCallOptions) error {
+func CreateObject(dynamicClient dynamic.Interface, tenant string, namespace string, name string, obj *unstructured.Unstructured, options ...*ApiCallOptions) error {
 	gvk := obj.GroupVersionKind()
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 	obj.SetName(name)
 	createFunc := func() error {
-		_, err := dynamicClient.Resource(gvr).Namespace(namespace).Create(obj, metav1.CreateOptions{})
+		_, err := dynamicClient.Resource(gvr).NamespaceWithMultiTenancy(namespace, tenant).Create(obj, metav1.CreateOptions{})
 		return err
 	}
 	options = append(options, Allow(apierrs.IsAlreadyExists))
@@ -264,12 +264,12 @@ func CreateObject(dynamicClient dynamic.Interface, namespace string, name string
 }
 
 // PatchObject updates (using patch) object with given name, group, version and kind based on given object description.
-func PatchObject(dynamicClient dynamic.Interface, namespace string, name string, obj *unstructured.Unstructured, options ...*ApiCallOptions) error {
+func PatchObject(dynamicClient dynamic.Interface, tenant string, namespace string, name string, obj *unstructured.Unstructured, options ...*ApiCallOptions) error {
 	gvk := obj.GroupVersionKind()
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 	obj.SetName(name)
 	updateFunc := func() error {
-		currentObj, err := dynamicClient.Resource(gvr).Namespace(namespace).Get(name, metav1.GetOptions{})
+		currentObj, err := dynamicClient.Resource(gvr).NamespaceWithMultiTenancy(namespace, tenant).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -277,34 +277,34 @@ func PatchObject(dynamicClient dynamic.Interface, namespace string, name string,
 		if err != nil {
 			return fmt.Errorf("creating patch diff error: %v", err)
 		}
-		_, err = dynamicClient.Resource(gvr).Namespace(namespace).Patch(obj.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
+		_, err = dynamicClient.Resource(gvr).NamespaceWithMultiTenancy(namespace, tenant).Patch(obj.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
 		return err
 	}
 	return RetryWithExponentialBackOff(RetryFunction(updateFunc, options...))
 }
 
 // DeleteObject deletes object with given name, group, version and kind.
-func DeleteObject(dynamicClient dynamic.Interface, gvk schema.GroupVersionKind, namespace string, name string, options ...*ApiCallOptions) error {
+func DeleteObject(dynamicClient dynamic.Interface, gvk schema.GroupVersionKind, tenant string, namespace string, name string, options ...*ApiCallOptions) error {
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 	deleteFunc := func() error {
 		// Delete operation removes object with all of the dependants.
 		falseVar := false
 		deleteOption := &metav1.DeleteOptions{OrphanDependents: &falseVar}
-		return dynamicClient.Resource(gvr).Namespace(namespace).Delete(name, deleteOption)
+		return dynamicClient.Resource(gvr).NamespaceWithMultiTenancy(namespace, tenant).Delete(name, deleteOption)
 	}
 	options = append(options, Allow(apierrs.IsNotFound))
 	return RetryWithExponentialBackOff(RetryFunction(deleteFunc, options...))
 }
 
 // GetObject retrieves object with given name, group, version and kind.
-func GetObject(dynamicClient dynamic.Interface, gvk schema.GroupVersionKind, namespace string, name string, options ...*ApiCallOptions) (*unstructured.Unstructured, error) {
+func GetObject(dynamicClient dynamic.Interface, gvk schema.GroupVersionKind, tenant string, namespace string, name string, options ...*ApiCallOptions) (*unstructured.Unstructured, error) {
 	var obj *unstructured.Unstructured
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 	getFunc := func() error {
 		var err error
 		// TODO(krzysied): Check in which cases IncludeUninitialized=true option is required -
 		// implement additional handling if needed.
-		obj, err = dynamicClient.Resource(gvr).Namespace(namespace).Get(name, metav1.GetOptions{})
+		obj, err = dynamicClient.Resource(gvr).NamespaceWithMultiTenancy(namespace, tenant).Get(name, metav1.GetOptions{})
 		return err
 	}
 	if err := RetryWithExponentialBackOff(RetryFunction(getFunc, options...)); err != nil {

--- a/perf-tests/clusterloader2/pkg/imagepreload/imagepreload.go
+++ b/perf-tests/clusterloader2/pkg/imagepreload/imagepreload.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/perf-tests/clusterloader2/pkg/measurement/util"
 	"k8s.io/kubernetes/perf-tests/clusterloader2/pkg/measurement/util/informer"
 	"k8s.io/kubernetes/perf-tests/clusterloader2/pkg/measurement/util/runtimeobjects"
+	perfutil "k8s.io/kubernetes/perf-tests/clusterloader2/pkg/util"
 )
 
 const (
@@ -106,7 +107,7 @@ func (c *controller) PreloadImages() error {
 	}
 
 	klog.Infof("Creating namespace %s...", namespace)
-	if err := client.CreateNamespace(kclient, namespace); err != nil {
+	if err := client.CreateNamespace(kclient, namespace, perfutil.GetTenant()); err != nil {
 		return err
 	}
 
@@ -137,10 +138,10 @@ func (c *controller) PreloadImages() error {
 	klog.Info("Waiting... done")
 
 	klog.Infof("Deleting namespace %s...", namespace)
-	if err := client.DeleteNamespace(kclient, namespace); err != nil {
+	if err := client.DeleteNamespace(kclient, namespace, perfutil.GetTenant()); err != nil {
 		return err
 	}
-	if err := client.WaitForDeleteNamespace(kclient, namespace); err != nil {
+	if err := client.WaitForDeleteNamespace(kclient, namespace, perfutil.GetTenant()); err != nil {
 		return err
 	}
 	return nil

--- a/perf-tests/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
+++ b/perf-tests/clusterloader2/pkg/measurement/common/bundle/test_metrics.go
@@ -41,9 +41,9 @@ func createTestMetricsMeasurement() measurement.Measurement {
 	if metrics.etcdMetrics, err = measurement.CreateMeasurement("EtcdMetrics"); err != nil {
 		klog.Errorf("%v: etcdMetrics creation error: %v", metrics, err)
 	}
-	if metrics.schedulingMetrics, err = measurement.CreateMeasurement("SchedulingMetrics"); err != nil {
+	/*if metrics.schedulingMetrics, err = measurement.CreateMeasurement("SchedulingMetrics"); err != nil {
 		klog.Errorf("%v: schedulingMetrics creation error: %v", metrics, err)
-	}
+	}*/
 	if metrics.metricsForE2E, err = measurement.CreateMeasurement("MetricsForE2E"); err != nil {
 		klog.Errorf("%v: metricsForE2E creation error: %v", metrics, err)
 	}
@@ -113,9 +113,9 @@ func (t *testMetrics) Execute(config *measurement.MeasurementConfig) ([]measurem
 	actionStartConfig := createConfig(config, map[string]interface{}{
 		"action": "start",
 	})
-	actionResetConfig := createConfig(config, map[string]interface{}{
+	/*actionResetConfig := createConfig(config, map[string]interface{}{
 		"action": "reset",
-	})
+	})*/
 	actionGatherConfig := createConfig(config, map[string]interface{}{
 		"action": "gather",
 	})
@@ -156,8 +156,8 @@ func (t *testMetrics) Execute(config *measurement.MeasurementConfig) ([]measurem
 	case "start":
 		summary, err := execute(t.etcdMetrics, actionStartConfig)
 		appendResults(&summaries, errList, summary, executeError(t.etcdMetrics.String(), action, err))
-		summary, err = execute(t.schedulingMetrics, actionResetConfig)
-		appendResults(&summaries, errList, summary, executeError(t.schedulingMetrics.String(), action, err))
+		//summary, err = execute(t.schedulingMetrics, actionResetConfig)
+		//appendResults(&summaries, errList, summary, executeError(t.schedulingMetrics.String(), action, err))
 		summary, err = execute(t.resourceUsageSummary, actionStartConfig)
 		appendResults(&summaries, errList, summary, executeError(t.resourceUsageSummary.String(), action, err))
 		summary, err = execute(t.etcdCPUProfile, etcdStartConfig)
@@ -183,8 +183,8 @@ func (t *testMetrics) Execute(config *measurement.MeasurementConfig) ([]measurem
 	case "gather":
 		summary, err := execute(t.etcdMetrics, actionGatherConfig)
 		appendResults(&summaries, errList, summary, executeError(t.etcdMetrics.String(), action, err))
-		summary, err = execute(t.schedulingMetrics, actionGatherConfig)
-		appendResults(&summaries, errList, summary, executeError(t.schedulingMetrics.String(), action, err))
+		//summary, err = execute(t.schedulingMetrics, actionGatherConfig)
+		//appendResults(&summaries, errList, summary, executeError(t.schedulingMetrics.String(), action, err))
 		summary, err = execute(t.metricsForE2E, config)
 		appendResults(&summaries, errList, summary, executeError(t.metricsForE2E.String(), action, err))
 		summary, err = execute(t.resourceUsageSummary, actionGatherConfig)
@@ -223,7 +223,7 @@ func (t *testMetrics) Execute(config *measurement.MeasurementConfig) ([]measurem
 // Dispose cleans up after the measurement.
 func (t *testMetrics) Dispose() {
 	t.etcdMetrics.Dispose()
-	t.schedulingMetrics.Dispose()
+	//t.schedulingMetrics.Dispose()
 	t.metricsForE2E.Dispose()
 	t.resourceUsageSummary.Dispose()
 	t.etcdCPUProfile.Dispose()

--- a/perf-tests/clusterloader2/pkg/measurement/common/metrics_for_e2e.go
+++ b/perf-tests/clusterloader2/pkg/measurement/common/metrics_for_e2e.go
@@ -70,8 +70,11 @@ func (m *metricsForE2EMeasurement) Execute(config *measurement.MeasurementConfig
 		config.ClusterFramework.GetClientSets().GetClient(),
 		nil, /*external client*/
 		grabMetricsFromKubelets,
-		true, /*grab metrics from scheduler*/
-		true, /*grab metrics from controller manager*/
+		//temporarily disable the metric collection on scheduler and controller manager for scale-out tests as they are in the TP sides
+		//true, /*grab metrics from scheduler*/
+		false,
+		//true, /*grab metrics from controller manager*/
+		false,
 		true, /*grab metrics from apiserver*/
 		false /*grab metrics from cluster autoscaler*/)
 	if err != nil {

--- a/perf-tests/clusterloader2/pkg/measurement/common/probes/probes.go
+++ b/perf-tests/clusterloader2/pkg/measurement/common/probes/probes.go
@@ -132,10 +132,10 @@ func (p *probesMeasurement) Dispose() {
 	}
 	klog.Infof("Stopping %s probe...", p)
 	k8sClient := p.framework.GetClientSets().GetClient()
-	if err := client.DeleteNamespace(k8sClient, probesNamespace); err != nil {
+	if err := client.DeleteNamespace(k8sClient, probesNamespace, util.GetTenant()); err != nil {
 		klog.Errorf("error while deleting %s namespace: %v", probesNamespace, err)
 	}
-	if err := client.WaitForDeleteNamespace(k8sClient, probesNamespace); err != nil {
+	if err := client.WaitForDeleteNamespace(k8sClient, probesNamespace, util.GetTenant()); err != nil {
 		klog.Errorf("error while waiting for %s namespace to be deleted: %v", probesNamespace, err)
 	}
 }
@@ -165,7 +165,7 @@ func (p *probesMeasurement) start(config *measurement.MeasurementConfig) error {
 		return err
 	}
 	k8sClient := p.framework.GetClientSets().GetClient()
-	if err := client.CreateNamespace(k8sClient, probesNamespace); err != nil {
+	if err := client.CreateNamespace(k8sClient, probesNamespace, util.GetTenant()); err != nil {
 		return err
 	}
 	if err := p.createProbesObjects(); err != nil {

--- a/perf-tests/clusterloader2/pkg/measurement/util/informer/informer.go
+++ b/perf-tests/clusterloader2/pkg/measurement/util/informer/informer.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	measurementutil "k8s.io/kubernetes/perf-tests/clusterloader2/pkg/measurement/util"
+	perfutil "k8s.io/kubernetes/perf-tests/clusterloader2/pkg/util"
 )
 
 // NewInformer creates a new informer
@@ -62,7 +63,7 @@ func NewDynamicInformer(
 		options.LabelSelector = selector.LabelSelector
 	}
 	tweakListOptions := dynamicinformer.TweakListOptionsFunc(optionsModifier)
-	dInformerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(c, 0, selector.Namespace, tweakListOptions)
+	dInformerFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactoryWithMultiTenancy(c, 0, selector.Namespace, tweakListOptions, perfutil.GetTenant())
 
 	informer := dInformerFactory.ForResource(gvr).Informer()
 	addEventHandler(informer, handleObj)

--- a/perf-tests/clusterloader2/pkg/measurement/util/object_store.go
+++ b/perf-tests/clusterloader2/pkg/measurement/util/object_store.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/kubernetes/perf-tests/clusterloader2/pkg/util"
 )
 
 // ObjectStore is a convenient wrapper around cache.Store.
@@ -81,12 +82,12 @@ func NewPodStore(c clientset.Interface, selector *ObjectSelector) (*PodStore, er
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			options.LabelSelector = selector.LabelSelector
 			options.FieldSelector = selector.FieldSelector
-			return c.CoreV1().Pods(selector.Namespace).List(options)
+			return c.CoreV1().PodsWithMultiTenancy(selector.Namespace, util.GetTenant()).List(options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.LabelSelector = selector.LabelSelector
 			options.FieldSelector = selector.FieldSelector
-			return c.CoreV1().Pods(selector.Namespace).Watch(options)
+			return c.CoreV1().PodsWithMultiTenancy(selector.Namespace, util.GetTenant()).Watch(options)
 		},
 	}
 	objectStore, err := newObjectStore(&v1.Pod{}, lw, selector)
@@ -117,12 +118,12 @@ func NewPVCStore(c clientset.Interface, selector *ObjectSelector) (*PVCStore, er
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			options.LabelSelector = selector.LabelSelector
 			options.FieldSelector = selector.FieldSelector
-			return c.CoreV1().PersistentVolumeClaims(selector.Namespace).List(options)
+			return c.CoreV1().PersistentVolumeClaimsWithMultiTenancy(selector.Namespace, util.GetTenant()).List(options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.LabelSelector = selector.LabelSelector
 			options.FieldSelector = selector.FieldSelector
-			return c.CoreV1().PersistentVolumeClaims(selector.Namespace).Watch(options)
+			return c.CoreV1().PersistentVolumeClaimsWithMultiTenancy(selector.Namespace, util.GetTenant()).Watch(options)
 		},
 	}
 	objectStore, err := newObjectStore(&v1.PersistentVolumeClaim{}, lw, selector)
@@ -153,12 +154,12 @@ func NewPVStore(c clientset.Interface, selector *ObjectSelector) (*PVStore, erro
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			options.LabelSelector = selector.LabelSelector
 			options.FieldSelector = selector.FieldSelector
-			return c.CoreV1().PersistentVolumes().List(options)
+			return c.CoreV1().PersistentVolumesWithMultiTenancy(util.GetTenant()).List(options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.LabelSelector = selector.LabelSelector
 			options.FieldSelector = selector.FieldSelector
-			return c.CoreV1().PersistentVolumes().Watch(options)
+			return c.CoreV1().PersistentVolumesWithMultiTenancy(util.GetTenant()).Watch(options)
 		},
 	}
 	objectStore, err := newObjectStore(&v1.PersistentVolume{}, lw, selector)

--- a/perf-tests/clusterloader2/pkg/prometheus/prometheus.go
+++ b/perf-tests/clusterloader2/pkg/prometheus/prometheus.go
@@ -135,7 +135,7 @@ func (pc *PrometheusController) SetUpPrometheusStack() error {
 	k8sClient := pc.framework.GetClientSets().GetClient()
 
 	klog.Info("Setting up prometheus stack")
-	if err := client.CreateNamespace(k8sClient, namespace); err != nil {
+	if err := client.CreateNamespace(k8sClient, namespace, util.GetTenant()); err != nil {
 		return err
 	}
 	// If enabled scraping windows node, need to setup windows node and template mapping
@@ -184,10 +184,10 @@ func (pc *PrometheusController) TearDownPrometheusStack() error {
 	}
 	klog.Info("Tearing down prometheus stack")
 	k8sClient := pc.framework.GetClientSets().GetClient()
-	if err := client.DeleteNamespace(k8sClient, namespace); err != nil {
+	if err := client.DeleteNamespace(k8sClient, namespace, util.GetTenant()); err != nil {
 		return err
 	}
-	if err := client.WaitForDeleteNamespace(k8sClient, namespace); err != nil {
+	if err := client.WaitForDeleteNamespace(k8sClient, namespace, util.GetTenant()); err != nil {
 		return err
 	}
 	return nil
@@ -333,7 +333,7 @@ func (pc *PrometheusController) isKubemark() bool {
 
 func dumpAdditionalLogsOnPrometheusSetupFailure(k8sClient kubernetes.Interface) {
 	klog.Info("Dumping monitoring/prometheus-k8s events...")
-	list, err := client.ListEvents(k8sClient, namespace, "prometheus-k8s")
+	list, err := client.ListEvents(k8sClient, util.GetTenant(), namespace, "prometheus-k8s")
 	if err != nil {
 		klog.Warningf("Error while listing monitoring/prometheus-k8s events: %v", err)
 		return

--- a/perf-tests/clusterloader2/pkg/test/simple_test_executor.go
+++ b/perf-tests/clusterloader2/pkg/test/simple_test_executor.go
@@ -102,7 +102,7 @@ func (ste *simpleTestExecutor) ExecuteTestSteps(ctx Context, conf *api.Config) *
 		return errors.NewErrorList(fmt.Errorf("automanaged namespaces listing failed: %v", err))
 	}
 	if len(automanagedNamespacesList) > 0 {
-		return errors.NewErrorList(fmt.Errorf("pre-existing automanaged namespaces found"))
+		return errors.NewErrorList(fmt.Errorf("pre-existing automanaged namespaces found %v   | %v ", automanagedNamespacesList, staleNamespaces))
 	}
 	var deleteStaleNS = ctx.GetClusterFramework().GetClusterConfig().DeleteStaleNamespaces
 	if len(staleNamespaces) > 0 && deleteStaleNS {
@@ -307,15 +307,15 @@ func (ste *simpleTestExecutor) ExecuteObject(ctx Context, object *api.Object, na
 	gvk := obj.GroupVersionKind()
 	switch operation {
 	case CREATE_OBJECT:
-		if err := ctx.GetClusterFramework().CreateObject(namespace, objName, obj); err != nil {
+		if err := ctx.GetClusterFramework().CreateObject(util.GetTenant(), namespace, objName, obj); err != nil {
 			errList.Append(fmt.Errorf("namespace %v object %v creation error: %v", namespace, objName, err))
 		}
 	case PATCH_OBJECT:
-		if err := ctx.GetClusterFramework().PatchObject(namespace, objName, obj); err != nil {
+		if err := ctx.GetClusterFramework().PatchObject(util.GetTenant(), namespace, objName, obj); err != nil {
 			errList.Append(fmt.Errorf("namespace %v object %v updating error: %v", namespace, objName, err))
 		}
 	case DELETE_OBJECT:
-		if err := ctx.GetClusterFramework().DeleteObject(gvk, namespace, objName); err != nil {
+		if err := ctx.GetClusterFramework().DeleteObject(gvk, util.GetTenant(), namespace, objName); err != nil {
 			errList.Append(fmt.Errorf("namespace %v object %v deletion error: %v", namespace, objName, err))
 		}
 	}

--- a/perf-tests/clusterloader2/pkg/util/multi-tenancy.go
+++ b/perf-tests/clusterloader2/pkg/util/multi-tenancy.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"os"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
+)
+
+func GetTenant() string {
+	tenantName := os.Getenv("SCALEOUT_TEST_TENANT")
+    if len(tenantName) == 0 {
+        return metav1.TenantSystem
+	}
+	
+	errs := apimachineryvalidation.ValidateTenantName(tenantName, false)
+	if len(errs) > 0 {
+		klog.Fatalf("Invalide tenant name %v: %v", tenantName, errs)
+	}
+
+    return strings.ToLower(tenantName)
+}
+
+


### PR DESCRIPTION
This PR allows the perf tests running under a specific non-system tenant, whose name is specified in the env var SCALEOUT_TEST_TENANT.

Verified in gce kubemark cluster as follows:
1. created a 2T1R kubemark test environment
2.  manually create a tenant named aaa in TP-1
2. Running the following commandline:
```
SCALEOUT_TEST_TENANT=aaa perf-tests/clusterloader2/run-e2e.sh --nodes=100 --provider=kubemark --kubeconfig=/home/cloudshare/go/src/k8s.io/arktos/test/kubemark/resources/kubeconfig.kubemark-tp-1 --report-dir=/home/cloudshare/perf-logs --testconfig=testing/density/config.yaml --testoverrides=./testing/experiments/use_simple_latency_query.yaml
```

I checked:
1. the test completed (though I got some timeout issues in pod deletion, the test itself was running to completion)
2. all the workloads are correctly created under the tenant
3. though we hit timeout issue in some pod deletion, the kubelet logs showed the the pod deletion request was received. So it shows that the perf test sends the pod deletion request as expected. 