### PR TITLE
Fix cross tenant gather

### DIFF
--- a/perf-tests/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
+++ b/perf-tests/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
@@ -229,5 +229,5 @@ func (p *podStartupLatencyMeasurement) checkPod(_, obj interface{}) {
 }
 
 func createMetaNamespaceKey(namespace, name string) string {
-	return namespace + "/" + name
+	return util.GetTenant() + "/" + namespace + "/" + name
 }

--- a/perf-tests/clusterloader2/pkg/measurement/util/informer/informer.go
+++ b/perf-tests/clusterloader2/pkg/measurement/util/informer/informer.go
@@ -43,7 +43,7 @@ func NewInformer(
 		options.FieldSelector = selector.FieldSelector
 		options.LabelSelector = selector.LabelSelector
 	}
-	listerWatcher := cache.NewFilteredListWatchFromClient(c.CoreV1(), kind, selector.Namespace, optionsModifier)
+	listerWatcher := cache.NewFilteredListWatchFromClientWithMultiTenancy(c.CoreV1(), kind, selector.Namespace, optionsModifier, perfutil.GetTenant())
 	informer := cache.NewSharedInformer(listerWatcher, nil, 0)
 	addEventHandler(informer, handleObj)
 

--- a/perf-tests/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
+++ b/perf-tests/clusterloader2/pkg/measurement/util/runtimeobjects/runtimeobjects.go
@@ -387,7 +387,8 @@ func CreateMetaNamespaceKey(obj runtime.Object) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("retrieving name error: %v", err)
 	}
-	return namespace + "/" + name, nil
+
+	return util.GetTenant() + "/" + namespace + "/" + name, nil
 }
 
 // GetNumObjectsMatchingSelector returns number of objects matching the given selector.


### PR DESCRIPTION
This PR fixes the issue that multi-tenancy may grab the data of wrong tenant and thus lead to unexpected failure.

Verified this issue is fixed. 