### PR TITLE
reduce the reset-uuid message log level to 3

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/meta.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/meta.go
@@ -40,7 +40,7 @@ func FillObjectMetaSystemFields(meta metav1.Object) {
 		if err != nil {
 			uid := uuid.NewUUID()
 			meta.SetUID(uid)
-			klog.Infof("Got invalid uuid [%s]. Assign a new one [%v]", uidStr, uid)
+			klog.V(3).Infof("Got invalid uuid [%s]. Assign a new one [%v]", uidStr, uid)
 		}
 	}
 	uid := meta.GetUID()


### PR DESCRIPTION
Due to https://github.com/CentaurusInfra/arktos/issues/790, there are excessive messages of "invalid uuid" in the apiserver logs of scalability tests. Yet we know this reset-uid operation is not blocking the test. So we lower the log level to have a cleaner log.

THis change has been verified in previous a 10K*2 test run in PoC branch.