### PR TITLE
Create direct tp config

### DIFF
--- a/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg
+++ b/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg
@@ -66,10 +66,10 @@ frontend scale-out-proxy
     default_backend tenant_api_one
 
 backend tenant_api_one
-    server tp_one {{ tenant_partition_one_ip }}:{{ arktos_api_port }} maxconn 2048
+    server tp_one {{ tenant_partition_one_ip }}:{{ arktos_api_port }} maxconn 500000
 
 backend tenant_api_two
-    server tp_two {{ tenant_partition_two_ip }}:{{ arktos_api_port }} maxconn 2048
+    server tp_two {{ tenant_partition_two_ip }}:{{ arktos_api_port }} maxconn 500000
 
 backend resource_api
-    server rp {{ resource_partition_ip }}:{{ arktos_api_port }} maxconn 2048
+    server rp {{ resource_partition_ip }}:{{ arktos_api_port }} maxconn 500000

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -528,7 +528,7 @@ loop:
 
 	watchDuration := r.clock.Since(start)
 	if watchDuration < 1*time.Second && eventCount == 0 {
-		return fmt.Errorf("very short watch: %s: Unexpected watch close - watch lasted less than a second and no items received", r.name)
+		klog.V(4).Infof("very short watch: %s: Unexpected watch close - watch lasted less than a second and no items received", r.name)
 	}
 	klog.V(4).Infof("%s: Watch close - %v total %v items received", r.name, r.expectedType, eventCount)
 	return nil


### PR DESCRIPTION
This PR create two kubeconfig files, directly connected to TP1/TP2, instead of the the proxy, under the folder test/kubemark/resources, when running start-kubemark.sh.

