### PR TITLE
fix QPS issue in insecure mode

### DIFF
--- a/pkg/cloudfabric-controller/client_builder.go
+++ b/pkg/cloudfabric-controller/client_builder.go
@@ -58,8 +58,8 @@ type SimpleControllerClientBuilder struct {
 }
 
 func (b SimpleControllerClientBuilder) Config(name string) (*restclient.Config, error) {
-	clientConfig := *b.ClientConfig
-	return restclient.AddUserAgent(&clientConfig, name), nil
+	clientConfig := restclient.CopyConfigs(b.ClientConfig)
+	return restclient.AddUserAgent(clientConfig, name), nil
 }
 
 func (b SimpleControllerClientBuilder) ConfigOrDie(name string) *restclient.Config {

--- a/pkg/controller/client_builder.go
+++ b/pkg/controller/client_builder.go
@@ -59,8 +59,8 @@ type SimpleControllerClientBuilder struct {
 }
 
 func (b SimpleControllerClientBuilder) Config(name string) (*restclient.Config, error) {
-	clientConfig := *b.ClientConfig
-	return restclient.AddUserAgent(&clientConfig, name), nil
+	clientConfig := restclient.CopyConfigs(b.ClientConfig)
+	return restclient.AddUserAgent(clientConfig, name), nil
 }
 
 func (b SimpleControllerClientBuilder) ConfigOrDie(name string) *restclient.Config {


### PR DESCRIPTION
We hit the issue in PoC branch where the QPS of some controllers is abnormally high, which is caused by different controllers share the same KubeConfig object. A workaround was provided in https://github.com/CentaurusInfra/arktos/pull/885.

Yet later it was found this QPS issue only happens when the controller-manager is started with "--use-serviceaccount-credentials" option turned off. The root cause is that all the controllers share the  same kubeconfig object in insecure mode. 

The workaround we had in PoC branch is an overkill as it also touches the code path of secure mode. This PR gives a clean fix by letting all the controllers, in **insecure** mode, own its own KubeConfig object. 

### Verification:
In PoC branch, I reverted the previous workaround and applied this fix, then printed out the KubeConfig objects used by tenant-controller/namespace-controller/dynamic-informer. As the screenshot show, they point to different objects.

![image](https://user-images.githubusercontent.com/51831990/105887247-52a77d80-5fc0-11eb-85cb-2499ea0a9433.png)


