### PR TITLE
add kubeclient manager for scale-out

### DIFF
--- a/cmd/kubelet/app/BUILD
+++ b/cmd/kubelet/app/BUILD
@@ -63,6 +63,7 @@ go_library(
         "//pkg/kubelet/dockershim/remote:go_default_library",
         "//pkg/kubelet/eviction:go_default_library",
         "//pkg/kubelet/eviction/api:go_default_library",
+        "//pkg/kubelet/kubeclientmanager:go_default_library",
         "//pkg/kubelet/kubeletconfig:go_default_library",
         "//pkg/kubelet/kubeletconfig/configfiles:go_default_library",
         "//pkg/kubelet/server:go_default_library",

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	arktos "k8s.io/arktos-ext/pkg/generated/clientset/versioned"
 	"k8s.io/client-go/datapartition"
+	"k8s.io/kubernetes/pkg/kubelet/kubeclientmanager"
 	"math/rand"
 	"net"
 	"net/http"
@@ -515,6 +516,9 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 			}
 		}
 	}
+
+	// initialize the kubeclient manager
+	kubeclientmanager.NewKubeClientManager()
 
 	// Register current configuration with /configz endpoint
 	err = initConfigz(&s.KubeletConfiguration)

--- a/hack/arktos-up.sh
+++ b/hack/arktos-up.sh
@@ -107,7 +107,7 @@ do
 done
 
 if [ "x${GO_OUT}" == "x" ]; then
-    make -C "${KUBE_ROOT}" WHAT="cmd/kubectl cmd/hyperkube cmd/kube-apiserver cmd/kube-controller-manager cmd/workload-controller-manager cmd/cloud-controller-manager cmd/kubelet cmd/kube-proxy cmd/kube-scheduler"
+    make -j4 -C "${KUBE_ROOT}" WHAT="cmd/kubectl cmd/hyperkube cmd/kube-apiserver cmd/kube-controller-manager cmd/workload-controller-manager cmd/cloud-controller-manager cmd/kubelet cmd/kube-proxy cmd/kube-scheduler"
 else
     echo "skipped the build."
 fi

--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -290,6 +290,7 @@ filegroup(
         "//pkg/kubelet/events:all-srcs",
         "//pkg/kubelet/eviction:all-srcs",
         "//pkg/kubelet/images:all-srcs",
+        "//pkg/kubelet/kubeclientmanager:all-srcs",
         "//pkg/kubelet/kubeletconfig:all-srcs",
         "//pkg/kubelet/kuberuntime:all-srcs",
         "//pkg/kubelet/leaky:all-srcs",

--- a/pkg/kubelet/config/BUILD
+++ b/pkg/kubelet/config/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//pkg/kubelet/checkpointmanager:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/events:go_default_library",
+        "//pkg/kubelet/kubeclientmanager:go_default_library",
         "//pkg/kubelet/types:go_default_library",
         "//pkg/kubelet/util/format:go_default_library",
         "//pkg/util/config:go_default_library",

--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/events"
+	"k8s.io/kubernetes/pkg/kubelet/kubeclientmanager"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/util/config"
@@ -260,6 +261,10 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 			if ref.Annotations == nil {
 				ref.Annotations = make(map[string]string)
 			}
+
+			// Bookkeeping mapping between tenant and its origin apiserver
+			kubeclientmanager.ClientManager.RegisterTenantSourceServer(source, ref)
+
 			ref.Annotations[kubetypes.ConfigSourceAnnotationKey] = source
 			if existing, found := oldPods[ref.UID]; found {
 				pods[ref.UID] = existing

--- a/pkg/kubelet/kubeclientmanager/BUILD
+++ b/pkg/kubelet/kubeclientmanager/BUILD
@@ -1,0 +1,43 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["kubeclient_manager.go"],
+    importpath = "k8s.io/kubernetes/pkg/kubelet/kubeclientmanager",
+    deps = [
+        "//pkg/kubelet/types:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["kubeclient_manager_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/pkg/kubelet/kubeclientmanager/kubeclient_manager.go
+++ b/pkg/kubelet/kubeclientmanager/kubeclient_manager.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2020 Authors of Arktos.
+Copyright 2020 Authors of Arktos - file modified.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeclientmanager
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+
+	"k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+)
+
+/*
+This manager keeps a map between tenant name and its corresponding tenant partition apiserver id.
+This map is to be used together with kubeTPClients in the Kubelet struct to obtain the correct kubeclient
+*/
+type KubeClientManager struct {
+	tenant2api     map[string]int // tenant name -> tenant partition apiserver id
+	tenant2apiLock sync.RWMutex
+}
+
+var ClientManager *KubeClientManager
+var kubeclientManagerOnce sync.Once
+
+func NewKubeClientManager() {
+	kubeclientManagerOnce.Do(
+		newKubeClientManagerFunc(),
+	)
+}
+
+func newKubeClientManagerFunc() func() {
+	return func() {
+		ClientManager = &KubeClientManager{
+			tenant2api: make(map[string]int),
+		}
+		klog.Infof("kubeclient manager initialized %v", ClientManager)
+	}
+}
+
+func (manager *KubeClientManager) RegisterTenantSourceServer(source string, ref *v1.Pod) {
+	if len(ref.Tenant) == 0 || !strings.HasPrefix(source, kubetypes.ApiserverSource) {
+		klog.Warningf("unable to register tenant source : tenant='%s', source='%s'", ref.Tenant, source)
+		return
+	}
+
+	manager.tenant2apiLock.Lock()
+	defer manager.tenant2apiLock.Unlock()
+
+	key := strings.ToLower(ref.Tenant)
+	if source == kubetypes.ApiserverSource {
+		klog.Infof("source is '%s', will only use kube client #0", kubetypes.ApiserverSource)
+		manager.tenant2api[key] = 0
+		return
+	}
+
+	clientId, err := strconv.Atoi(source[len(kubetypes.ApiserverSource):])
+	if err != nil {
+		klog.Errorf("unable to get a tenant partition id, Err: %s", err)
+		return
+	}
+
+	if _, ok := manager.tenant2api[key]; !ok {
+		manager.tenant2api[key] = clientId
+		klog.Infof("added %d to the map, map has %+v", clientId, manager.tenant2api)
+	}
+}
+
+func (manager *KubeClientManager) GetTPClient(kubeClients []clientset.Interface, tenant string) clientset.Interface {
+	manager.tenant2apiLock.RLock()
+	defer manager.tenant2apiLock.RUnlock()
+	if kubeClients == nil || len(kubeClients) == 0 {
+		klog.Errorf("invalid kubeClients : %v", kubeClients)
+		return nil
+	}
+	pick := manager.pickClient(tenant)
+	klog.Infof("using client #%v for tenant '%s'", pick, tenant)
+	return kubeClients[pick]
+}
+
+func (manager *KubeClientManager) pickClient(tenant string) int {
+	pick, ok := manager.tenant2api[strings.ToLower(tenant)]
+	if !ok {
+		klog.Warningf("no registered client for tenant %s, defaulted to client #0", tenant)
+		pick = 0
+	}
+	return pick
+}

--- a/pkg/kubelet/kubeclientmanager/kubeclient_manager_test.go
+++ b/pkg/kubelet/kubeclientmanager/kubeclient_manager_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeclientmanager
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"reflect"
+	"testing"
+)
+
+func TestNewKubeClientManagerRunOnce(t *testing.T) {
+	NewKubeClientManager()
+	ClientManager.tenant2api["john"] = 1
+	NewKubeClientManager()
+
+	if len(ClientManager.tenant2api) != 1 {
+		t.Error("KubeClientManager has been initialized more than once")
+	}
+}
+
+func TestRegisterTenantSourceServer(t *testing.T) {
+	testcases := []struct {
+		pod         *v1.Pod
+		source      string
+		expectedMap map[string]int
+	}{
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Tenant: "",
+				},
+			},
+			source:      "api",
+			expectedMap: map[string]int{},
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Tenant: "jane",
+				},
+			},
+			source:      "noprefix",
+			expectedMap: map[string]int{},
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Tenant: "john",
+				},
+			},
+			source: "api",
+			expectedMap: map[string]int{
+				"john": 0,
+			},
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Tenant: "alex",
+				},
+			},
+			source: "api0",
+			expectedMap: map[string]int{
+				"alex": 0,
+			},
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Tenant: "AlEX",
+				},
+			},
+			source: "api1",
+			expectedMap: map[string]int{
+				"alex": 1,
+			},
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Tenant: "AlEX",
+				},
+			},
+			source: "api999",
+			expectedMap: map[string]int{
+				"alex": 999,
+			},
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Tenant: "AlEX",
+				},
+			},
+			source:      "apixxx",
+			expectedMap: map[string]int{},
+		},
+	}
+
+	for i, test := range testcases {
+		newKubeClientManagerFunc()()
+		ClientManager.RegisterTenantSourceServer(test.source, test.pod)
+		if !reflect.DeepEqual(test.expectedMap, ClientManager.tenant2api) {
+			t.Errorf("case %d faile: expected %v, got %v", i, test.expectedMap, ClientManager.tenant2api)
+		}
+	}
+}
+
+func TestGetTPClient(t *testing.T) {
+	client0 := &clientset.Clientset{}
+	client1 := &clientset.Clientset{}
+
+	testcases := []struct {
+		kubeClients    []clientset.Interface
+		tenant         string
+		tenant2api     map[string]int
+		expectedClient clientset.Interface
+	}{
+		{
+			kubeClients: nil, // invalid Client array
+			tenant:      "ron",
+			tenant2api: map[string]int{
+				"kip": 1,
+			},
+			expectedClient: nil,
+		},
+		{
+			kubeClients: []clientset.Interface{ // invalid Client array
+			},
+			tenant: "jane",
+			tenant2api: map[string]int{
+				"ale": 1,
+			},
+			expectedClient: nil,
+		},
+		{
+			kubeClients: []clientset.Interface{
+				client0,
+				client1,
+			},
+			tenant: "apple",
+			tenant2api: map[string]int{
+				"apple": 0,
+			},
+			expectedClient: client0,
+		},
+		{
+			kubeClients: []clientset.Interface{
+				client0,
+				client1,
+			},
+			tenant: "apple",
+			tenant2api: map[string]int{
+				"apple": 1,
+			},
+			expectedClient: client1,
+		},
+		{
+			kubeClients: []clientset.Interface{
+				client0,
+				client1,
+			},
+			tenant: "alex",
+			tenant2api: map[string]int{
+				"joe":   1,
+				"katie": 0,
+			},
+			expectedClient: client0,
+		},
+	}
+	for i, test := range testcases {
+		newKubeClientManagerFunc()()
+		ClientManager.tenant2api = test.tenant2api
+		actualClient := ClientManager.GetTPClient(test.kubeClients, test.tenant)
+		if test.expectedClient != actualClient {
+			t.Errorf("case %d failed: expected %v, got %v", i, test.expectedClient, actualClient)
+		}
+	}
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -490,6 +490,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		hostnameOverridden:                      len(hostnameOverride) > 0,
 		nodeName:                                nodeName,
 		kubeClient:                              kubeDeps.KubeClient,
+		kubeTPClients:                           kubeDeps.KubeTPClients,
 		heartbeatClient:                         kubeDeps.HeartbeatClient,
 		onRepeatedHeartbeatFailure:              kubeDeps.OnHeartbeatFailure,
 		rootDirectory:                           rootDirectory,
@@ -905,7 +906,8 @@ type Kubelet struct {
 
 	nodeName        types.NodeName
 	runtimeCache    kubecontainer.RuntimeCache
-	kubeClient      clientset.Interface
+	kubeClient      clientset.Interface // TO DO: to be removed
+	kubeTPClients   []clientset.Interface
 	heartbeatClient clientset.Interface
 	iptClient       utilipt.Interface
 	rootDirectory   string


### PR DESCRIPTION
### Changes
The new kubeclient manager provides the kubeclient for a specific tenant. In specific:

1. registers tenant with its corresponding apisever id
2. looks up and returns kubeclient based on tenant/apiserver id mapping

The actual usage of this kubeclient manager will be in a few following PRs.

### Validation
1. Arktos-up came up correctly
2. Created and deleted the follow resources correctly
```
kubectl create tenant zeth
kubectl create -f /tmp/web.yaml --tenant zeth
kubectl create deployment nginx --image=nginx --tenant zeth
kubectl create -f vanilla.yaml --tenant zeth

kubectl create tenant apple
kubectl create -f /tmp/web.yaml --tenant apple
kubectl create deployment nginx --image=nginx --tenant apple
kubectl create -f vanilla.yaml --tenant apple
```