### PR TITLE
separate and direct haproxy and add scheduler & controller prometheus

### DIFF
--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -1417,7 +1417,7 @@ global:
 scrape_configs:
   - job_name: prometheus-metrics
     static_configs:
-    - targets: ['127.0.0.1:2379','127.0.0.1:8080']
+    - targets: ['127.0.0.1:2379','127.0.0.1:8080','127.0.0.1:10251','127.0.0.1:10252']
   - job_name: 'haproxy'
     static_configs:
     - targets: ['scale_out_proxy_ip:8404']

--- a/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg
+++ b/hack/scale_out_poc/haproxy_2T1R/haproxy.cfg
@@ -1,6 +1,6 @@
 global
-        log /dev/log    local0
-        log /dev/log    local1 notice
+        log 127.0.0.1 local0
+        log 127.0.0.1 local1 notice
         chroot /var/lib/haproxy
         stats socket /run/haproxy/admin.sock mode 660 level admin expose-fd listeners
         stats timeout 30s

--- a/hack/scale_out_poc/haproxy_2T1R/setup_haproxy.sh
+++ b/hack/scale_out_poc/haproxy_2T1R/setup_haproxy.sh
@@ -58,6 +58,48 @@ install_haproxy_if_needed() {
         fi
 }
 
+patch-haproxy-prometheus() {
+  # based on https://www.haproxy.com/blog/haproxy-exposes-a-prometheus-metrics-endpoint
+  echo 'Patching Haproxy to expose prometheus...'
+  haproxy_patch_tmp=/tmp/haproxy
+  run_command_exit_if_failed sudo apt install -y git ca-certificates gcc libc6-dev liblua5.3-dev libpcre3-dev libssl-dev libsystemd-dev make wget zlib1g-dev
+  run_command_exit_if_failed git clone https://github.com/haproxy/haproxy.git ${haproxy_patch_tmp}
+  run_command_exit_if_failed pushd ${haproxy_patch_tmp}
+  run_command_exit_if_failed git checkout tags/v2.3.0
+  run_command_exit_if_failed make TARGET=linux-glibc USE_LUA=1 USE_OPENSSL=1 USE_PCRE=1 USE_ZLIB=1 USE_SYSTEMD=1 EXTRA_OBJS=contrib/prometheus-exporter/service-prometheus.o -j4
+  run_command_exit_if_failed sudo make install-bin
+  run_command_exit_if_failed sudo systemctl reset-failed haproxy.service
+  run_command_exit_if_failed sudo systemctl stop haproxy
+  run_command_exit_if_failed sudo cp /usr/local/sbin/haproxy /usr/sbin/haproxy
+  run_command_exit_if_failed sudo systemctl start haproxy
+  run_command_exit_if_failed haproxy -vv|grep Prometheus
+  run_command_exit_if_failed popd
+  run_command_exit_if_failed rm -rf ${haproxy_patch_tmp}
+}
+
+function direct-haproxy-logging {
+  haproxy_conf=`find /etc/rsyslog.d -name *haproxy.conf`
+
+  if [ -z "$haproxy_conf" ]; then
+    echo "haproxy conf file not found in /etc/rsyslog.d/"
+    return
+  fi
+
+  if grep -q "UDPServerRun 514" "$haproxy_conf"; then
+    echo "skipped updating haproxy.conf for directing logging"
+    return
+  fi
+
+   echo '
+$ModLoad imudp
+$UDPServerRun 514
+local0.* -/var/log/haproxy.log
+' >> $haproxy_conf
+
+  run_command_exit_if_failed sudo service rsyslog restart
+  echo "haproxy logging directed to /var/log/haproxy.log only"
+}
+
 config_haproxy() {
         script_root=$(dirname "${BASH_SOURCE}")
         local -r temp_file="/tmp/haproxy.cfg"
@@ -99,6 +141,10 @@ tenant_partition_two_ip=${TENANT_PARTITION_TWO_IP}
 validate_params
 
 install_haproxy_if_needed
+
+patch-haproxy-prometheus
+
+direct-haproxy-logging 
 
 config_haproxy
 


### PR DESCRIPTION
### Changes: 
- make haproxy emit log only to /var/log/haproxy.log in **one-box environment**. 
- build the same haproxy with prometheus in one-box environment
- this changes apply to 2-tp 1-rp setup script. a second PR will follow to make the same changes in the N tp and 1 rp script that is also used for GCE setup
- enable prometheus scraping to scheduler 
- enable prometheus scraping to controller

### Why this change?
- prior to this change, haproxy log is either flooding /var/log/syslog, or writing to both /var/log/syslog and /var/log/haproxy.log
- consistent haproxy version with the one used in GCE
- help debugging and analysis in one-box

### Notes
- change is based on https://pc-freak.net/blog/enable-haproxy-logging-separate-log-varloghaproxylog-prevent-haproxy-duplicate-messages-varlogmessages/
- metrics info in https://www.sumologic.com/blog/kubernetes-monitoring/

### How tested?
- local one box (2tp-1rp) envirment. verified haproxy log only shows up in /var/log/haproxy.log, not in /var/log/syslog
- scheduler metrics in one-box testing:
![image](https://user-images.githubusercontent.com/252020/103695037-bd7d1000-4f50-11eb-9fe1-1251e39c9a6c.png)

- metrics shows up in GCE 100-node env
![image](https://user-images.githubusercontent.com/252020/103750202-4b8de080-4fbb-11eb-86fb-150febdd0953.png)
