### PR TITLE
1.18 Goaway changes

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -139,8 +139,8 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, stopCh <-chan struct{}) error
 		klog.Errorf("unable to register configz: %c", err)
 	}
 
-	// Setup any healthz checks we will want to use.
-	var checks []healthz.HealthzChecker
+	// Setup any health checks we will want to use.
+	var checks []healthz.HealthChecker
 	var electionChecker *leaderelection.HealthzAdaptor
 	if c.ComponentConfig.Generic.LeaderElection.LeaderElect {
 		electionChecker = leaderelection.NewLeaderHealthzAdaptor(time.Second * 20)

--- a/cmd/controller-manager/app/serve.go
+++ b/cmd/controller-manager/app/serve.go
@@ -52,7 +52,7 @@ func BuildHandlerChain(apiHandler http.Handler, authorizationInfo *apiserver.Aut
 }
 
 // NewBaseHandler takes in CompletedConfig and returns a handler.
-func NewBaseHandler(c *componentbaseconfig.DebuggingConfiguration, checks ...healthz.HealthzChecker) *mux.PathRecorderMux {
+func NewBaseHandler(c *componentbaseconfig.DebuggingConfiguration, checks ...healthz.HealthChecker) *mux.PathRecorderMux {
 	mux := mux.NewPathRecorderMux("controller-manager")
 	healthz.InstallHandler(mux, checks...)
 	if c.EnableProfiling {

--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -154,8 +154,8 @@ func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delega
 		return nil, err
 	}
 
-	err = aggregatorServer.GenericAPIServer.AddHealthzChecks(
-		makeAPIServiceAvailableHealthzCheck(
+	err = aggregatorServer.GenericAPIServer.AddHealthChecks(
+		makeAPIServiceAvailableHealthCheck(
 			"autoregister-completion",
 			apiServices,
 			aggregatorServer.APIRegistrationInformers.Apiregistration().InternalVersion().APIServices(),
@@ -187,9 +187,9 @@ func makeAPIService(gv schema.GroupVersion) *apiregistration.APIService {
 	}
 }
 
-// makeAPIServiceAvailableHealthzCheck returns a healthz check that returns healthy
+// makeAPIServiceAvailableHealthCheck returns a healthz check that returns healthy
 // once all of the specified services have been observed to be available at least once.
-func makeAPIServiceAvailableHealthzCheck(name string, apiServices []*apiregistration.APIService, apiServiceInformer informers.APIServiceInformer) healthz.HealthzChecker {
+func makeAPIServiceAvailableHealthCheck(name string, apiServices []*apiregistration.APIService, apiServiceInformer informers.APIServiceInformer) healthz.HealthChecker {
 	// Track the auto-registered API services that have not been observed to be available yet
 	pendingServiceNamesLock := &sync.RWMutex{}
 	pendingServiceNames := sets.NewString()

--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -154,7 +154,7 @@ func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delega
 		return nil, err
 	}
 
-	err = aggregatorServer.GenericAPIServer.AddHealthChecks(
+	err = aggregatorServer.GenericAPIServer.AddBootSequenceHealthChecks(
 		makeAPIServiceAvailableHealthCheck(
 			"autoregister-completion",
 			apiServices,

--- a/cmd/kube-apiserver/app/testing/BUILD
+++ b/cmd/kube-apiserver/app/testing/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/server/healthz:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
         "//staging/src/k8s.io/client-go/datapartition:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -33,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
-	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -48,8 +47,6 @@ type TearDownFunc func()
 type TestServerInstanceOptions struct {
 	// DisableStorageCleanup Disable the automatic storage cleanup
 	DisableStorageCleanup bool
-	// Injected health
-	InjectedHealthChecker healthz.HealthChecker
 }
 
 // TestServer return values supplied by kube-test-ApiServer
@@ -150,17 +147,10 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 	t.Logf("runtime-config=%v", completedOptions.APIEnablement.RuntimeConfig)
 	t.Logf("Starting kube-apiserver on port %d...", s.SecureServing.BindPort)
 	server, err := app.CreateServerChain(completedOptions, stopCh)
-
-	if instanceOptions.InjectedHealthChecker != nil {
-		t.Logf("Adding health check with delay %v %v", s.GenericServerRunOptions.MaxStartupSequenceDuration, instanceOptions.InjectedHealthChecker.Name())
-		if err := server.AddDelayedHealthzChecks(s.GenericServerRunOptions.MaxStartupSequenceDuration, instanceOptions.InjectedHealthChecker); err != nil {
-			return result, err
-		}
-	}
-
 	if err != nil {
 		return result, fmt.Errorf("failed to create server chain: %v", err)
 	}
+	
 	errCh := make(chan error)
 	go func(stopCh <-chan struct{}) {
 		if err := server.PrepareRun().Run(stopCh); err != nil {

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -150,7 +150,7 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 	if err != nil {
 		return result, fmt.Errorf("failed to create server chain: %v", err)
 	}
-	
+
 	errCh := make(chan error)
 	go func(stopCh <-chan struct{}) {
 		if err := server.PrepareRun().Run(stopCh); err != nil {

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -49,7 +49,7 @@ type TestServerInstanceOptions struct {
 	// DisableStorageCleanup Disable the automatic storage cleanup
 	DisableStorageCleanup bool
 	// Injected health
-	InjectedHealthzChecker healthz.HealthzChecker
+	InjectedHealthChecker healthz.HealthChecker
 }
 
 // TestServer return values supplied by kube-test-ApiServer
@@ -151,9 +151,11 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 	t.Logf("Starting kube-apiserver on port %d...", s.SecureServing.BindPort)
 	server, err := app.CreateServerChain(completedOptions, stopCh)
 
-	if instanceOptions.InjectedHealthzChecker != nil {
-		t.Logf("Adding health check with delay %v %v", s.GenericServerRunOptions.MaxStartupSequenceDuration, instanceOptions.InjectedHealthzChecker.Name())
-		server.AddDelayedHealthzChecks(s.GenericServerRunOptions.MaxStartupSequenceDuration, instanceOptions.InjectedHealthzChecker)
+	if instanceOptions.InjectedHealthChecker != nil {
+		t.Logf("Adding health check with delay %v %v", s.GenericServerRunOptions.MaxStartupSequenceDuration, instanceOptions.InjectedHealthChecker.Name())
+		if err := server.AddDelayedHealthzChecks(s.GenericServerRunOptions.MaxStartupSequenceDuration, instanceOptions.InjectedHealthChecker); err != nil {
+			return result, err
+		}
 	}
 
 	if err != nil {

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -173,7 +173,7 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 	}
 
 	// Setup any healthz checks we will want to use.
-	var checks []healthz.HealthzChecker
+	var checks []healthz.HealthChecker
 	var electionChecker *leaderelection.HealthzAdaptor
 	if c.ComponentConfig.Generic.LeaderElection.LeaderElect {
 		electionChecker = leaderelection.NewLeaderHealthzAdaptor(time.Second * 20)

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -198,7 +198,7 @@ func Run(cc schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}) error
 	}
 
 	// Setup healthz checks.
-	var checks []healthz.HealthzChecker
+	var checks []healthz.HealthChecker
 	if cc.ComponentConfig.LeaderElection.LeaderElect {
 		checks = append(checks, cc.LeaderElection.WatchDog)
 	}
@@ -316,7 +316,7 @@ func newMetricsHandler(config *kubeschedulerconfig.KubeSchedulerConfiguration) h
 // newHealthzHandler creates a healthz server from the config, and will also
 // embed the metrics handler if the healthz and metrics address configurations
 // are the same.
-func newHealthzHandler(config *kubeschedulerconfig.KubeSchedulerConfiguration, separateMetrics bool, checks ...healthz.HealthzChecker) http.Handler {
+func newHealthzHandler(config *kubeschedulerconfig.KubeSchedulerConfiguration, separateMetrics bool, checks ...healthz.HealthChecker) http.Handler {
 	pathRecorderMux := mux.NewPathRecorderMux("kube-scheduler")
 	healthz.InstallHandler(pathRecorderMux, checks...)
 	if !separateMetrics {

--- a/cmd/workload-controller-manager/app/controllermanager.go
+++ b/cmd/workload-controller-manager/app/controllermanager.go
@@ -93,7 +93,7 @@ const (
 
 func StartControllerManager(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 	// Setup any healthz checks we will want to use.
-	var checks []healthz.HealthzChecker
+	var checks []healthz.HealthChecker
 
 	// Start the controller manager HTTP server
 	// unsecuredMux is the handler for these controller *after* authn/authz filters have been applied

--- a/cmd/workload-controller-manager/app/serve.go
+++ b/cmd/workload-controller-manager/app/serve.go
@@ -52,7 +52,7 @@ func BuildHandlerChain(apiHandler http.Handler, authorizationInfo *apiserver.Aut
 }
 
 // NewBaseHandler takes in CompletedConfig and returns a handler.
-func NewBaseHandler(c *componentbaseconfig.DebuggingConfiguration, checks ...healthz.HealthzChecker) *mux.PathRecorderMux {
+func NewBaseHandler(c *componentbaseconfig.DebuggingConfiguration, checks ...healthz.HealthChecker) *mux.PathRecorderMux {
 	mux := mux.NewPathRecorderMux("controller-manager")
 	healthz.InstallHandler(mux, checks...)
 	if c.EnableProfiling {

--- a/hack/arktos_copyright_copied_k8s_files
+++ b/hack/arktos_copyright_copied_k8s_files
@@ -23,10 +23,13 @@ staging/src/k8s.io/apiserver/pkg/endpoints/discovery/util.go
 staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response_test.go
 staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
 staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+staging/src/k8s.io/apiserver/pkg/server/filters/goaway.go
+staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
 staging/src/k8s.io/apiserver/pkg/server/healthz.go
 staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
 staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
 staging/src/k8s.io/apiserver/pkg/server/hooks.go
+staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
 staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object.go
 staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
 staging/src/k8s.io/apiserver/pkg/storage/etcd3/api_object_versioner.go

--- a/hack/arktos_copyright_copied_k8s_files
+++ b/hack/arktos_copyright_copied_k8s_files
@@ -1,3 +1,5 @@
+cmd/cloud-controller-manager/app/controllermanager.go
+cmd/controller-manager/app/serve.go
 pkg/cloudfabric-controller/client_builder.go
 pkg/cloudfabric-controller/controller_ref_manager.go
 pkg/cloudfabric-controller/controller_ref_manager_test.go
@@ -21,6 +23,10 @@ staging/src/k8s.io/apiserver/pkg/endpoints/discovery/util.go
 staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response_test.go
 staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
 staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+staging/src/k8s.io/apiserver/pkg/server/healthz.go
+staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
+staging/src/k8s.io/apiserver/pkg/server/hooks.go
 staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object.go
 staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
 staging/src/k8s.io/apiserver/pkg/storage/etcd3/api_object_versioner.go

--- a/hack/arktos_copyright_copied_k8s_files
+++ b/hack/arktos_copyright_copied_k8s_files
@@ -30,6 +30,7 @@ staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
 staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
 staging/src/k8s.io/apiserver/pkg/server/hooks.go
 staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
+staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
 staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object.go
 staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
 staging/src/k8s.io/apiserver/pkg/storage/etcd3/api_object_versioner.go
@@ -50,4 +51,3 @@ staging/src/k8s.io/apiserver/pkg/storage/etcd3/testing/utils.go
 staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/grpc_service.go
 staging/src/k8s.io/cli-runtime/pkg/resource/scheme.go
 test/e2e/node/node_problem_detector.go
-

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -404,7 +404,7 @@ func (m *Master) InstallLegacyAPI(c *completedConfig, restOptionsGetter generic.
 
 func (m *Master) installTunneler(nodeTunneler tunneler.Tunneler, nodeClient corev1client.NodeInterface) {
 	nodeTunneler.Run(nodeAddressProvider{nodeClient}.externalAddresses)
-	m.GenericAPIServer.AddHealthzChecks(healthz.NamedCheck("SSH Tunnel Check", tunneler.TunnelSyncHealthChecker(nodeTunneler)))
+	m.GenericAPIServer.AddHealthChecks(healthz.NamedCheck("SSH Tunnel Check", tunneler.TunnelSyncHealthChecker(nodeTunneler)))
 	prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "apiserver_proxy_tunnel_sync_duration_seconds",
 		Help: "The time since the last successful synchronization of the SSH tunnels for proxy requests.",

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -209,7 +209,8 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{Name: "system:discovery"},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("get").URLs(
-					"/readyz", "/healthz", "/version", "/version/",
+					"/livez", "/readyz", "/healthz",
+					"/version", "/version/",
 					"/openapi", "/openapi/*",
 					"/api", "/api/*",
 					"/apis", "/apis/*",
@@ -229,7 +230,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{Name: "system:public-info-viewer"},
 			Rules: []rbacv1.PolicyRule{
 				rbacv1helpers.NewRule("get").URLs(
-					"/readyz", "/healthz", "/version", "/version/",
+					"/livez", "/readyz", "/healthz", "/version", "/version/",
 				).RuleOrDie(),
 			},
 		},

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -536,6 +536,7 @@ items:
     - /apis
     - /apis/*
     - /healthz
+    - /livez
     - /openapi
     - /openapi/*
     - /readyz
@@ -1181,6 +1182,7 @@ items:
   rules:
   - nonResourceURLs:
     - /healthz
+    - /livez
     - /readyz
     - /version
     - /version/

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -21,6 +21,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -135,6 +135,8 @@ type Config struct {
 	DiscoveryAddresses discovery.Addresses
 	// The default set of healthz checks. There might be more added via AddHealthChecks dynamically.
 	HealthzChecks []healthz.HealthChecker
+	// The default set of livez checks. There might be more added via AddHealthChecks dynamically.
+	LivezChecks []healthz.HealthChecker
 	// The default set of readyz-only checks. There might be more added via AddReadyzChecks dynamically.
 	ReadyzChecks []healthz.HealthChecker
 	// LegacyAPIGroupPrefixes is used to set up URL parsing for authorization and for validating requests
@@ -161,9 +163,9 @@ type Config struct {
 
 	// This represents the maximum amount of time it should take for apiserver to complete its startup
 	// sequence and become healthy. From apiserver's start time to when this amount of time has
-	// elapsed, /healthz will assume that unfinished post-start hooks will complete successfully and
+	// elapsed, /livez will assume that unfinished post-start hooks will complete successfully and
 	// therefore return true.
-	MaxStartupSequenceDuration time.Duration
+	LivezGracePeriod time.Duration
 	// The limit on the total size increase all "copy" operations in a json
 	// patch may cause.
 	// This affects all places that applies json patch in the binary.
@@ -269,6 +271,7 @@ func NewConfig(codecs serializer.CodecFactory) *Config {
 		DisabledPostStartHooks:      sets.NewString(),
 		HealthzChecks:               append([]healthz.HealthChecker{}, defaultHealthChecks...),
 		ReadyzChecks:                append([]healthz.HealthChecker{}, defaultHealthChecks...),
+		LivezChecks:                 append([]healthz.HealthChecker{}, defaultHealthChecks...),
 		EnableIndex:                 true,
 		EnableDiscovery:             true,
 		EnableProfiling:             true,
@@ -277,7 +280,7 @@ func NewConfig(codecs serializer.CodecFactory) *Config {
 		MaxMutatingRequestsInFlight: 200,
 		RequestTimeout:              time.Duration(60) * time.Second,
 		MinRequestTimeout:           1800,
-		MaxStartupSequenceDuration:  time.Duration(0),
+		LivezGracePeriod:            time.Duration(0),
 		// 10MB is the recommended maximum client request size in bytes
 		// the etcd server should accept. See
 		// https://github.com/etcd-io/etcd/blob/release-3.3/etcdserver/server.go#L90.
@@ -498,15 +501,16 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 		preShutdownHooks:       map[string]preShutdownHookEntry{},
 		disabledPostStartHooks: c.DisabledPostStartHooks,
 
-		healthzChecks:              c.HealthzChecks,
-		readyzChecks:               c.ReadyzChecks,
-		readinessStopCh:            make(chan struct{}),
-		maxStartupSequenceDuration: c.MaxStartupSequenceDuration,
+		healthzChecks:    c.HealthzChecks,
+		livezChecks:      c.LivezChecks,
+		readyzChecks:     c.ReadyzChecks,
+		readinessStopCh:  make(chan struct{}),
+		livezGracePeriod: c.LivezGracePeriod,
 
 		DiscoveryGroupManager: discovery.NewRootAPIsHandler(c.DiscoveryAddresses, c.Serializer),
 
 		maxRequestBodyBytes: c.MaxRequestBodyBytes,
-		healthzClock:        clock.RealClock{},
+		livezClock:          clock.RealClock{},
 	}
 
 	for {
@@ -552,9 +556,7 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 		if skip {
 			continue
 		}
-
-		s.healthzChecks = append(s.healthzChecks, delegateCheck)
-		s.readyzChecks = append(s.readyzChecks, delegateCheck)
+		s.AddHealthChecks(delegateCheck)
 	}
 
 	s.listedPathProvider = routes.ListedPathProviders{s.listedPathProvider, delegationTarget}

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -133,10 +133,10 @@ type Config struct {
 	// DiscoveryAddresses is used to build the IPs pass to discovery. If nil, the ExternalAddress is
 	// always reported
 	DiscoveryAddresses discovery.Addresses
-	// The default set of healthz checks. There might be more added via AddHealthzChecks dynamically.
-	HealthzChecks []healthz.HealthzChecker
+	// The default set of healthz checks. There might be more added via AddHealthChecks dynamically.
+	HealthzChecks []healthz.HealthChecker
 	// The default set of readyz-only checks. There might be more added via AddReadyzChecks dynamically.
-	ReadyzChecks []healthz.HealthzChecker
+	ReadyzChecks []healthz.HealthChecker
 	// LegacyAPIGroupPrefixes is used to set up URL parsing for authorization and for validating requests
 	// to InstallLegacyAPIGroup. New API servers don't generally have legacy groups at all.
 	LegacyAPIGroupPrefixes sets.String
@@ -260,15 +260,15 @@ type AuthorizationInfo struct {
 
 // NewConfig returns a Config struct with the default values
 func NewConfig(codecs serializer.CodecFactory) *Config {
-	defaultHealthChecks := []healthz.HealthzChecker{healthz.PingHealthz, healthz.LogHealthz}
+	defaultHealthChecks := []healthz.HealthChecker{healthz.PingHealthz, healthz.LogHealthz}
 	return &Config{
 		Serializer:                  codecs,
 		BuildHandlerChainFunc:       DefaultBuildHandlerChain,
 		HandlerChainWaitGroup:       new(utilwaitgroup.SafeWaitGroup),
 		LegacyAPIGroupPrefixes:      sets.NewString(DefaultLegacyAPIPrefix),
 		DisabledPostStartHooks:      sets.NewString(),
-		HealthzChecks:               append([]healthz.HealthzChecker{}, defaultHealthChecks...),
-		ReadyzChecks:                append([]healthz.HealthzChecker{}, defaultHealthChecks...),
+		HealthzChecks:               append([]healthz.HealthChecker{}, defaultHealthChecks...),
+		ReadyzChecks:                append([]healthz.HealthChecker{}, defaultHealthChecks...),
 		EnableIndex:                 true,
 		EnableDiscovery:             true,
 		EnableProfiling:             true,

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -182,6 +182,12 @@ type Config struct {
 	// Predicate which is true for paths of long-running http requests
 	LongRunningFunc apirequest.LongRunningRequestCheck
 
+	// GoawayChance is the probability that send a GOAWAY to HTTP/2 clients. When client received
+	// GOAWAY, the in-flight requests will not be affected and new requests will use
+	// a new TCP connection to triggering re-balancing to another server behind the load balance.
+	// Default to 0, means never send GOAWAY. Max is 0.02 to prevent break the apiserver.
+	GoawayChance float64
+
 	// MergedResourceConfig indicates which groupVersion enabled and its resources enabled/disabled.
 	// This is composed of genericapiserver defaultAPIResourceConfig and those parsed from flags.
 	// If not specify any in flags, then genericapiserver will only enable defaultAPIResourceConfig.
@@ -588,6 +594,9 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	handler = genericfilters.WithTimeoutForNonLongRunningRequests(handler, c.LongRunningFunc, c.RequestTimeout)
 	handler = genericfilters.WithWaitGroup(handler, c.LongRunningFunc, c.HandlerChainWaitGroup)
 	handler = genericapifilters.WithRequestInfo(handler, c.RequestInfoResolver)
+	if c.SecureServing != nil && !c.SecureServing.DisableHTTP2 && c.GoawayChance > 0 {
+		handler = genericfilters.WithProbabilisticGoaway(handler, c.GoawayChance)
+	}
 	handler = genericfilters.WithPanicRecovery(handler)
 	return handler
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -246,6 +246,9 @@ type SecureServingInfo struct {
 	// HTTP2MaxStreamsPerConnection is the limit that the api server imposes on each client.
 	// A value of zero means to use the default provided by golang's HTTP/2 support.
 	HTTP2MaxStreamsPerConnection int
+
+	// DisableHTTP2 indicates that http2 should not be enabled.
+	DisableHTTP2 bool
 }
 
 type AuthenticationInfo struct {

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http/httputil"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/request/fakeuser"
 	"k8s.io/apiserver/pkg/server/healthz"
@@ -105,31 +106,36 @@ func TestNewWithDelegate(t *testing.T) {
 	// Wait for the hooks to finish before checking the response
 	<-delegatePostStartHookChan
 	<-wrappingPostStartHookChan
-
-	checkPath(server.URL, http.StatusOK, `{
-  "paths": [
-    "/apis",
-    "/bar",
-    "/foo",
-    "/healthz",
-    "/healthz/delegate-health",
-    "/healthz/log",
-    "/healthz/ping",
-    "/healthz/poststarthook/delegate-post-start-hook",
-    "/healthz/poststarthook/generic-apiserver-start-informers",
-    "/healthz/poststarthook/wrapping-post-start-hook",
-    "/healthz/wrapping-health",
-    "/metrics",
-    "/readyz",
-    "/readyz/delegate-health",
-    "/readyz/log",
-    "/readyz/ping",
-    "/readyz/poststarthook/delegate-post-start-hook",
-    "/readyz/poststarthook/generic-apiserver-start-informers",
-    "/readyz/poststarthook/wrapping-post-start-hook",
-    "/readyz/shutdown"
-  ]
-}`, t)
+	expectedPaths := []string{
+		"/apis",
+		"/bar",
+		"/foo",
+		"/healthz",
+		"/healthz/delegate-health",
+		"/healthz/log",
+		"/healthz/ping",
+		"/healthz/poststarthook/delegate-post-start-hook",
+		"/healthz/poststarthook/generic-apiserver-start-informers",
+		"/healthz/poststarthook/wrapping-post-start-hook",
+		"/healthz/wrapping-health",
+		"/livez",
+		"/livez/delegate-health",
+		"/livez/log",
+		"/livez/ping",
+		"/livez/poststarthook/delegate-post-start-hook",
+		"/livez/poststarthook/generic-apiserver-start-informers",
+		"/livez/poststarthook/wrapping-post-start-hook",
+		"/metrics",
+		"/readyz",
+		"/readyz/delegate-health",
+		"/readyz/log",
+		"/readyz/ping",
+		"/readyz/poststarthook/delegate-post-start-hook",
+		"/readyz/poststarthook/generic-apiserver-start-informers",
+		"/readyz/poststarthook/wrapping-post-start-hook",
+		"/readyz/shutdown",
+	}
+	checkExpectedPathsAtRoot(server.URL, expectedPaths, t)
 	checkPath(server.URL+"/healthz", http.StatusInternalServerError, `[+]ping ok
 [+]log ok
 [-]wrapping-health failed: reason withheld
@@ -151,22 +157,57 @@ healthz check failed
 }
 
 func checkPath(url string, expectedStatusCode int, expectedBody string, t *testing.T) {
-	resp, err := http.Get(url)
-	if err != nil {
-		t.Fatal(err)
-	}
-	dump, _ := httputil.DumpResponse(resp, true)
-	t.Log(string(dump))
+	t.Run(url, func(t *testing.T) {
+		resp, err := http.Get(url)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dump, _ := httputil.DumpResponse(resp, true)
+		t.Log(string(dump))
 
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if e, a := expectedBody, string(body); e != a {
-		t.Errorf("%q expected %v, got %v", url, e, a)
-	}
-	if e, a := expectedStatusCode, resp.StatusCode; e != a {
-		t.Errorf("%q expected %v, got %v", url, e, a)
-	}
+		if e, a := expectedBody, string(body); e != a {
+			t.Errorf("%q expected %v, got %v", url, e, a)
+		}
+		if e, a := expectedStatusCode, resp.StatusCode; e != a {
+			t.Errorf("%q expected %v, got %v", url, e, a)
+		}
+	})
+}
+
+func checkExpectedPathsAtRoot(url string, expectedPaths []string, t *testing.T) {
+	t.Run(url, func(t *testing.T) {
+		resp, err := http.Get(url)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dump, _ := httputil.DumpResponse(resp, true)
+		t.Log(string(dump))
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var result map[string]interface{}
+		json.Unmarshal(body, &result)
+		paths, ok := result["paths"].([]interface{})
+		if !ok {
+			t.Errorf("paths not found")
+		}
+		pathset := sets.NewString()
+		for _, p := range paths {
+			pathset.Insert(p.(string))
+		}
+		expectedset := sets.NewString(expectedPaths...)
+		for _, p := range pathset.Difference(expectedset) {
+			t.Errorf("Got %v path, which we did not expect", p)
+		}
+		for _, p := range expectedset.Difference(pathset) {
+			t.Errorf(" Expected %v path which we did not get", p)
+		}
+	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = [
         "content_type_test.go",
         "cors_test.go",
+        "goaway_test.go",
         "maxinflight_test.go",
         "timeout_test.go",
     ],
@@ -25,6 +26,7 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/filters:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
+        "//vendor/golang.org/x/net/http2:go_default_library",
     ],
 )
 
@@ -34,6 +36,7 @@ go_library(
         "content_type.go",
         "cors.go",
         "doc.go",
+        "goaway.go",
         "longrunning.go",
         "maxinflight.go",
         "timeout.go",

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/goaway.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/goaway.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"math/rand"
+	"net/http"
+	"sync"
+)
+
+// GoawayDecider decides if server should send a GOAWAY
+type GoawayDecider interface {
+	Goaway(r *http.Request) bool
+}
+
+var (
+	// randPool used to get a rand.Rand and generate a random number thread-safely,
+	// which improve the performance of using rand.Rand with a locker
+	randPool = &sync.Pool{
+		New: func() interface{} {
+			return rand.New(rand.NewSource(rand.Int63()))
+		},
+	}
+)
+
+// WithProbabilisticGoaway returns an http.Handler that send GOAWAY probabilistically
+// according to the given chance for HTTP2 requests. After client receive GOAWAY,
+// the in-flight long-running requests will not be influenced, and the new requests
+// will use a new TCP connection to re-balancing to another server behind the load balance.
+func WithProbabilisticGoaway(inner http.Handler, chance float64) http.Handler {
+	return &goaway{
+		handler: inner,
+		decider: &probabilisticGoawayDecider{
+			chance: chance,
+			next: func() float64 {
+				rnd := randPool.Get().(*rand.Rand)
+				ret := rnd.Float64()
+				randPool.Put(rnd)
+				return ret
+			},
+		},
+	}
+}
+
+// goaway send a GOAWAY to client according to decider for HTTP2 requests
+type goaway struct {
+	handler http.Handler
+	decider GoawayDecider
+}
+
+// ServeHTTP implement HTTP handler
+func (h *goaway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Proto == "HTTP/2.0" && h.decider.Goaway(r) {
+		// Send a GOAWAY and tear down the TCP connection when idle.
+		w.Header().Set("Connection", "close")
+	}
+
+	h.handler.ServeHTTP(w, r)
+}
+
+// probabilisticGoawayDecider send GOAWAY probabilistically according to chance
+type probabilisticGoawayDecider struct {
+	chance float64
+	next   func() float64
+}
+
+// Goaway implement GoawayDecider
+func (p *probabilisticGoawayDecider) Goaway(r *http.Request) bool {
+	if p.next() < p.chance {
+		return true
+	}
+
+	return false
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/goaway_test.go
@@ -1,0 +1,309 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"crypto/tls"
+	"io"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/net/http2"
+)
+
+func TestProbabilisticGoawayDecider(t *testing.T) {
+	cases := []struct {
+		name         string
+		chance       float64
+		nextFn       func(chance float64) func() float64
+		expectGOAWAY bool
+	}{
+		{
+			name:   "always not GOAWAY",
+			chance: 0,
+			nextFn: func(chance float64) func() float64 {
+				return rand.Float64
+			},
+			expectGOAWAY: false,
+		},
+		{
+			name:   "always GOAWAY",
+			chance: 1,
+			nextFn: func(chance float64) func() float64 {
+				return rand.Float64
+			},
+			expectGOAWAY: true,
+		},
+		{
+			name:   "hit GOAWAY",
+			chance: rand.Float64() + 0.01,
+			nextFn: func(chance float64) func() float64 {
+				return func() float64 {
+					return chance - 0.001
+				}
+			},
+			expectGOAWAY: true,
+		},
+		{
+			name:   "does not hit GOAWAY",
+			chance: rand.Float64() + 0.01,
+			nextFn: func(chance float64) func() float64 {
+				return func() float64 {
+					return chance + 0.001
+				}
+			},
+			expectGOAWAY: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := probabilisticGoawayDecider{chance: tc.chance, next: tc.nextFn(tc.chance)}
+			result := d.Goaway(nil)
+			if result != tc.expectGOAWAY {
+				t.Errorf("expect GOAWAY: %v, got: %v", tc.expectGOAWAY, result)
+			}
+		})
+	}
+}
+
+// TestClientReceivedGOAWAY tests the in-flight watch requests will not be affected and new requests use a
+// connection after client received GOAWAY, and server response watch request with GOAWAY will not break client
+// watching body read.
+func TestClientReceivedGOAWAY(t *testing.T) {
+	const (
+		urlNormal          = "/normal"
+		urlWatch           = "/watch"
+		urlGoaway          = "/goaway"
+		urlWatchWithGoaway = "/watch-with-goaway"
+	)
+
+	const (
+		// indicate the bytes watch request will be sent
+		// used to check if watch request was broke by GOAWAY
+		watchExpectSendBytes = 5
+	)
+
+	watchHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timer := time.NewTicker(time.Second)
+
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(200)
+
+		flusher, _ := w.(http.Flusher)
+		flusher.Flush()
+
+		count := 0
+		for {
+			select {
+			case <-timer.C:
+				n, err := w.Write([]byte("w"))
+				if err != nil {
+					return
+				}
+				flusher.Flush()
+				count += n
+				if count == watchExpectSendBytes {
+					return
+				}
+			}
+		}
+	})
+
+	mux := http.NewServeMux()
+	mux.Handle(urlNormal, WithProbabilisticGoaway(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello"))
+		return
+	}), 0))
+	mux.Handle(urlWatch, WithProbabilisticGoaway(watchHandler, 0))
+	mux.Handle(urlGoaway, WithProbabilisticGoaway(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello"))
+		return
+	}), 1))
+	mux.Handle(urlWatchWithGoaway, WithProbabilisticGoaway(watchHandler, 1))
+
+	s := httptest.NewUnstartedServer(mux)
+
+	http2Options := &http2.Server{}
+
+	if err := http2.ConfigureServer(s.Config, http2Options); err != nil {
+		t.Fatalf("failed to configure test server to be HTTP2 server, err: %v", err)
+	}
+
+	s.TLS = s.Config.TLSConfig
+	s.StartTLS()
+	defer s.Close()
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{http2.NextProtoTLS},
+	}
+
+	cases := []struct {
+		name string
+		reqs []string
+		// expectConnections always equals to GOAWAY requests(urlGoaway or urlWatchWithGoaway) + 1
+		expectConnections int
+	}{
+		{
+			name:              "all normal requests use only one connection",
+			reqs:              []string{urlNormal, urlNormal, urlNormal},
+			expectConnections: 1,
+		},
+		{
+			name:              "got GOAWAY after set-up watch",
+			reqs:              []string{urlNormal, urlWatch, urlGoaway, urlNormal, urlNormal},
+			expectConnections: 2,
+		},
+		{
+			name:              "got GOAWAY after set-up watch, and set-up a new watch",
+			reqs:              []string{urlNormal, urlWatch, urlGoaway, urlWatch, urlNormal, urlNormal},
+			expectConnections: 2,
+		},
+		{
+			name:              "got 2 GOAWAY after set-up watch",
+			reqs:              []string{urlNormal, urlWatch, urlGoaway, urlGoaway, urlNormal, urlNormal},
+			expectConnections: 3,
+		},
+		{
+			name:              "combine with watch-with-goaway",
+			reqs:              []string{urlNormal, urlWatchWithGoaway, urlNormal, urlWatch, urlGoaway, urlNormal, urlNormal},
+			expectConnections: 3,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// localAddr indicates how many TCP connection set up
+			localAddr := make([]string, 0)
+
+			// init HTTP2 client
+			client := http.Client{
+				Transport: &http2.Transport{
+					TLSClientConfig: tlsConfig,
+					DialTLS: func(network, addr string, cfg *tls.Config) (conn net.Conn, err error) {
+						conn, err = tls.Dial(network, addr, cfg)
+						if err != nil {
+							t.Fatalf("unexpect connection err: %v", err)
+						}
+						localAddr = append(localAddr, conn.LocalAddr().String())
+						return
+					},
+				},
+			}
+
+			watchChs := make([]chan int, 0)
+			for _, url := range tc.reqs {
+				req, err := http.NewRequest(http.MethodGet, s.URL+url, nil)
+				if err != nil {
+					t.Fatalf("unexpect new request error: %v", err)
+				}
+				resp, err := client.Do(req)
+				if err != nil {
+					t.Fatalf("failed request test server, err: %v", err)
+				}
+
+				// encounter watch bytes received, does not expect to be broken
+				if url == urlWatch || url == urlWatchWithGoaway {
+					ch := make(chan int)
+					watchChs = append(watchChs, ch)
+					go func() {
+						count := 0
+						for {
+							buffer := make([]byte, 1)
+							n, err := resp.Body.Read(buffer)
+							if err != nil {
+								// urlWatch will receive io.EOF,
+								// urlWatchWithGoaway will receive http2.GoAwayError
+								if err != io.EOF {
+									if _, ok := err.(http2.GoAwayError); !ok {
+										t.Errorf("watch received not EOF err: %v", err)
+									}
+								}
+								ch <- count
+								return
+							}
+							count += n
+						}
+					}()
+				}
+			}
+
+			// check TCP connection count
+			if tc.expectConnections != len(localAddr) {
+				t.Fatalf("expect TCP connection: %d, actual: %d", tc.expectConnections, len(localAddr))
+			}
+
+			// check if watch request is broken by GOAWAY response
+			watchTimeout := time.NewTimer(time.Second * 10)
+			for _, watchCh := range watchChs {
+				select {
+				case n := <-watchCh:
+					if n != watchExpectSendBytes {
+						t.Fatalf("in-flight watch was broken by GOAWAY response, expect go bytes: %d, actual got: %d", watchExpectSendBytes, n)
+					}
+				case <-watchTimeout.C:
+					t.Error("watch receive timeout")
+				}
+			}
+		})
+	}
+}
+
+func TestHTTP1Requests(t *testing.T) {
+	s := httptest.NewUnstartedServer(WithProbabilisticGoaway(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello"))
+		return
+	}), 1))
+
+	http2Options := &http2.Server{}
+
+	if err := http2.ConfigureServer(s.Config, http2Options); err != nil {
+		t.Fatalf("failed to configure test server to be HTTP2 server, err: %v", err)
+	}
+
+	s.TLS = s.Config.TLSConfig
+	s.StartTLS()
+	defer s.Close()
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"http/1.1"},
+	}
+
+	client := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+
+	resp, err := client.Get(s.URL)
+	if err != nil {
+		t.Fatalf("failed to request the server, err: %v", err)
+	}
+
+	if v := resp.Header.Get("Connection"); v != "" {
+		t.Errorf("expect response HTTP header Connection to be empty, but got: %s", v)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -147,14 +147,19 @@ type GenericAPIServer struct {
 	preShutdownHooksCalled bool
 
 	// healthz checks
-	healthzLock                sync.Mutex
-	healthzChecks              []healthz.HealthChecker
-	healthzChecksInstalled     bool
-	readyzLock                 sync.Mutex
-	readyzChecks               []healthz.HealthChecker
-	readyzChecksInstalled      bool
-	maxStartupSequenceDuration time.Duration
-	healthzClock               clock.Clock
+	healthzLock            sync.Mutex
+	healthzChecks          []healthz.HealthChecker
+	healthzChecksInstalled bool
+	// livez checks
+	livezLock            sync.Mutex
+	livezChecks          []healthz.HealthChecker
+	livezChecksInstalled bool
+	// readyz checks
+	readyzLock            sync.Mutex
+	readyzChecks          []healthz.HealthChecker
+	readyzChecksInstalled bool
+	livezGracePeriod      time.Duration
+	livezClock            clock.Clock
 	// the readiness stop channel is used to signal that the apiserver has initiated a shutdown sequence, this
 	// will cause readyz to return unhealthy.
 	readinessStopCh chan struct{}
@@ -269,7 +274,12 @@ func (s *GenericAPIServer) PrepareRun() preparedGenericAPIServer {
 	}
 
 	s.installHealthz()
-	s.installReadyz(s.readinessStopCh)
+	s.installLivez()
+	err := s.addReadyzShutdownCheck(s.readinessStopCh)
+	if err != nil {
+		klog.Errorf("Failed to install readyz shutdown check %s", err)
+	}
+	s.installReadyz()
 
 	// Register audit backend preShutdownHook.
 	if s.AuditBackend != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -148,10 +148,10 @@ type GenericAPIServer struct {
 
 	// healthz checks
 	healthzLock                sync.Mutex
-	healthzChecks              []healthz.HealthzChecker
+	healthzChecks              []healthz.HealthChecker
 	healthzChecksInstalled     bool
 	readyzLock                 sync.Mutex
-	readyzChecks               []healthz.HealthzChecker
+	readyzChecks               []healthz.HealthChecker
 	readyzChecksInstalled      bool
 	maxStartupSequenceDuration time.Duration
 	healthzClock               clock.Clock
@@ -199,7 +199,7 @@ type DelegationTarget interface {
 	PreShutdownHooks() map[string]preShutdownHookEntry
 
 	// HealthzChecks returns the healthz checks that need to be combined
-	HealthzChecks() []healthz.HealthzChecker
+	HealthzChecks() []healthz.HealthChecker
 
 	// ListedPaths returns the paths for supporting an index
 	ListedPaths() []string
@@ -218,7 +218,7 @@ func (s *GenericAPIServer) PostStartHooks() map[string]postStartHookEntry {
 func (s *GenericAPIServer) PreShutdownHooks() map[string]preShutdownHookEntry {
 	return s.preShutdownHooks
 }
-func (s *GenericAPIServer) HealthzChecks() []healthz.HealthzChecker {
+func (s *GenericAPIServer) HealthzChecks() []healthz.HealthChecker {
 	return s.healthzChecks
 }
 func (s *GenericAPIServer) ListedPaths() []string {
@@ -245,8 +245,8 @@ func (s emptyDelegate) PostStartHooks() map[string]postStartHookEntry {
 func (s emptyDelegate) PreShutdownHooks() map[string]preShutdownHookEntry {
 	return map[string]preShutdownHookEntry{}
 }
-func (s emptyDelegate) HealthzChecks() []healthz.HealthzChecker {
-	return []healthz.HealthzChecker{}
+func (s emptyDelegate) HealthzChecks() []healthz.HealthChecker {
+	return []healthz.HealthChecker{}
 }
 func (s emptyDelegate) ListedPaths() []string {
 	return []string{}

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz.go
@@ -25,15 +25,15 @@ import (
 	"k8s.io/apiserver/pkg/server/healthz"
 )
 
-// AddHealthzCheck adds HealthzCheck(s) to both healthz and readyz. All healthz checks
+// AddHealthChecks adds HealthzCheck(s) to both healthz and readyz. All healthz checks
 // are automatically added to readyz, since we want to avoid the situation where the
 // apiserver is ready but not live.
-func (s *GenericAPIServer) AddHealthzChecks(checks ...healthz.HealthzChecker) error {
+func (s *GenericAPIServer) AddHealthChecks(checks ...healthz.HealthChecker) error {
 	return s.AddDelayedHealthzChecks(0, checks...)
 }
 
 // AddReadyzChecks allows you to add a HealthzCheck to readyz.
-func (s *GenericAPIServer) AddReadyzChecks(checks ...healthz.HealthzChecker) error {
+func (s *GenericAPIServer) AddReadyzChecks(checks ...healthz.HealthChecker) error {
 	s.readyzLock.Lock()
 	defer s.readyzLock.Unlock()
 	return s.addReadyzChecks(checks...)
@@ -41,7 +41,7 @@ func (s *GenericAPIServer) AddReadyzChecks(checks ...healthz.HealthzChecker) err
 
 // addReadyzChecks allows you to add a HealthzCheck to readyz.
 // premise: readyzLock has been obtained
-func (s *GenericAPIServer) addReadyzChecks(checks ...healthz.HealthzChecker) error {
+func (s *GenericAPIServer) addReadyzChecks(checks ...healthz.HealthChecker) error {
 	if s.readyzChecksInstalled {
 		return fmt.Errorf("unable to add because the readyz endpoint has already been created")
 	}
@@ -94,7 +94,7 @@ func (c shutdownCheck) Check(req *http.Request) error {
 // grace period has not yet elapsed. One may want to set a grace period in order to prevent
 // the kubelet from restarting the kube-apiserver due to long-ish boot sequences. Readyz health
 // checks have no grace period, since we want readyz to fail while boot has not completed.
-func (s *GenericAPIServer) AddDelayedHealthzChecks(delay time.Duration, checks ...healthz.HealthzChecker) error {
+func (s *GenericAPIServer) AddDelayedHealthzChecks(delay time.Duration, checks ...healthz.HealthChecker) error {
 	s.healthzLock.Lock()
 	defer s.healthzLock.Unlock()
 	if s.healthzChecksInstalled {
@@ -110,7 +110,7 @@ func (s *GenericAPIServer) AddDelayedHealthzChecks(delay time.Duration, checks .
 }
 
 // delayedHealthCheck wraps a health check which will not fail until the explicitly defined delay has elapsed.
-func delayedHealthCheck(check healthz.HealthzChecker, clock clock.Clock, delay time.Duration) healthz.HealthzChecker {
+func delayedHealthCheck(check healthz.HealthChecker, clock clock.Clock, delay time.Duration) healthz.HealthChecker {
 	return delayedHealthzCheck{
 		check,
 		clock.Now().Add(delay),
@@ -119,7 +119,7 @@ func delayedHealthCheck(check healthz.HealthzChecker, clock clock.Clock, delay t
 }
 
 type delayedHealthzCheck struct {
-	check      healthz.HealthzChecker
+	check      healthz.HealthChecker
 	startCheck time.Time
 	clock      clock.Clock
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz.go
@@ -25,29 +25,67 @@ import (
 	"k8s.io/apiserver/pkg/server/healthz"
 )
 
-// AddHealthChecks adds HealthzCheck(s) to both healthz and readyz. All healthz checks
-// are automatically added to readyz, since we want to avoid the situation where the
-// apiserver is ready but not live.
+// AddHealthChecks adds HealthCheck(s) to health endpoints (healthz, livez, readyz) but
+// configures the liveness grace period to be zero, which means we expect this health check
+// to immediately indicate that the apiserver is unhealthy.
 func (s *GenericAPIServer) AddHealthChecks(checks ...healthz.HealthChecker) error {
-	return s.AddDelayedHealthzChecks(0, checks...)
+	// we opt for a delay of zero here, because this entrypoint adds generic health checks
+	// and not health checks which are specifically related to kube-apiserver boot-sequences.
+	return s.addHealthChecks(0, checks...)
 }
 
-// AddReadyzChecks allows you to add a HealthzCheck to readyz.
-func (s *GenericAPIServer) AddReadyzChecks(checks ...healthz.HealthChecker) error {
+// AddBootSequenceHealthChecks adds health checks to the old healthz endpoint (for backwards compatibility reasons)
+// as well as livez and readyz. The livez grace period is defined by the value of the
+// command-line flag --livez-grace-period; before the grace period elapses, the livez health checks
+// will default to healthy. One may want to set a grace period in order to prevent the kubelet from restarting
+// the kube-apiserver due to long-ish boot sequences. Readyz health checks, on the other hand, have no grace period,
+// since readyz should fail until boot fully completes.
+func (s *GenericAPIServer) AddBootSequenceHealthChecks(checks ...healthz.HealthChecker) error {
+	return s.addHealthChecks(s.livezGracePeriod, checks...)
+}
+
+// addHealthChecks adds health checks to healthz, livez, and readyz. The delay passed in will set
+// a corresponding grace period on livez.
+func (s *GenericAPIServer) addHealthChecks(livezGracePeriod time.Duration, checks ...healthz.HealthChecker) error {
+	s.healthzLock.Lock()
+	defer s.healthzLock.Unlock()
+	if s.healthzChecksInstalled {
+		return fmt.Errorf("unable to add because the healthz endpoint has already been created")
+	}
+	s.healthzChecks = append(s.healthzChecks, checks...)
+	return s.addLivezChecks(livezGracePeriod, checks...)
+}
+
+// addReadyzChecks allows you to add a HealthCheck to readyz.
+func (s *GenericAPIServer) addReadyzChecks(checks ...healthz.HealthChecker) error {
 	s.readyzLock.Lock()
 	defer s.readyzLock.Unlock()
-	return s.addReadyzChecks(checks...)
-}
-
-// addReadyzChecks allows you to add a HealthzCheck to readyz.
-// premise: readyzLock has been obtained
-func (s *GenericAPIServer) addReadyzChecks(checks ...healthz.HealthChecker) error {
 	if s.readyzChecksInstalled {
 		return fmt.Errorf("unable to add because the readyz endpoint has already been created")
 	}
-
 	s.readyzChecks = append(s.readyzChecks, checks...)
 	return nil
+}
+
+// addLivezChecks allows you to add a HealthCheck to livez. It will also automatically add a check to readyz,
+// since we want to avoid being ready when we are not live.
+func (s *GenericAPIServer) addLivezChecks(delay time.Duration, checks ...healthz.HealthChecker) error {
+	s.livezLock.Lock()
+	defer s.livezLock.Unlock()
+	if s.livezChecksInstalled {
+		return fmt.Errorf("unable to add because the livez endpoint has already been created")
+	}
+	for _, check := range checks {
+		s.livezChecks = append(s.livezChecks, delayedHealthCheck(check, s.livezClock, delay))
+	}
+	return s.addReadyzChecks(checks...)
+}
+
+// addReadyzShutdownCheck is a convenience function for adding a readyz shutdown check, so
+// that we can register that the api-server is no longer ready while we attempt to gracefully
+// shutdown.
+func (s *GenericAPIServer) addReadyzShutdownCheck(stopCh <-chan struct{}) error {
+	return s.addReadyzChecks(shutdownCheck{stopCh})
 }
 
 // installHealthz creates the healthz endpoint for this server
@@ -55,19 +93,23 @@ func (s *GenericAPIServer) installHealthz() {
 	s.healthzLock.Lock()
 	defer s.healthzLock.Unlock()
 	s.healthzChecksInstalled = true
-
 	healthz.InstallHandler(s.Handler.NonGoRestfulMux, s.healthzChecks...)
 }
 
 // installReadyz creates the readyz endpoint for this server.
-func (s *GenericAPIServer) installReadyz(stopCh <-chan struct{}) {
+func (s *GenericAPIServer) installReadyz() {
 	s.readyzLock.Lock()
 	defer s.readyzLock.Unlock()
-	s.addReadyzChecks(shutdownCheck{stopCh})
-
 	s.readyzChecksInstalled = true
-
 	healthz.InstallReadyzHandler(s.Handler.NonGoRestfulMux, s.readyzChecks...)
+}
+
+// installLivez creates the livez endpoint for this server.
+func (s *GenericAPIServer) installLivez() {
+	s.livezLock.Lock()
+	defer s.livezLock.Unlock()
+	s.livezChecksInstalled = true
+	healthz.InstallLivezHandler(s.Handler.NonGoRestfulMux, s.livezChecks...)
 }
 
 // shutdownCheck fails if the embedded channel is closed. This is intended to allow for graceful shutdown sequences
@@ -89,46 +131,27 @@ func (c shutdownCheck) Check(req *http.Request) error {
 	return nil
 }
 
-// AddDelayedHealthzChecks adds a health check to both healthz and readyz. The delay parameter
-// allows you to set the grace period for healthz checks, which will return healthy while
-// grace period has not yet elapsed. One may want to set a grace period in order to prevent
-// the kubelet from restarting the kube-apiserver due to long-ish boot sequences. Readyz health
-// checks have no grace period, since we want readyz to fail while boot has not completed.
-func (s *GenericAPIServer) AddDelayedHealthzChecks(delay time.Duration, checks ...healthz.HealthChecker) error {
-	s.healthzLock.Lock()
-	defer s.healthzLock.Unlock()
-	if s.healthzChecksInstalled {
-		return fmt.Errorf("unable to add because the healthz endpoint has already been created")
-	}
-	for _, check := range checks {
-		s.healthzChecks = append(s.healthzChecks, delayedHealthCheck(check, s.healthzClock, s.maxStartupSequenceDuration))
-	}
-
-	s.readyzLock.Lock()
-	defer s.readyzLock.Unlock()
-	return s.addReadyzChecks(checks...)
-}
-
-// delayedHealthCheck wraps a health check which will not fail until the explicitly defined delay has elapsed.
+// delayedHealthCheck wraps a health check which will not fail until the explicitly defined delay has elapsed. This
+// is intended for use primarily for livez health checks.
 func delayedHealthCheck(check healthz.HealthChecker, clock clock.Clock, delay time.Duration) healthz.HealthChecker {
-	return delayedHealthzCheck{
+	return delayedLivezCheck{
 		check,
 		clock.Now().Add(delay),
 		clock,
 	}
 }
 
-type delayedHealthzCheck struct {
+type delayedLivezCheck struct {
 	check      healthz.HealthChecker
 	startCheck time.Time
 	clock      clock.Clock
 }
 
-func (c delayedHealthzCheck) Name() string {
+func (c delayedLivezCheck) Name() string {
 	return c.check.Name()
 }
 
-func (c delayedHealthzCheck) Check(req *http.Request) error {
+func (c delayedLivezCheck) Check(req *http.Request) error {
 	if c.clock.Now().After(c.startCheck) {
 		return c.check.Check(req)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -101,6 +101,14 @@ func InstallReadyzHandler(mux mux, checks ...HealthChecker) {
 	InstallPathHandler(mux, "/readyz", checks...)
 }
 
+// InstallLivezHandler registers handlers for liveness checking on the path
+// "/livez" to mux. *All handlers* for mux must be specified in
+// exactly one call to InstallHandler. Calling InstallHandler more
+// than once for the same mux will result in a panic.
+func InstallLivezHandler(mux mux, checks ...HealthChecker) {
+	InstallPathHandler(mux, "/livez", checks...)
+}
+
 // InstallPathHandler registers handlers for health checking on
 // a specific path to mux. *All handlers* for the path must be
 // specified in exactly one call to InstallPathHandler. Calling

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -31,14 +31,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// HealthzChecker is a named healthz checker.
-type HealthzChecker interface {
+// HealthChecker is a named healthz checker.
+type HealthChecker interface {
 	Name() string
 	Check(req *http.Request) error
 }
 
 // PingHealthz returns true automatically when checked
-var PingHealthz HealthzChecker = ping{}
+var PingHealthz HealthChecker = ping{}
 
 // ping implements the simplest possible healthz checker.
 type ping struct{}
@@ -53,7 +53,7 @@ func (ping) Check(_ *http.Request) error {
 }
 
 // LogHealthz returns true if logging is not blocked
-var LogHealthz HealthzChecker = &log{}
+var LogHealthz HealthChecker = &log{}
 
 type log struct {
 	startOnce    sync.Once
@@ -81,7 +81,7 @@ func (l *log) Check(_ *http.Request) error {
 }
 
 // NamedCheck returns a healthz checker for the given name and function.
-func NamedCheck(name string, check func(r *http.Request) error) HealthzChecker {
+func NamedCheck(name string, check func(r *http.Request) error) HealthChecker {
 	return &healthzCheck{name, check}
 }
 
@@ -89,7 +89,7 @@ func NamedCheck(name string, check func(r *http.Request) error) HealthzChecker {
 // "/healthz" to mux. *All handlers* for mux must be specified in
 // exactly one call to InstallHandler. Calling InstallHandler more
 // than once for the same mux will result in a panic.
-func InstallHandler(mux mux, checks ...HealthzChecker) {
+func InstallHandler(mux mux, checks ...HealthChecker) {
 	InstallPathHandler(mux, "/healthz", checks...)
 }
 
@@ -97,7 +97,7 @@ func InstallHandler(mux mux, checks ...HealthzChecker) {
 // "/readyz" to mux. *All handlers* for mux must be specified in
 // exactly one call to InstallHandler. Calling InstallHandler more
 // than once for the same mux will result in a panic.
-func InstallReadyzHandler(mux mux, checks ...HealthzChecker) {
+func InstallReadyzHandler(mux mux, checks ...HealthChecker) {
 	InstallPathHandler(mux, "/readyz", checks...)
 }
 
@@ -106,13 +106,13 @@ func InstallReadyzHandler(mux mux, checks ...HealthzChecker) {
 // specified in exactly one call to InstallPathHandler. Calling
 // InstallPathHandler more than once for the same path and mux will
 // result in a panic.
-func InstallPathHandler(mux mux, path string, checks ...HealthzChecker) {
+func InstallPathHandler(mux mux, path string, checks ...HealthChecker) {
 	if len(checks) == 0 {
 		klog.V(5).Info("No default health checks specified. Installing the ping handler.")
-		checks = []HealthzChecker{PingHealthz}
+		checks = []HealthChecker{PingHealthz}
 	}
 
-	klog.V(5).Info("Installing healthz checkers:", formatQuoted(checkerNames(checks...)...))
+	klog.V(5).Infof("Installing health checkers for (%v): %v", path, formatQuoted(checkerNames(checks...)...))
 
 	mux.Handle(path, handleRootHealthz(checks...))
 	for _, check := range checks {
@@ -125,13 +125,13 @@ type mux interface {
 	Handle(pattern string, handler http.Handler)
 }
 
-// healthzCheck implements HealthzChecker on an arbitrary name and check function.
+// healthzCheck implements HealthChecker on an arbitrary name and check function.
 type healthzCheck struct {
 	name  string
 	check func(r *http.Request) error
 }
 
-var _ HealthzChecker = &healthzCheck{}
+var _ HealthChecker = &healthzCheck{}
 
 func (c *healthzCheck) Name() string {
 	return c.name
@@ -151,7 +151,7 @@ func getExcludedChecks(r *http.Request) sets.String {
 }
 
 // handleRootHealthz returns an http.HandlerFunc that serves the provided checks.
-func handleRootHealthz(checks ...HealthzChecker) http.HandlerFunc {
+func handleRootHealthz(checks ...HealthChecker) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		failed := false
 		excluded := getExcludedChecks(r)
@@ -210,7 +210,7 @@ func adaptCheckToHandler(c func(r *http.Request) error) http.HandlerFunc {
 }
 
 // checkerNames returns the names of the checks in the same order as passed in.
-func checkerNames(checks ...HealthzChecker) []string {
+func checkerNames(checks ...HealthChecker) []string {
 	// accumulate the names of checks for printing them out.
 	checkerNames := make([]string, 0, len(checks))
 	for _, check := range checks {

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
@@ -111,7 +111,7 @@ func testMultipleChecks(path string, t *testing.T) {
 
 	for i, test := range tests {
 		mux := http.NewServeMux()
-		checks := []HealthzChecker{PingHealthz}
+		checks := []HealthChecker{PingHealthz}
 		if test.addBadCheck {
 			checks = append(checks, NamedCheck("bad", func(_ *http.Request) error {
 				return errors.New("this will fail")
@@ -158,14 +158,14 @@ func TestCheckerNames(t *testing.T) {
 
 	testCases := []struct {
 		desc string
-		have []HealthzChecker
+		have []HealthChecker
 		want []string
 	}{
-		{"no checker", []HealthzChecker{}, []string{}},
-		{"one checker", []HealthzChecker{c1}, []string{n1}},
-		{"other checker", []HealthzChecker{c2}, []string{n2}},
-		{"checker order", []HealthzChecker{c1, c2}, []string{n1, n2}},
-		{"different checker order", []HealthzChecker{c2, c1}, []string{n2, n1}},
+		{"no checker", []HealthChecker{}, []string{}},
+		{"one checker", []HealthChecker{c1}, []string{n1}},
+		{"other checker", []HealthChecker{c2}, []string{n2}},
+		{"checker order", []HealthChecker{c1, c2}, []string{n1, n2}},
+		{"different checker order", []HealthChecker{c2, c1}, []string{n2, n1}},
 	}
 
 	for _, tc := range testCases {

--- a/staging/src/k8s.io/apiserver/pkg/server/hooks.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/hooks.go
@@ -22,12 +22,11 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	"k8s.io/klog"
-
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/server/healthz"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/klog"
 )
 
 // PostStartHookFunc is a function that is called after the server has started.
@@ -97,7 +96,7 @@ func (s *GenericAPIServer) AddPostStartHook(name string, hook PostStartHookFunc)
 	// done is closed when the poststarthook is finished.  This is used by the health check to be able to indicate
 	// that the poststarthook is finished
 	done := make(chan struct{})
-	if err := s.AddDelayedHealthzChecks(s.maxStartupSequenceDuration, postStartHookHealthz{name: "poststarthook/" + name, done: done}); err != nil {
+	if err := s.AddBootSequenceHealthChecks(postStartHookHealthz{name: "poststarthook/" + name, done: done}); err != nil {
 		return err
 	}
 	s.postStartHooks[name] = postStartHookEntry{hook: hook, originatingStack: string(debug.Stack()), done: done}

--- a/staging/src/k8s.io/apiserver/pkg/server/hooks.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/hooks.go
@@ -219,7 +219,7 @@ type postStartHookHealthz struct {
 	done chan struct{}
 }
 
-var _ healthz.HealthzChecker = postStartHookHealthz{}
+var _ healthz.HealthChecker = postStartHookHealthz{}
 
 func (h postStartHookHealthz) Name() string {
 	return h.name

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -42,7 +42,7 @@ type ServerRunOptions struct {
 	MaxRequestsInFlight         int
 	MaxMutatingRequestsInFlight int
 	RequestTimeout              time.Duration
-	MaxStartupSequenceDuration  time.Duration
+	LivezGracePeriod            time.Duration
 	MinRequestTimeout           int
 	// We intentionally did not add a flag for this option. Users of the
 	// apiserver library can wire it to a flag.
@@ -65,7 +65,7 @@ func NewServerRunOptions() *ServerRunOptions {
 		MaxRequestsInFlight:         defaults.MaxRequestsInFlight,
 		MaxMutatingRequestsInFlight: defaults.MaxMutatingRequestsInFlight,
 		RequestTimeout:              defaults.RequestTimeout,
-		MaxStartupSequenceDuration:  defaults.MaxStartupSequenceDuration,
+		LivezGracePeriod:            defaults.LivezGracePeriod,
 		MinRequestTimeout:           defaults.MinRequestTimeout,
 		JSONPatchMaxCopyBytes:       defaults.JSONPatchMaxCopyBytes,
 		MaxRequestBodyBytes:         defaults.MaxRequestBodyBytes,
@@ -78,7 +78,7 @@ func (s *ServerRunOptions) ApplyTo(c *server.Config) error {
 	c.ExternalAddress = s.ExternalHost
 	c.MaxRequestsInFlight = s.MaxRequestsInFlight
 	c.MaxMutatingRequestsInFlight = s.MaxMutatingRequestsInFlight
-	c.MaxStartupSequenceDuration = s.MaxStartupSequenceDuration
+	c.LivezGracePeriod = s.LivezGracePeriod
 	c.RequestTimeout = s.RequestTimeout
 	c.MinRequestTimeout = s.MinRequestTimeout
 	c.JSONPatchMaxCopyBytes = s.JSONPatchMaxCopyBytes
@@ -113,8 +113,8 @@ func (s *ServerRunOptions) Validate() []error {
 		errors = append(errors, fmt.Errorf("--target-ram-mb can not be negative value"))
 	}
 
-	if s.MaxStartupSequenceDuration < 0 {
-		errors = append(errors, fmt.Errorf("--maximum-startup-sequence-duration can not be a negative value"))
+	if s.LivezGracePeriod < 0 {
+		errors = append(errors, fmt.Errorf("--livez-grace-period can not be a negative value"))
 	}
 
 	if s.EnableInfightQuotaHandler {
@@ -196,9 +196,9 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 		"it out. This is the default request timeout for requests but may be overridden by flags such as "+
 		"--min-request-timeout for specific types of requests.")
 
-	fs.DurationVar(&s.MaxStartupSequenceDuration, "maximum-startup-sequence-duration", s.MaxStartupSequenceDuration, ""+
+	fs.DurationVar(&s.LivezGracePeriod, "livez-grace-period", s.LivezGracePeriod, ""+
 		"This option represents the maximum amount of time it should take for apiserver to complete its startup sequence "+
-		"and become healthy. From apiserver's start time to when this amount of time has elapsed, /healthz will assume "+
+		"and become live. From apiserver's start time to when this amount of time has elapsed, /livez will assume "+
 		"that unfinished post-start hooks will complete successfully and therefore return true.")
 
 	fs.IntVar(&s.MinRequestTimeout, "min-request-timeout", s.MinRequestTimeout, ""+

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -42,6 +42,7 @@ type ServerRunOptions struct {
 	MaxRequestsInFlight         int
 	MaxMutatingRequestsInFlight int
 	RequestTimeout              time.Duration
+	GoawayChance                float64
 	LivezGracePeriod            time.Duration
 	MinRequestTimeout           int
 	// We intentionally did not add a flag for this option. Users of the
@@ -80,6 +81,7 @@ func (s *ServerRunOptions) ApplyTo(c *server.Config) error {
 	c.MaxMutatingRequestsInFlight = s.MaxMutatingRequestsInFlight
 	c.LivezGracePeriod = s.LivezGracePeriod
 	c.RequestTimeout = s.RequestTimeout
+	c.GoawayChance = s.GoawayChance
 	c.MinRequestTimeout = s.MinRequestTimeout
 	c.JSONPatchMaxCopyBytes = s.JSONPatchMaxCopyBytes
 	c.MaxRequestBodyBytes = s.MaxRequestBodyBytes
@@ -143,6 +145,10 @@ func (s *ServerRunOptions) Validate() []error {
 		errors = append(errors, fmt.Errorf("--request-timeout can not be negative value"))
 	}
 
+	if s.GoawayChance < 0 || s.GoawayChance > 0.02 {
+		errors = append(errors, fmt.Errorf("--goaway-chance can not be less than 0 or greater than 0.02"))
+	}
+
 	if s.MinRequestTimeout < 0 {
 		errors = append(errors, fmt.Errorf("--min-request-timeout can not be negative value"))
 	}
@@ -195,6 +201,12 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 		"An optional field indicating the duration a handler must keep a request open before timing "+
 		"it out. This is the default request timeout for requests but may be overridden by flags such as "+
 		"--min-request-timeout for specific types of requests.")
+
+	fs.Float64Var(&s.GoawayChance, "goaway-chance", s.GoawayChance, ""+
+		"To prevent HTTP/2 clients from getting stuck on a single apiserver, randomly close a connection (GOAWAY). "+
+		"The client's other in-flight requests won't be affected, and the client will reconnect, likely landing on a different apiserver after going through the load balancer again. "+
+		"This argument sets the fraction of requests that will be sent a GOAWAY. Clusters with single apiservers, or which don't use a load balancer, should NOT enable this. "+
+		"Min is 0 (off), Max is .02 (1/50 requests); .001 (1/1000) is a recommended starting point.")
 
 	fs.DurationVar(&s.LivezGracePeriod, "livez-grace-period", s.LivezGracePeriod, ""+
 		"This option represents the maximum amount of time it should take for apiserver to complete its startup sequence "+

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options_test.go
@@ -137,7 +137,7 @@ func TestServerRunOptionsValidate(t *testing.T) {
 			expectErr: "--max-resource-write-bytes can not be negative value",
 		},
 		{
-			name: "Test when MaxStartupSequenceDuration is negative value",
+			name: "Test when LivezGracePeriod is negative value",
 			testOptions: &ServerRunOptions{
 				AdvertiseAddress:            net.ParseIP("192.168.10.10"),
 				CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
@@ -148,9 +148,9 @@ func TestServerRunOptionsValidate(t *testing.T) {
 				JSONPatchMaxCopyBytes:       10 * 1024 * 1024,
 				MaxRequestBodyBytes:         10 * 1024 * 1024,
 				TargetRAMMB:                 65536,
-				MaxStartupSequenceDuration:  -time.Second,
+				LivezGracePeriod:            -time.Second,
 			},
-			expectErr: "--maximum-startup-sequence-duration can not be a negative value",
+			expectErr: "--livez-grace-period can not be a negative value",
 		},
 		{
 			name: "Test when ServerRunOptions is valid",

--- a/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
@@ -60,6 +60,11 @@ func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Dur
 		},
 	}
 
+	if s.DisableHTTP2 {
+		klog.Info("Forcing use of http/1.1 only")
+		secureServer.TLSConfig.NextProtos = []string{"http/1.1"}
+	}
+
 	if s.MinTLSVersion > 0 {
 		secureServer.TLSConfig.MinVersion = s.MinTLSVersion
 	}
@@ -108,9 +113,11 @@ func (s *SecureServingInfo) Serve(handler http.Handler, shutdownTimeout time.Dur
 	// increase the connection buffer size from the 1MB default to handle the specified number of concurrent streams
 	http2Options.MaxUploadBufferPerConnection = http2Options.MaxUploadBufferPerStream * int32(http2Options.MaxConcurrentStreams)
 
-	// apply settings to the server
-	if err := http2.ConfigureServer(secureServer, http2Options); err != nil {
-		return nil, fmt.Errorf("error configuring http2: %v", err)
+	if !s.DisableHTTP2 {
+		// apply settings to the server
+		if err := http2.ConfigureServer(secureServer, http2Options); err != nil {
+			return nil, fmt.Errorf("error configuring http2: %v", err)
+		}
 	}
 
 	klog.Infof("Serving securely on %s", secureServer.Addr)

--- a/test/integration/master/kube_apiserver_test.go
+++ b/test/integration/master/kube_apiserver_test.go
@@ -97,7 +97,7 @@ func endpointReturnsStatusOK(client *kubernetes.Clientset, path string) bool {
 func TestStartupSequenceHealthzAndReadyz(t *testing.T) {
 	hc := &delayedCheck{}
 	instanceOptions := &kubeapiservertesting.TestServerInstanceOptions{
-		InjectedHealthzChecker: hc,
+		InjectedHealthChecker: hc,
 	}
 	server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, []string{"--maximum-startup-sequence-duration", "5s"}, framework.SharedEtcd())
 	defer server.TearDownFn()

--- a/test/integration/master/kube_apiserver_test.go
+++ b/test/integration/master/kube_apiserver_test.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -94,35 +93,16 @@ func endpointReturnsStatusOK(client *kubernetes.Clientset, path string) bool {
 	return status == http.StatusOK
 }
 
-func TestStartupSequenceHealthzAndReadyz(t *testing.T) {
-	hc := &delayedCheck{}
-	instanceOptions := &kubeapiservertesting.TestServerInstanceOptions{
-		InjectedHealthChecker: hc,
-	}
-	server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, []string{"--maximum-startup-sequence-duration", "5s"}, framework.SharedEtcd())
+func TestLivezAndReadyz(t *testing.T) {
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, []string{"--livez-grace-period", "0s"}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	client, err := kubernetes.NewForConfig(server.ClientConfig)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	if endpointReturnsStatusOK(client, "/readyz") {
-		t.Fatalf("readyz should start unready")
-	}
-	// we need to wait longer than our grace period
-	err = wait.Poll(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-		return !endpointReturnsStatusOK(client, "/healthz"), nil
-	})
-	if err != nil {
-		t.Fatalf("healthz should have become unhealthy: %v", err)
-	}
-	hc.makeHealthy()
-	err = wait.Poll(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-		return endpointReturnsStatusOK(client, "/healthz"), nil
-	})
-	if err != nil {
-		t.Fatalf("healthz should have become healthy again: %v", err)
+	if !endpointReturnsStatusOK(client, "/livez") {
+		t.Fatalf("livez should be healthy")
 	}
 	if !endpointReturnsStatusOK(client, "/readyz") {
 		t.Fatalf("readyz should be healthy")
@@ -301,28 +281,4 @@ func TestReconcilerMasterLeaseMultiMoreMasters(t *testing.T) {
 
 func TestReconcilerMasterLeaseMultiCombined(t *testing.T) {
 	testReconcilersMasterLease(t, 3, 3)
-}
-
-type delayedCheck struct {
-	healthLock sync.Mutex
-	isHealthy  bool
-}
-
-func (h *delayedCheck) Name() string {
-	return "delayed-check"
-}
-
-func (h *delayedCheck) Check(req *http.Request) error {
-	h.healthLock.Lock()
-	defer h.healthLock.Unlock()
-	if h.isHealthy {
-		return nil
-	}
-	return fmt.Errorf("isn't healthy")
-}
-
-func (h *delayedCheck) makeHealthy() {
-	h.healthLock.Lock()
-	defer h.healthLock.Unlock()
-	h.isHealthy = true
 }


### PR DESCRIPTION
10K single cluster density test is currently having "etcdserver: too many requests" issue. Pick up community https://github.com/kubernetes/kubernetes/pull/88567 just in case it helps.

Other cherry pick changes are due to dependencies.
Plus Arktos copy right setting.

1/25 density test data looks better than 1/15 & 1/21. apiserver_current_inflight_request is much smooth and closer to 1.18. This is a good cherry-pick

Arktos 1/25/2021
![apiserver_current_inflight_requests](https://user-images.githubusercontent.com/7363144/105897278-d1a2b300-5fcc-11eb-9fc7-6182a10cfe50.PNG)

1.18
![density-api-inflight-all](https://user-images.githubusercontent.com/7363144/105897440-03b41500-5fcd-11eb-8b44-f99f327d39aa.png)

