### PR TITLE
remove network CRD and object retrieval for scalability tests

### DIFF
--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -2229,7 +2229,7 @@ function start-kube-controller-manager {
     RUN_CONTROLLERS="nodelifecycle"
   fi
   if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-    RUN_CONTROLLERS="*,-nodeipam,-nodelifecycle"
+    RUN_CONTROLLERS="*,-nodeipam,-nodelifecycle,-mizar,-network"
   fi
   if [[ -n "${RUN_CONTROLLERS:-}" ]]; then
     params+=" --controllers=${RUN_CONTROLLERS}"

--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -27,16 +27,12 @@ import (
 	"strings"
 
 	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	arktosv1 "k8s.io/arktos-ext/pkg/apis/arktosextensions/v1"
 	arktosextensions "k8s.io/arktos-ext/pkg/generated/clientset/versioned/typed/arktosextensions/v1"
 	"k8s.io/client-go/tools/record"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
-	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 )
@@ -87,34 +83,7 @@ func NewConfigurer(recorder record.EventRecorder, nodeRef *v1.ObjectReference, n
 }
 
 func (c *Configurer) getClusterDNS(pod *v1.Pod) ([]net.IP, error) {
-	networkName, ok := pod.Labels[arktosv1.NetworkLabel]
-	if !ok {
-		networkName = arktosv1.NetworkDefault
-	}
-
-	if network, err := c.arktosV1Client.NetworksWithMultiTenancy(pod.Tenant).Get(networkName, metav1.GetOptions{}); err == nil {
-		if network.Status.Phase != arktosv1.NetworkReady {
-			return nil, fmt.Errorf("network %s/%s is in %q phase, not ready", network.Tenant, network.Name, network.Status.Phase)
-		}
-
-		ip := net.ParseIP(network.Status.DNSServiceIP)
-		if ip != nil {
-			return []net.IP{ip}, nil
-		}
-	} else {
-		klog.Errorf("failed to get network %s/%s: %v", pod.Tenant, networkName, err)
-	}
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.MandatoryArktosNetwork) {
-		return nil, fmt.Errorf("network %s/%s not found", pod.Tenant, networkName)
-	}
-
-	// fallback to default cluster DNS for pods on the default network
-	if networkName == arktosv1.NetworkDefault {
-		return c.clusterDNS, nil
-	}
-
-	return nil, nil
+	return c.clusterDNS, nil
 }
 
 func omitDuplicates(strs []string) []string {

--- a/staging/src/k8s.io/client-go/util/flowcontrol/throttle.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/throttle.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -371,15 +371,3 @@ if [[ "${CREATE_TEST_TENANTS:-false}" == "true" ]]; then
   "${KUBECTL}" --kubeconfig="${TP_ONE_KUBECONFIG}" get tenants
   echo
 fi
-
-### for multiple TP tests, apply network crd on each TP
-###
-if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then  
-  echo -e "Apply network CRD on TP1 cluster"
-  ${KUBECTL} --kubeconfig=${TP1_KUBECONFIG_DIRECT} apply -f "${KUBE_ROOT}/pkg/controller/artifacts/crd-network.yaml"
-
-  if [[ "${SCALEOUT_CLUSTER_TWO_TPS:-false}" == "true" ]]; then
-    echo -e "Apply network CRD on TP2 cluster"
-    ${KUBECTL} --kubeconfig=${TP2_KUBECONFIG_DIRECT} apply -f "${KUBE_ROOT}/pkg/controller/artifacts/crd-network.yaml"
-  fi
-fi


### PR DESCRIPTION
As scalability test is bothered by too many requests to get network object, whose work is not completely in place yet. To improve the performance of apiserver, this PR removes the defintion and usage of network CRD in scalablity tests.

Verified in one BOX:
1. deployment creation/scale succeeded
2. apiserver.log and haproxy.log showed there is not request to "GET "tenants/####/networks/default" any more