### PR TITLE
Debug logging in kubelet and scheduler

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -917,7 +917,7 @@ func (kl *Kubelet) PodResourcesAreReclaimed(pod *v1.Pod, status v1.PodStatus) bo
 		// hack, verify the cause of terminating pod issue in perf
 		//
 		if strings.Contains(err.Error(), "not found") {
-			klog.V(4).Infof("DEBUG: Ignore container not found errors")
+			klog.V(2).Infof("DEBUG: Ignore container not found errors")
 			return true
 		}
 

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -208,6 +208,7 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 		return result, err
 	}
 
+	klog.V(2).Infof("DEBUG: Compute predicates pod: %v/%v/%v", pod.Tenant, pod.Namespace, pod.Name)
 	trace.Step("Computing predicates")
 	startPredicateEvalTime := time.Now()
 	filteredNodes, failedPredicateMap, err := g.findNodesThatFit(pod, nodes)
@@ -227,6 +228,7 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 	metrics.SchedulingLatency.WithLabelValues(metrics.PredicateEvaluation).Observe(metrics.SinceInSeconds(startPredicateEvalTime))
 	metrics.DeprecatedSchedulingLatency.WithLabelValues(metrics.PredicateEvaluation).Observe(metrics.SinceInSeconds(startPredicateEvalTime))
 
+	klog.V(2).Infof("DEBUG: Prioritizing pod: %v/%v/%v", pod.Tenant, pod.Namespace, pod.Name)
 	trace.Step("Prioritizing")
 	startPriorityEvalTime := time.Now()
 	// When only one node after predicate, just use it.
@@ -250,6 +252,7 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 	metrics.SchedulingLatency.WithLabelValues(metrics.PriorityEvaluation).Observe(metrics.SinceInSeconds(startPriorityEvalTime))
 	metrics.DeprecatedSchedulingLatency.WithLabelValues(metrics.PriorityEvaluation).Observe(metrics.SinceInSeconds(startPriorityEvalTime))
 
+	klog.V(2).Infof("DEBUG: Selecting host pod: %v/%v/%v", pod.Tenant, pod.Namespace, pod.Name)
 	trace.Step("Selecting host")
 
 	host, err := g.selectHost(priorityList)

--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -413,6 +413,8 @@ func (cache *schedulerCache) AddPod(pod *v1.Pod) error {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
+	klog.V(2).Infof("DEBUG: ADD_DEL: Add pod from cache: %v/%v/%v", pod.Tenant, pod.Namespace, pod.Name)
+
 	currState, ok := cache.podStates[key]
 	switch {
 	case ok && cache.assumedPods[key]:
@@ -476,6 +478,8 @@ func (cache *schedulerCache) RemovePod(pod *v1.Pod) error {
 
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
+
+	klog.V(2).Infof("DEBUG: ADD_DEL: Remove pod from cache: %v/%v/%v", pod.Tenant, pod.Namespace, pod.Name)
 
 	currState, ok := cache.podStates[key]
 	switch {


### PR DESCRIPTION
Update some key logging entries to level 2 so that they can be visible in perf run with default logging level settings.