### PR TITLE
kubemark changes for kubelet scale-out migrated code

### DIFF
--- a/cmd/kubemark/BUILD
+++ b/cmd/kubemark/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/dockershim:go_default_library",
         "//pkg/kubelet/dockershim/libdocker:go_default_library",
+        "//pkg/kubelet/kubeclientmanager:go_default_library",
         "//pkg/kubemark:go_default_library",
         "//pkg/master/ports:go_default_library",
         "//pkg/util/iptables/testing:go_default_library",

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -52,7 +52,7 @@ type HollowKubelet struct {
 func NewHollowKubelet(
 	flags *options.KubeletFlags,
 	config *kubeletconfig.KubeletConfiguration,
-	client *clientset.Clientset,
+	clients []clientset.Interface,
 	arktosClient arktosCientset.Interface,
 	heartbeatClient *clientset.Clientset,
 	cadvisorInterface cadvisor.Interface,
@@ -65,7 +65,7 @@ func NewHollowKubelet(
 	volumePlugins = append(volumePlugins, secret.ProbeVolumePlugins()...)
 	volumePlugins = append(volumePlugins, projected.ProbeVolumePlugins()...)
 	d := &kubelet.Dependencies{
-		KubeClient:         client,
+		KubeClient:         clients[0],
 		ArktosExtClient:    arktosClient,
 		HeartbeatClient:    heartbeatClient,
 		DockerClientConfig: dockerClientConfig,
@@ -78,6 +78,7 @@ func NewHollowKubelet(
 		OOMAdjuster:        oom.NewFakeOOMAdjuster(),
 		Mounter:            mount.New("" /* default mount path */),
 		Subpather:          &subpath.FakeSubpath{},
+		KubeTPClients:      clients,
 	}
 
 	return &HollowKubelet{
@@ -141,7 +142,6 @@ func GetHollowKubeletConfig(opt *HollowKubletOptions) (*options.KubeletFlags, *k
 	c.FileCheckFrequency.Duration = 20 * time.Second
 	c.HTTPCheckFrequency.Duration = 20 * time.Second
 	c.NodeStatusUpdateFrequency.Duration = 10 * time.Second
-	c.NodeStatusReportFrequency.Duration = 5 * time.Minute
 	c.SyncFrequency.Duration = 10 * time.Second
 	c.EvictionPressureTransitionPeriod.Duration = 5 * time.Minute
 	c.MaxPods = int32(opt.MaxPods)


### PR DESCRIPTION
### Changes
kubemark to adopt the scale-out kubelet changes

### Validation
1. Arktos-up.sh came up correctly, and created and deleted the follow resources correctly
```
kubectl create tenant zeth
kubectl create -f /tmp/web.yaml --tenant zeth
kubectl create deployment nginx --image=nginx --tenant zeth
kubectl create -f vanilla.yaml --tenant zeth

kubectl create tenant apple
kubectl create -f /tmp/web.yaml --tenant apple
kubectl create deployment nginx --image=nginx --tenant apple
kubectl create -f vanilla.yaml --tenant apple
```

2. kubemark 100-node cluster & 100-node density tests
![image](https://user-images.githubusercontent.com/252020/105917061-bf357300-5fe6-11eb-8e13-7000516c1b04.png)

startup latencies also normal.