### PR TITLE
Partial fix for kube-up & start-kubemark for non-scaleout cluster

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2370,19 +2370,20 @@ function kube-up() {
     fi
     check-cluster
       
-    if [ -z "${LOCAL_KUBECONFIG_TMP:-}" ]; then
-      echo "Local_kubeconfig_tmp not set"
-    else
-      cp -f ${KUBECONFIG} ${LOCAL_KUBECONFIG_TMP}
-      echo "DBG:" grep -i "server:" ${LOCAL_KUBECONFIG_TMP}
+    if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
+      if [ -z "${LOCAL_KUBECONFIG_TMP:-}" ]; then
+        echo "Local_kubeconfig_tmp not set"
+      else
+        cp -f ${KUBECONFIG} ${LOCAL_KUBECONFIG_TMP}
+        echo "DBG:" grep -i "server:" ${LOCAL_KUBECONFIG_TMP}
+      fi
+      if [[ "${KUBERNETES_SCALEOUT_PROXY:-false}" == "true" ]]; then
+        echo "Logging open file limits configured for $KUBERNETES_SCALEOUT_PROXY_APP"
+        echo "-----------------------------"
+        ssh-to-node ${PROXY_NAME} "for npid in \$(pidof ${KUBERNETES_SCALEOUT_PROXY_APP}); do sudo prlimit --pid \$npid | grep NOFILE ; done"
+        echo "-----------------------------"
+      fi
     fi
-    if [[ "${KUBERNETES_SCALEOUT_PROXY:-false}" == "true" ]]; then
-      echo "Logging open file limits configured for $KUBERNETES_SCALEOUT_PROXY_APP"
-      echo "-----------------------------"
-      ssh-to-node ${PROXY_NAME} "for npid in \$(pidof ${KUBERNETES_SCALEOUT_PROXY_APP}); do sudo prlimit --pid \$npid | grep NOFILE ; done"
-      echo "-----------------------------"
-    fi
-
   fi
 }
 

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2376,6 +2376,12 @@ function kube-up() {
       cp -f ${KUBECONFIG} ${LOCAL_KUBECONFIG_TMP}
       echo "DBG:" grep -i "server:" ${LOCAL_KUBECONFIG_TMP}
     fi
+    if [[ "${KUBERNETES_SCALEOUT_PROXY:-false}" == "true" ]]; then
+      echo "Logging open file limits configured for $KUBERNETES_SCALEOUT_PROXY_APP"
+      echo "-----------------------------"
+      ssh-to-node ${PROXY_NAME} "for npid in \$(pidof ${KUBERNETES_SCALEOUT_PROXY_APP}); do sudo prlimit --pid \$npid | grep NOFILE ; done"
+      echo "-----------------------------"
+    fi
 
   fi
 }

--- a/test/kubemark/resources/hollow-node_template_scaleout.yaml
+++ b/test/kubemark/resources/hollow-node_template_scaleout.yaml
@@ -50,10 +50,20 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: TENANT_SERVERS
+          valueFrom:
+            configMapKeyRef:
+              name: node-configmap
+              key: tenant.servers
+        - name: RESOURCE_SERVER
+          valueFrom:
+            configMapKeyRef:
+              name: node-configmap
+              key: resource.server
         command:
         - /bin/sh
         - -c
-        - /kubemark --morph=kubelet --name=$(NODE_NAME) {{hollow_kubelet_params}} --kubeconfig=/kubeconfig/kubelet.kubeconfig $(CONTENT_TYPE) --alsologtostderr 1>>/var/log/kubelet-$(NODE_NAME).log 2>&1
+        - /kubemark --morph=kubelet --tenant-servers={{tenant_servers}} --resource-server={{resource_server}} --name=$(NODE_NAME) {{hollow_kubelet_params}} --kubeconfig=/kubeconfig/kubelet.kubeconfig $(CONTENT_TYPE) --alsologtostderr 1>>/var/log/kubelet-$(NODE_NAME).log 2>&1
         volumeMounts:
         - name: kubeconfig-volume
           mountPath: /kubeconfig
@@ -66,32 +76,6 @@ spec:
             memory: 100M
         securityContext:
           privileged: true
-      - name: hollow-proxy
-        image: {{kubemark_image_registry}}/kubemark:{{kubemark_image_tag}}
-        env:
-        - name: CONTENT_TYPE
-          valueFrom:
-            configMapKeyRef:
-              name: node-configmap
-              key: content.type
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        command:
-        - /bin/sh
-        - -c
-        - /kubemark --morph=proxy --name=$(NODE_NAME) {{hollow_proxy_params}} --kubeconfig=/kubeconfig/kubeproxy.kubeconfig $(CONTENT_TYPE) --alsologtostderr 1>>/var/log/kubeproxy-$(NODE_NAME).log 2>&1
-        volumeMounts:
-        - name: kubeconfig-volume
-          mountPath: /kubeconfig
-          readOnly: true
-        - name: logs-volume
-          mountPath: /var/log
-        resources:
-          requests:
-            cpu: {{HOLLOW_PROXY_CPU}}m
-            memory: {{HOLLOW_PROXY_MEM}}Ki
       - name: hollow-node-problem-detector
         image: k8s.gcr.io/node-problem-detector:v0.4.1
         env:
@@ -102,7 +86,11 @@ spec:
         command:
         - /bin/sh
         - -c
-        - /node-problem-detector --system-log-monitors=/config/kernel.monitor --apiserver-override="https://{{master_ip}}:443?inClusterConfig=false&auth=/kubeconfig/npd.kubeconfig" --alsologtostderr 1>>/var/log/npd-$(NODE_NAME).log 2>&1
+      # For Arktos scaleout POC only
+      # simply use master_ip for the Resource cluster master URL
+      # perviously hardcoded 443 as port could break the replacement logic currently in POC with insecure ports
+      #
+        - /node-problem-detector --system-log-monitors=/config/kernel.monitor --apiserver-override="{{master_ip}}?inClusterConfig=false&auth=/kubeconfig/npd.kubeconfig" --alsologtostderr 1>>/var/log/npd-$(NODE_NAME).log 2>&1
         volumeMounts:
         - name: kubeconfig-volume
           mountPath: /kubeconfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: This helps verify that max open files configuration for haproxy is correctly configured for all processes.

**Which issue(s) this PR fixes**: Perf cluster deployment (kube-up + start-kubemark) has regressed in scale-out-poc branch for non scale-out architecture (scale-up). This partially fixes the regression. Currently, the non scaleout cluster fails in start-kubemark due to kubemark binary unable start if tenant & resource server params are missing. The binary should start in scale-up mode if that were the case. This will be a separate PR.

I tested this by doing kube-up and start-kubemark for both scaleout & non-scaleout arch. It comes up successfully for scaleout, so it is not regressing current work.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
