### PR TITLE
fix haproxy cfg & script to work in one-box

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2808,6 +2808,9 @@ function init-proxy-cfg() {
   sed -i -e "s@{{ *arktos_api_port *}}@8080@g" "${PROXY_CONFIG_FILE_TMP}" 
 
   sed -i -e "s@{{ *connection_timeout *}}@10m@g" "${PROXY_CONFIG_FILE_TMP}" 
+
+  sed -i -e "/^ONEBOX_ONLY:/d"  "${PROXY_CONFIG_FILE_TMP}"
+  sed -i -e "s/KUBEMARK_ONLY://g" "${PROXY_CONFIG_FILE_TMP}"
 }
 
 function update-proxy() {

--- a/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg
+++ b/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg
@@ -20,40 +20,9 @@ global
         #  https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=haproxy
         ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS
         ssl-default-bind-options no-sslv3
-        nbproc 32
-        cpu-map 1 0 
-        cpu-map 2 1
-        cpu-map 3 2 
-        cpu-map 4 3
-        cpu-map 5 4 
-        cpu-map 6 5 
-        cpu-map 7 6
-        cpu-map 8 7 
-        cpu-map 9 8
-        cpu-map 10 9 
-        cpu-map 11 10
-        cpu-map 12 11
-        cpu-map 13 12 
-        cpu-map 14 13
-        cpu-map 15 14 
-        cpu-map 16 15
-        cpu-map 17 16
-        cpu-map 18 17 
-        cpu-map 19 18
-        cpu-map 20 19 
-        cpu-map 21 20
-        cpu-map 22 21
-        cpu-map 23 22 
-        cpu-map 24 23
-        cpu-map 25 24 
-        cpu-map 26 25
-        cpu-map 27 26
-        cpu-map 28 27 
-        cpu-map 29 28
-        cpu-map 30 29 
-        cpu-map 31 30
-        cpu-map 32 31
-        stats bind-process 32
+        nbproc 64        
+        cpu-map auto:1-64  0-63
+        stats bind-process 64
         
 
 defaults
@@ -74,14 +43,13 @@ defaults
         errorfile 503 /etc/haproxy/errors/503.http
         errorfile 504 /etc/haproxy/errors/504.http
 
-# the following setup enable the prometheus export
-frontend stats
-    bind *:8404
-    option http-use-htx
-    http-request use-service prometheus-exporter if { path /metrics }
-    stats enable
-    stats uri /stats
-    stats refresh 10s
+KUBEMARK_ONLY:frontend stats
+KUBEMARK_ONLY:    bind *:8404
+KUBEMARK_ONLY:    option http-use-htx
+KUBEMARK_ONLY:    http-request use-service prometheus-exporter if { path /metrics }
+KUBEMARK_ONLY:    stats enable
+KUBEMARK_ONLY:    stats uri /stats
+KUBEMARK_ONLY:    stats refresh 10s
 
 # the following setup can be used to enable the stats page of proxy
 #listen stats

--- a/hack/scale_out_poc/haproxy_2T1R/setup_haproxy.sh
+++ b/hack/scale_out_poc/haproxy_2T1R/setup_haproxy.sh
@@ -74,6 +74,9 @@ config_haproxy() {
 
         sed -i -e "s@{{ *connection_timeout *}}@${connection_timeout}@g" "${temp_file}"
 
+        sed -i -e "/^KUBEMARK_ONLY:/d"  "${temp_file}"
+        sed -i -e "s/ONEBOX_ONLY://g" "${temp_file}"
+
         run_command_exit_if_failed sudo cp "${temp_file}" "/etc/haproxy/haproxy.cfg"
 }
 


### PR DESCRIPTION
Recent changes to haproxy.cfg to add Prometheus monitoring to proxy breaks the one-box haproxy setup. This PR fixes it by removing those lines when generating the haproxy.cfg.

Also included in this PR:
1. increase the number of processes of haproxy from 32 to 64 ( the max value allowed) as we have very powerful machines in tests.
2. code refactoring

Verification:
1. verified in my local env that it works.
2. Verified that the clusters were built after integrating with the Haproxy Prometheus fix (https://github.com/CentaurusInfra/arktos/pull/895)