### PR TITLE
set larger haproxy maxconn for scale out tests

### DIFF
--- a/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg
+++ b/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg
@@ -66,10 +66,10 @@ frontend scale-out-proxy
     default_backend tenant_api_one
 
 backend tenant_api_one
-    server tp_one {{ tenant_partition_one_ip }}:{{ arktos_api_port }} maxconn 2048
+    server tp_one {{ tenant_partition_one_ip }}:{{ arktos_api_port }} maxconn 500000
 
 backend tenant_api_two
-    server tp_two {{ tenant_partition_two_ip }}:{{ arktos_api_port }} maxconn 2048
+    server tp_two {{ tenant_partition_two_ip }}:{{ arktos_api_port }} maxconn 500000
 
 backend resource_api
-    server rp {{ resource_partition_ip }}:{{ arktos_api_port }} maxconn 2048
+    server rp {{ resource_partition_ip }}:{{ arktos_api_port }} maxconn 500000


### PR DESCRIPTION
the original maxconn value (2048) is too small. Increase it to 500K per backend. 

As doc online, a haproxy is able to process 2M connections. 
Reference https://www.freecodecamp.org/news/how-we-fine-tuned-haproxy-to-achieve-2-000-000-concurrent-ssl-connections-d017e61a4d27/#:~:text=HAProxy%20Configuration,-This%20is%20probably&text=The%20maxconn%20setting%20allows%20us,support%20overall%20(one%20way).&text=The%20max%20open%20files%20has,being%20set%20at%202%20million.