### PR TITLE
fix backcompat issue in hollow-node

### DIFF
--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -178,7 +178,13 @@ func run(config *hollowNodeConfig) {
 	}
 
 	if len(config.TenantServers) == 0 {
-		klog.Fatalf("Missing TenantServers. Exiting.")
+		klog.V(3).Infof("TenantServers is not set. Default to single tenant partition and clientConfig setting")
+		config.TenantServers = make([]string, 1)
+		config.TenantServers[0] = clientConfigs.GetConfig().Host
+	}
+	if config.ResourceServer =="" {
+		klog.V(3).Infof("Resource is not set. Default to clientConfig setting")
+		config.ResourceServer = clientConfigs.GetConfig().Host
 	}
 
 	numberTenantPartitions := len(config.TenantServers)


### PR DESCRIPTION
hollow node backcompat support. this follows the same approach as kubelet cmd/app/server.go does.

Tested with latest POC branch with Vinay's PR