### PR TITLE
make density test work on non-default TP

### DIFF
--- a/perf-tests/clusterloader2/pkg/chaos/nodes.go
+++ b/perf-tests/clusterloader2/pkg/chaos/nodes.go
@@ -111,7 +111,7 @@ func (k *NodeKiller) pickNodes() ([]v1.Node, error) {
 		return nil, err
 	}
 
-	prometheusPods, err := client.ListPodsWithOptions(k.client, monitoringNamespace, metav1.ListOptions{
+	prometheusPods, err := client.ListPodsWithOptions(k.client, util.GetTenant(), monitoringNamespace, metav1.ListOptions{
 		LabelSelector: prometheusLabel,
 	})
 	if err != nil {

--- a/perf-tests/clusterloader2/pkg/framework/client/objects.go
+++ b/perf-tests/clusterloader2/pkg/framework/client/objects.go
@@ -147,10 +147,10 @@ func RetryFunction(f func() error, options ...*ApiCallOptions) wait.ConditionFun
 }
 
 // ListPodsWithOptions lists the pods using the provided options.
-func ListPodsWithOptions(c clientset.Interface, namespace string, listOpts metav1.ListOptions) ([]apiv1.Pod, error) {
+func ListPodsWithOptions(c clientset.Interface, tenant, namespace string, listOpts metav1.ListOptions) ([]apiv1.Pod, error) {
 	var pods []apiv1.Pod
 	listFunc := func() error {
-		podsList, err := c.CoreV1().Pods(namespace).List(listOpts)
+		podsList, err := c.CoreV1().PodsWithMultiTenancy(namespace, tenant).List(listOpts)
 		if err != nil {
 			return err
 		}

--- a/perf-tests/clusterloader2/pkg/imagepreload/imagepreload.go
+++ b/perf-tests/clusterloader2/pkg/imagepreload/imagepreload.go
@@ -118,7 +118,7 @@ func (c *controller) PreloadImages() error {
 	}
 
 	klog.Infof("Getting %s/%s deamonset size...", namespace, daemonsetName)
-	ds, err := kclient.AppsV1().DaemonSets(namespace).Get(daemonsetName, metav1.GetOptions{})
+	ds, err := kclient.AppsV1().DaemonSetsWithMultiTenancy(namespace, perfutil.GetTenant()).Get(daemonsetName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/perf-tests/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
+++ b/perf-tests/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
@@ -181,7 +181,7 @@ func (p *podStartupLatencyMeasurement) gatherScheduleTimes(c clientset.Interface
 		"source":              corev1.DefaultSchedulerName,
 	}.AsSelector().String()
 	options := metav1.ListOptions{FieldSelector: selector}
-	schedEvents, err := c.CoreV1().Events(p.selector.Namespace).List(options)
+	schedEvents, err := c.CoreV1().EventsWithMultiTenancy(p.selector.Namespace, util.GetTenant()).List(options)
 	if err != nil {
 		return err
 	}

--- a/perf-tests/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
+++ b/perf-tests/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
@@ -34,6 +34,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/perf-tests/clusterloader2/pkg/framework/client"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	"k8s.io/kubernetes/perf-tests/clusterloader2/pkg/util"
 )
 
 // ListRuntimeObjectsForKind returns objects of given kind that satisfy given namespace, labelSelector and fieldSelector.
@@ -45,7 +46,7 @@ func ListRuntimeObjectsForKind(d dynamic.Interface, gvr schema.GroupVersionResou
 		FieldSelector: fieldSelector,
 	}
 	listFunc = func() error {
-		list, err := d.Resource(gvr).List(listOpts)
+		list, err := d.Resource(gvr).NamespaceWithMultiTenancy(metav1.NamespaceAll, util.GetTenant()).List(listOpts)
 		if err != nil {
 			return err
 		}
@@ -390,10 +391,10 @@ func CreateMetaNamespaceKey(obj runtime.Object) (string, error) {
 }
 
 // GetNumObjectsMatchingSelector returns number of objects matching the given selector.
-func GetNumObjectsMatchingSelector(c dynamic.Interface, namespace string, resource schema.GroupVersionResource, labelSelector labels.Selector) (int, error) {
+func GetNumObjectsMatchingSelector(c dynamic.Interface, tenant, namespace string, resource schema.GroupVersionResource, labelSelector labels.Selector) (int, error) {
 	var numObjects int
 	listFunc := func() error {
-		list, err := c.Resource(resource).Namespace(namespace).List(metav1.ListOptions{LabelSelector: labelSelector.String()})
+		list, err := c.Resource(resource).NamespaceWithMultiTenancy(namespace, tenant).List(metav1.ListOptions{LabelSelector: labelSelector.String()})
 		numObjects = len(list.Items)
 		return err
 	}

--- a/perf-tests/clusterloader2/pkg/prometheus/experimental.go
+++ b/perf-tests/clusterloader2/pkg/prometheus/experimental.go
@@ -26,6 +26,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
+	
+	"k8s.io/kubernetes/perf-tests/clusterloader2/pkg/util"
 )
 
 type prometheusDiskMetadata struct {
@@ -62,7 +64,7 @@ func (pc *PrometheusController) cachePrometheusDiskMetadataIfEnabled() error {
 func (pc *PrometheusController) tryRetrievePrometheusDiskMetadata() (bool, error) {
 	klog.Info("Retrieving Prometheus' persistent disk metadata...")
 	k8sClient := pc.framework.GetClientSets().GetClient()
-	list, err := k8sClient.CoreV1().PersistentVolumes().List(metav1.ListOptions{})
+	list, err := k8sClient.CoreV1().PersistentVolumesWithMultiTenancy(util.GetTenant()).List(metav1.ListOptions{})
 	if err != nil {
 		klog.Errorf("Listing PVs failed: %v", err)
 		// Poll() stops on error so returning nil

--- a/perf-tests/clusterloader2/pkg/test/simple_test_executor.go
+++ b/perf-tests/clusterloader2/pkg/test/simple_test_executor.go
@@ -402,6 +402,7 @@ func getReplicaCountOfNewObject(ctx Context, namespace string, object *api.Objec
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 	replicaCount, err := runtimeobjects.GetNumObjectsMatchingSelector(
 		ctx.GetClusterFramework().GetDynamicClients().GetClient(),
+		util.GetTenant(),
 		namespace,
 		gvr,
 		selector)

--- a/statefulset.yaml
+++ b/statefulset.yaml
@@ -1,0 +1,61 @@
+{{$EnablePVs := DefaultParam .CL2_ENABLE_PVS true}}
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{.Name}}
+  labels:
+    group: load
+spec:
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      group: load
+      name: {{.Name}}
+  serviceName: {{.Name}}
+  replicas: {{RandIntRange .ReplicasMin .ReplicasMax}}
+  template:
+    metadata:
+      labels:
+        group: load
+        name: {{.Name}}
+    spec:
+      containers:
+      - name: {{.Name}}
+        image: k8s.gcr.io/pause:3.1
+        ports:
+          - containerPort: 80
+            name: web
+        resources:
+          requests:
+            cpu: 10m
+            memory: "10M"
+        {{if $EnablePVs}}
+        volumeMounts:
+          - name: pv
+            mountPath: /var/pv
+        {{end}}
+      terminationGracePeriodSeconds: 1
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+  {{if $EnablePVs}}
+  # NOTE: PVs created this way should be cleaned-up manually, as deleting the StatefulSet doesn't automatically delete PVs.
+  # To avoid deleting all the PVs at once during namespace deletion, they should be deleted explicitly via Phase.
+  volumeClaimTemplates:
+    - metadata:
+        name: pv
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 100Mi
+  {{end}}


### PR DESCRIPTION
This PR fixes the issue that density test fails when the test tenant does not belong to the default TP.

Verification:

Combining this PR with https://github.com/CentaurusInfra/arktos/pull/902 and https://github.com/CentaurusInfra/arktos/pull/897, a test cluster with 3 TPs and 1 RP was created. Density tests succeeded for each of the following three tenants:
1. arktos ( home TP: TP1)
2. memphis ( home TP: TP2)
3. zeta (home TP: TP3)