### PR TITLE
make haproxy dump logs only to /var/log/haproxy.log (part 2)

### DIFF
--- a/hack/scale_out_poc/config_haproxy/haproxy.cfg.template
+++ b/hack/scale_out_poc/config_haproxy/haproxy.cfg.template
@@ -1,6 +1,6 @@
 global
-        log /dev/log    local0
-        log /dev/log    local1 notice
+        log 127.0.0.1 local0
+        log 127.0.0.1 local1 notice
         chroot /var/lib/haproxy
         stats socket /run/haproxy/admin.sock mode 660 level admin expose-fd listeners
         stats timeout 30s


### PR DESCRIPTION
### Changes
This is the 2nd part of changes for haproxy logging after https://github.com/CentaurusInfra/arktos/pull/906.

### How Validated?
- one box: cluster start and sanity test runs correctly. haproxy log shows up only in /var/log/haproxy.log
- GCE: 100-node density test passes. logs correct.
![image](https://user-images.githubusercontent.com/252020/103836735-c3511f00-503e-11eb-876b-3635deb7ae1e.png)
