### PR TITLE
fix static pod's invalid uuid issue

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2376,7 +2376,13 @@ function kube-up() {
       cp -f ${KUBECONFIG} ${LOCAL_KUBECONFIG_TMP}
       echo "DBG:" grep -i "server:" ${LOCAL_KUBECONFIG_TMP}
     fi
-
+    if [[ "${KUBERNETES_SCALEOUT_PROXY:-false}" == "true" ]]; then
+      # Debug: log proxy open file limits
+      echo "Logging open file limits configured for $KUBERNETES_SCALEOUT_PROXY_APP"
+      echo "-----------------------------"
+      ssh-to-node ${PROXY_NAME} "for npid in \$(pidof ${KUBERNETES_SCALEOUT_PROXY_APP}); do sudo prlimit --pid \$npid | grep NOFILE ; done"
+      echo "-----------------------------"
+    fi
   fi
 }
 

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -630,8 +630,8 @@ function kube::util::ensure-cfssl {
     kernel=$(uname -s)
     case "${kernel}" in
       Linux)
-        curl --retry 10 -L -o cfssl https://pkg.cfssl.org/R1.2/cfssl_linux-amd64
-        curl --retry 10 -L -o cfssljson https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
+        curl --retry 10 -L -o cfssl http://pkg.cfssl.org/R1.2/cfssl_linux-amd64
+        curl --retry 10 -L -o cfssljson http://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
         ;;
       Darwin)
         curl --retry 10 -L -o cfssl https://pkg.cfssl.org/R1.2/cfssl_darwin-amd64

--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -20,7 +20,6 @@ package config
 
 import (
 	"crypto/md5"
-	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -59,7 +58,8 @@ func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName types.Node
 			fmt.Fprintf(hasher, "url:%s", source)
 		}
 		hash.DeepHashObject(hasher, pod)
-		pod.UID = types.UID(hex.EncodeToString(hasher.Sum(nil)[0:]))
+		hexVlaue := hasher.Sum(nil)[0:]
+		pod.UID = types.UID(fmt.Sprintf("%x-%x-%x-%x-%x", hexVlaue[0:4], hexVlaue[4:6], hexVlaue[6:8], hexVlaue[8:10], hexVlaue[10:]))
 		klog.V(5).Infof("Generated UID %q pod %q from %s", pod.UID, pod.Name, source)
 	}
 


### PR DESCRIPTION
We saw a lot of messages like "Got invalid uuid [XXXXXXXXXXXXXXXXXXXXXXXXX]. Assign a new one [XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX]" in the kube-apiserver.log in TP master. This PR fixes this issue.

#### Root cause:
The root cause is the static pod's UID is in the formaet of XXXXXXXXXXXXXXXXXXXXXXXXX, while the api server expects a UID in the format of XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX.

#### Verification:
Created a 100-node cluster and finished a density test successfully. No message of "Got invalid uuid" was seen in the kube-apiserver.log in TP-1 master.

#### more
this change also fixed the issue that static pods restarts frequently (once per minute or more). As show below,  the static pods were not restarted since being created.

![image](https://user-images.githubusercontent.com/51831990/104153812-2cff5f00-5398-11eb-9f16-9b11a26013f7.png)


