### PR TITLE
Extend kubelet to use kubeclient from more than 2 tenant partitions

### DIFF
--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -19,7 +19,10 @@ package config
 
 import (
 	"fmt"
+	"k8s.io/kubernetes/pkg/kubelet/util"
 	"reflect"
+	"strconv"
+	"strings"
 	"sync"
 
 	"k8s.io/api/core/v1"
@@ -260,6 +263,14 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 			if ref.Annotations == nil {
 				ref.Annotations = make(map[string]string)
 			}
+
+			if strings.HasPrefix(source, kubetypes.ApiserverSource) {
+				if _, ok := util.Tenant2api[ref.Tenant]; !ok {
+					clientId, _ := strconv.Atoi(source[(len(source) - 1):])
+					util.Tenant2api[ref.Tenant] = clientId
+				}
+			}
+
 			ref.Annotations[kubetypes.ConfigSourceAnnotationKey] = source
 			if existing, found := oldPods[ref.UID]; found {
 				pods[ref.UID] = existing

--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"k8s.io/kubernetes/pkg/kubelet/util"
 	"reflect"
-	"strconv"
-	"strings"
 	"sync"
 
 	"k8s.io/api/core/v1"
@@ -264,12 +262,8 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 				ref.Annotations = make(map[string]string)
 			}
 
-			if strings.HasPrefix(source, kubetypes.ApiserverSource) {
-				if _, ok := util.Tenant2api[ref.Tenant]; !ok {
-					clientId, _ := strconv.Atoi(source[(len(source) - 1):])
-					util.Tenant2api[ref.Tenant] = clientId
-				}
-			}
+			// Bookkeeping mapping between tenant and its origin apiserver
+			util.RegisterTenantSourceServer(source, ref)
 
 			ref.Annotations[kubetypes.ConfigSourceAnnotationKey] = source
 			if existing, found := oldPods[ref.UID]; found {

--- a/pkg/kubelet/configmap/configmap_manager.go
+++ b/pkg/kubelet/configmap/configmap_manager.go
@@ -19,7 +19,7 @@ package configmap
 
 import (
 	"fmt"
-	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/kubelet/util"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -63,7 +63,7 @@ func NewSimpleConfigMapManager(kubeClients []clientset.Interface) Manager {
 }
 
 func (s *simpleConfigMapManager) GetConfigMap(tenant, namespace, name string) (*v1.ConfigMap, error) {
-	client := getTPClient(s.kubeClients, tenant)
+	client := util.GetTPClient(s.kubeClients, tenant)
 	return client.CoreV1().ConfigMapsWithMultiTenancy(namespace, tenant).Get(name, metav1.GetOptions{})
 }
 
@@ -113,19 +113,6 @@ const (
 	defaultTTL = time.Minute
 )
 
-func getTPClient(kubeClients []clientset.Interface, tenant string) clientset.Interface {
-	var client clientset.Interface
-	pick := 0
-	if len(kubeClients) == 1 || tenant[0] <= 'm' {
-		client = kubeClients[0]
-	} else {
-		client = kubeClients[1]
-		pick = 1
-	}
-	klog.Infof("tenant %s using client # %d", tenant, pick)
-	return client
-}
-
 // NewCachingConfigMapManager creates a manager that keeps a cache of all configmaps
 // necessary for registered pods.
 // It implement the following logic:
@@ -136,7 +123,7 @@ func getTPClient(kubeClients []clientset.Interface, tenant string) clientset.Int
 //   value in cache; otherwise it is just fetched from cache
 func NewCachingConfigMapManager(kubeClient []clientset.Interface, getTTL manager.GetObjectTTLFunc) Manager {
 	getConfigMap := func(tenant, namespace, name string, opts metav1.GetOptions) (runtime.Object, error) {
-		client := getTPClient(kubeClient, tenant)
+		client := util.GetTPClient(kubeClient, tenant)
 		return client.CoreV1().ConfigMapsWithMultiTenancy(namespace, tenant).Get(name, opts)
 	}
 	configMapStore := manager.NewObjectStore(getConfigMap, clock.RealClock{}, getTTL, defaultTTL)
@@ -153,11 +140,11 @@ func NewCachingConfigMapManager(kubeClient []clientset.Interface, getTTL manager
 // - every GetObject() returns a value from local cache propagated via watches
 func NewWatchingConfigMapManager(kubeClients []clientset.Interface) Manager {
 	listConfigMap := func(tenant, namespace string, opts metav1.ListOptions) (runtime.Object, error) {
-		client := getTPClient(kubeClients, tenant)
+		client := util.GetTPClient(kubeClients, tenant)
 		return client.CoreV1().ConfigMapsWithMultiTenancy(namespace, tenant).List(opts)
 	}
 	watchConfigMap := func(tenant, namespace string, opts metav1.ListOptions) (watch.Interface, error) {
-		client := getTPClient(kubeClients, tenant)
+		client := util.GetTPClient(kubeClients, tenant)
 		return client.CoreV1().ConfigMapsWithMultiTenancy(namespace, tenant).Watch(opts)
 	}
 	newConfigMap := func() runtime.Object {

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"k8s.io/kubernetes/pkg/kubelet/util"
 	"net/http"
 	"net/url"
 	"os"
@@ -1961,7 +1962,7 @@ func hasHostNamespace(pod *v1.Pod) bool {
 func (kl *Kubelet) hasHostMountPVC(pod *v1.Pod) bool {
 	for _, volume := range pod.Spec.Volumes {
 		if volume.PersistentVolumeClaim != nil {
-			tenantClient := kl.getTPClient(pod.Tenant)
+			tenantClient := util.GetTPClient(kl.kubeClient, pod.Tenant)
 			pvc, err := tenantClient.CoreV1().PersistentVolumeClaimsWithMultiTenancy(pod.Namespace, pod.Tenant).Get(volume.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
 			if err != nil {
 				klog.Warningf("unable to retrieve pvc %s:%s - %v", pod.Namespace, volume.PersistentVolumeClaim.ClaimName, err)

--- a/pkg/kubelet/util/util.go
+++ b/pkg/kubelet/util/util.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,7 +19,24 @@ package util
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
 )
+
+// poc, tenant name -> api server id
+var Tenant2api map[string]int
+
+func GetTPClient(kubeClients []clientset.Interface, tenant string) clientset.Interface {
+	var client clientset.Interface
+	pick, ok := Tenant2api[tenant]
+	if len(kubeClients) == 1 || !ok { // !ok to force a retry
+		client = kubeClients[0]
+	} else {
+		client = kubeClients[pick]
+	}
+	klog.V(4).Infof("tenant %s using client # %d", tenant, pick)
+	return client
+}
 
 // FromApiserverCache modifies <opts> so that the GET request will
 // be served from apiserver cache instead of from etcd.

--- a/pkg/kubelet/util/util.go
+++ b/pkg/kubelet/util/util.go
@@ -18,17 +18,43 @@ limitations under the License.
 package util
 
 import (
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"strconv"
+	"strings"
+	"sync"
 )
 
 // poc, tenant name -> api server id
 var Tenant2api map[string]int
 
+var Tenant2apiLock sync.RWMutex
+
+func RegisterTenantSourceServer(source string, ref *v1.Pod) {
+	if len(ref.Tenant) == 0 || !strings.HasPrefix(source, kubetypes.ApiserverSource) {
+		return
+	}
+	key := strings.ToLower(ref.Tenant)
+	clientId, err := strconv.Atoi(source[(len(source) - 1):])
+	if err != nil {
+		klog.Errorf("Failed to get apiserver id. Err: %s", err)
+		return
+	}
+	Tenant2apiLock.Lock()
+	defer Tenant2apiLock.Unlock()
+	if _, ok := Tenant2api[key]; !ok {
+		Tenant2api[key] = clientId
+	}
+}
+
 func GetTPClient(kubeClients []clientset.Interface, tenant string) clientset.Interface {
+	Tenant2apiLock.RLock()
+	defer Tenant2apiLock.RUnlock()
 	var client clientset.Interface
-	pick, ok := Tenant2api[tenant]
+	pick, ok := Tenant2api[strings.ToLower(tenant)]
 	if len(kubeClients) == 1 || !ok { // !ok to force a retry
 		client = kubeClients[0]
 	} else {


### PR DESCRIPTION
### Changes

- kubelet supports using kube clients from more than 2 tenant partitions
- remove duplication of GetTPClient (finally!)

### Validation

cannot test more than 2 tenants though without proxy change.

- one box test with 2 tenants (done)
- 100-node test with arktos tenant (done)