### PR TITLE
cherry pick commits to fix concurrent map error

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
@@ -196,8 +196,8 @@ func (a *AggregatedWatcher) Stop() {
 		a.stopped = true
 		a.allowWatcherReset = false
 		for _, stopCh := range a.stopChans {
-			go func(stopCh chan int) {
-				stopCh <- 1
+			go func(ch chan int) {
+				ch <- 1
 			}(stopCh)
 		}
 	}


### PR DESCRIPTION
### changes

 - cherry pick https://github.com/CentaurusInfra/arktos/commit/3a8629f40d1c01c1ec32cab74408ce9be3113256
 - left out added tests due to this being poc
 - fixing "fatal error: concurrent map iteration and map write"

### validation

- no regression with pod, deployment and statefulset
- kubelet not crashing within reasonable amount of times and tries