### PR TITLE
Quick fix of handling mirror pod issue

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -303,6 +303,8 @@ func makePodSourceConfig(kubeCfg *kubeletconfiginternal.KubeletConfiguration, ku
 	// NOTE: This MUST happen before creating the apiserver source
 	// below, or the checkpoint would override the source of truth.
 
+	// TODO: for multiple TP support, bootstrapcheckpointPath for multiple API servers to avoid conflicts
+	//
 	var updatechannel chan<- interface{}
 	if bootstrapCheckpointPath != "" {
 		klog.Infof("Adding checkpoint path: %v", bootstrapCheckpointPath)
@@ -1667,6 +1669,8 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 	// Create Mirror Pod for Static Pod if it doesn't already exist
 	if kubetypes.IsStaticPod(pod) {
 		podFullName := kubecontainer.GetPodFullName(pod)
+		klog.V(4).Infof("Handle static pod: %v", podFullName)
+
 		deleted := false
 		if mirrorPod != nil {
 			if mirrorPod.DeletionTimestamp != nil || !kl.podManager.IsMirrorPodOf(mirrorPod, pod) {

--- a/pkg/kubelet/pod/mirror_client.go
+++ b/pkg/kubelet/pod/mirror_client.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"strings"
 )
 
 // MirrorClient knows how to create/delete a mirror pod in the API server.
@@ -109,7 +110,7 @@ func (mc *basicMirrorClient) DeleteMirrorPod(podFullName string) error {
 // IsStaticPod returns true if the pod is a static pod.
 func IsStaticPod(pod *v1.Pod) bool {
 	source, err := kubetypes.GetPodSource(pod)
-	return err == nil && source != kubetypes.ApiserverSource
+	return err == nil && !strings.HasPrefix(source, kubetypes.ApiserverSource)
 }
 
 // IsMirrorPod returns true if the pod is a mirror pod.

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -19,6 +19,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -212,5 +213,5 @@ func IsCriticalPodBasedOnPriority(priority int32) bool {
 // IsStaticPod returns true if the pod is a static pod.
 func IsStaticPod(pod *v1.Pod) bool {
 	source, err := GetPodSource(pod)
-	return err == nil && source != ApiserverSource
+	return err == nil && !strings.HasPrefix(source, ApiserverSource)
 }


### PR DESCRIPTION
When support for multiple tenant partition cluster was added, we explicitly differentiate the "source" of api server as api0 , api1 etc. with a suffix of digit for each partitions. however, this breaks the logic with , at least, the static pod check where relies on the source=="api".

quick fix for now, is to check the prefix of the source, instead of the full string comparison.

verified with 100 node perf run.
```
ybai2016@new-yb01-k8s-scaleout-minion-group-1655 /var/log $ grep -i "Creating a mirror pod" kubelet-hollow-node-*.log
ybai2016@new-yb01-k8s-scaleout-minion-group-1655 /var/log $ 
```