### PR TITLE
fix the haproxy crash after patching for prometheus

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2864,11 +2864,12 @@ function patch-haproxy-prometheus {
   echo 'Patching Haproxy to expose prometheus...'
   ssh-to-node ${PROXY_NAME} "sudo apt install -y git ca-certificates gcc libc6-dev liblua5.3-dev libpcre3-dev libssl-dev libsystemd-dev make wget zlib1g-dev"
   ssh-to-node ${PROXY_NAME} "git clone https://github.com/haproxy/haproxy.git /tmp/haproxy"
+  ssh-to-node ${PROXY_NAME} "cd /tmp/haproxy;git checkout tags/v2.3.0"
   ssh-to-node ${PROXY_NAME} "cd /tmp/haproxy;make TARGET=linux-glibc USE_LUA=1 USE_OPENSSL=1 USE_PCRE=1 USE_ZLIB=1 USE_SYSTEMD=1 EXTRA_OBJS=contrib/prometheus-exporter/service-prometheus.o -j4"
   ssh-to-node ${PROXY_NAME} "cd /tmp/haproxy;sudo make install-bin"
+  ssh-to-node ${PROXY_NAME} "sudo systemctl reset-failed haproxy.service"
   ssh-to-node ${PROXY_NAME} "sudo systemctl stop haproxy"
   ssh-to-node ${PROXY_NAME} "sudo cp /usr/local/sbin/haproxy /usr/sbin/haproxy"
-  ssh-to-node ${PROXY_NAME} "sudo systemctl reset-failed haproxy.service"
   ssh-to-node ${PROXY_NAME} "sudo systemctl start haproxy"
   ssh-to-node ${PROXY_NAME} "haproxy -vv|grep Prometheus"
 }

--- a/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg
+++ b/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg
@@ -74,6 +74,7 @@ defaults
         errorfile 503 /etc/haproxy/errors/503.http
         errorfile 504 /etc/haproxy/errors/504.http
 
+# the following setup enable the prometheus export
 frontend stats
     bind *:8404
     option http-use-htx
@@ -81,6 +82,15 @@ frontend stats
     stats enable
     stats uri /stats
     stats refresh 10s
+
+# the following setup can be used to enable the stats page of proxy
+#listen stats
+#    bind *:8404
+#    stats enable
+#    stats hide-version
+#    stats refresh 10s
+#    stats show-node
+#    stats uri  /stats
 
 frontend scale-out-proxy
     bind *:{{ proxy_port }} alpn h2,http/1.1


### PR DESCRIPTION
### Changes

Fixed the crash when haproxy is restarted when starting 2tp1rp cluster.

### Validation
Tested using 100-node, 1000-node and 5k node cluster. Cluster came up correctly and prometheus metrics showed up too.