### PR TITLE
Append limits.conf to explictly set for root and haproxy

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2844,6 +2844,10 @@ function setup-proxy() {
   ssh-to-node ${PROXY_NAME} "sudo sysctl -p"
   ssh-to-node ${PROXY_NAME} "sudo sed -i '\$a*       hard    nofile          1000000' /etc/security/limits.conf"
   ssh-to-node ${PROXY_NAME} "sudo sed -i '\$a*       soft    nofile          1000000' /etc/security/limits.conf"
+  ssh-to-node ${PROXY_NAME} "sudo sed -i '\$aroot       hard    nofile          1000000' /etc/security/limits.conf"
+  ssh-to-node ${PROXY_NAME} "sudo sed -i '\$aroot       soft    nofile          1000000' /etc/security/limits.conf"
+  ssh-to-node ${PROXY_NAME} "sudo sed -i '\$ahaproxy       hard    nofile          1000000' /etc/security/limits.conf"
+  ssh-to-node ${PROXY_NAME} "sudo sed -i '\$ahaproxy       soft    nofile          1000000' /etc/security/limits.conf"
   ssh-to-node ${PROXY_NAME} "sudo apt update -y"
   ssh-to-node ${PROXY_NAME} "sudo apt install -y ${KUBERNETES_SCALEOUT_PROXY_APP}"
 }


### PR DESCRIPTION
we found the * entry doesn't seem work for the root account, as we can see the nofile is 1024 when issue ulimit -a under root account.
explicitly set this for root and haproxy account to ensure the nofile setting for them.

verified in testing:

```
ybai2016@new-yb01-k8s-scaleout-kubemark-proxy:~$ sudo su -
root@new-yb01-k8s-scaleout-kubemark-proxy:~# ulimit -a
core file size          (blocks, -c) 0
data seg size           (kbytes, -d) unlimited
scheduling priority             (-e) 0
file size               (blocks, -f) unlimited
pending signals                 (-i) 837329
max locked memory       (kbytes, -l) 16384
max memory size         (kbytes, -m) unlimited
open files                      (-n) 1000000
pipe size            (512 bytes, -p) 8
POSIX message queues     (bytes, -q) 819200
real-time priority              (-r) 0
stack size              (kbytes, -s) 8192
cpu time               (seconds, -t) unlimited
max user processes              (-u) 837329
virtual memory          (kbytes, -v) unlimited
file locks                      (-x) unlimited
root@new-yb01-k8s-scaleout-kubemark-proxy:~# vi /etc/security/limits.conf
root@new-yb01-k8s-scaleout-kubemark-proxy:~# grep -i nofile /etc/security/limits.conf
#        - nofile - max number of open files
*       hard    nofile          1000000
*       soft    nofile          1000000
root       hard    nofile          1000000
root       soft    nofile          1000000
haproxy       hard    nofile          1000000
haproxy       soft    nofile          1000000
root@new-yb01-k8s-scaleout-kubemark-proxy:~#
```