### PR TITLE
Use insecure port in configs only for scaleout architecture

### DIFF
--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -1423,11 +1423,7 @@ scrape_configs:
   - job_name: prometheus-metrics
     static_configs:
     - targets: ['127.0.0.1:2379','127.0.0.1:8080','127.0.0.1:10251','127.0.0.1:10252']
-  - job_name: 'haproxy'
-    static_configs:
-    - targets: ['scale_out_proxy_ip:8404']
 EOF
-  sed -i -e "s/scale_out_proxy_ip/$PROXY_RESERVED_IP/g" /tmp/prometheus-metrics.yaml
   ./prometheus --config.file="/tmp/prometheus-metrics.yaml" --web.listen-address=":9090" --web.enable-admin-api &
 }
 

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -617,12 +617,10 @@ function create-master-auth {
     for extra_component in "${extra_components[@]}"; do
       local token="$(secure_random 32)"
       append_or_replace_prefixed_line "${known_tokens_csv}" "${token}," "system:${extra_component},uid:system:${extra_component}"
-      if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" == "true" ]]; then
-        if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-          create-kubeconfig "${extra_component}" "${token}" "${PROXY_RESERVED_IP}" "8888" "http"
-        else
-          create-kubeconfig "${extra_component}" "${token}" "localhost" "8080" "http"
-        fi
+      if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+        create-kubeconfig "${extra_component}" "${token}" "${PROXY_RESERVED_IP}" "8888" "http"
+      elif [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
+        create-kubeconfig "${extra_component}" "${token}" "localhost" "8080" "http"
       else
         create-kubeconfig "${extra_component}" "${token}"
       fi
@@ -1074,7 +1072,7 @@ function create-master-kubelet-auth {
   # set in the environment.
   if [[ -n "${KUBELET_APISERVER:-}" && -n "${KUBELET_CERT:-}" && -n "${KUBELET_KEY:-}" ]]; then
     REGISTER_MASTER_KUBELET="true"
-    if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" == "true" ]]; then
+    if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]] || [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
       create-kubelet-kubeconfig ${KUBELET_APISERVER} "8080" "http"
     else
       create-kubelet-kubeconfig ${KUBELET_APISERVER}
@@ -1691,11 +1689,12 @@ function start-kube-apiserver {
     params+=" --etcd-keyfile=${ETCD_APISERVER_CLIENT_KEY_PATH}"
   fi
   params+=" --secure-port=443"
-  if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" != "true" ]]; then
+  if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" == "false" ]]; then
     # Default is :8080
     params+=" --insecure-port=0"
-  else
-    params+=" --insecure-bind-address=0.0.0.0 --insecure-port=8080"
+  fi
+  if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]] || [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+    params+=" --insecure-bind-address=0.0.0.0"
   fi
   params+=" --tls-cert-file=${APISERVER_SERVER_CERT_PATH}"
   params+=" --tls-private-key-file=${APISERVER_SERVER_KEY_PATH}"
@@ -2196,12 +2195,8 @@ function apply-encryption-config() {
 #   DOCKER_REGISTRY
 function start-kube-controller-manager {
   echo "Start kubernetes controller-manager"
-  if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" == "true" ]]; then
-    if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]] || [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-      create-kubeconfig "kube-controller-manager" ${KUBE_CONTROLLER_MANAGER_TOKEN} "${PROXY_RESERVED_IP}" "8888" "http"
-    else
-      create-kubeconfig "kube-controller-manager" ${KUBE_CONTROLLER_MANAGER_TOKEN} "localhost" "8080" "http"
-    fi
+  if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]] || [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+    create-kubeconfig "kube-controller-manager" ${KUBE_CONTROLLER_MANAGER_TOKEN} "${PROXY_RESERVED_IP}" "8888" "http"
   else
     create-kubeconfig "kube-controller-manager" ${KUBE_CONTROLLER_MANAGER_TOKEN}
   fi
@@ -2326,12 +2321,8 @@ function start-workload-controller-manager {
   mkdir -p /etc/srv/kubernetes/workload-controller-manager
   echo "Start workload controller-manager"
   local master_ip=${1:-}  #optional
-  if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" == "true" ]]; then
-    if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]] || [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-      create-kubeconfig "workload-controller-manager" ${WORKLOAD_CONTROLLER_MANAGER_TOKEN} ${PROXY_RESERVED_IP} "8888" "http"
-    else
-      create-kubeconfig "workload-controller-manager" ${WORKLOAD_CONTROLLER_MANAGER_TOKEN} ${master_ip} "8080" "http"
-    fi
+  if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]] || [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+    create-kubeconfig "workload-controller-manager" ${WORKLOAD_CONTROLLER_MANAGER_TOKEN} ${PROXY_RESERVED_IP} "8888" "http"
   else
     create-kubeconfig "workload-controller-manager" ${WORKLOAD_CONTROLLER_MANAGER_TOKEN} ${master_ip}
   fi
@@ -2380,12 +2371,8 @@ function start-workload-controller-manager {
 #   DOCKER_REGISTRY
 function start-kube-scheduler {
   echo "Start kubernetes scheduler"
-  if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" == "true" ]]; then
-    if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-      create-kubeconfig "kube-scheduler" ${KUBE_SCHEDULER_TOKEN} "${PROXY_RESERVED_IP}" "8888" "http"
-    else
-      create-kubeconfig "kube-scheduler" ${KUBE_SCHEDULER_TOKEN} "localhost" "8080" "http"
-    fi
+  if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+    create-kubeconfig "kube-scheduler" ${KUBE_SCHEDULER_TOKEN} "${PROXY_RESERVED_IP}" "8888" "http"
   else
     create-kubeconfig "kube-scheduler" ${KUBE_SCHEDULER_TOKEN}
   fi
@@ -2435,12 +2422,8 @@ function start-cluster-autoscaler {
   if [[ "${ENABLE_CLUSTER_AUTOSCALER:-}" == "true" ]]; then
     echo "Start kubernetes cluster autoscaler"
     setup-addon-manifests "addons" "rbac/cluster-autoscaler"
-    if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" == "true" ]]; then
-      if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-        create-kubeconfig "cluster-autoscaler" ${KUBE_CLUSTER_AUTOSCALER_TOKEN} "${PROXY_RESERVED_IP}" "8888" "http"
-      else
-        create-kubeconfig "cluster-autoscaler" ${KUBE_CLUSTER_AUTOSCALER_TOKEN} "localhost" "8080" "http"
-      fi
+    if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]] || [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+      create-kubeconfig "cluster-autoscaler" ${KUBE_CLUSTER_AUTOSCALER_TOKEN} "${PROXY_RESERVED_IP}" "8888" "http"
     else
       create-kubeconfig "cluster-autoscaler" ${KUBE_CLUSTER_AUTOSCALER_TOKEN}
     fi
@@ -2789,12 +2772,10 @@ function start-kube-addons {
   local -r src_dir="${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty"
   local -r dst_dir="/etc/kubernetes/addons"
 
-  if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" == "true" ]]; then
-    if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-      create-kubeconfig "addon-manager" ${ADDON_MANAGER_TOKEN} "${PROXY_RESERVED_IP}" "8888" "http"
-    else
-      create-kubeconfig "addon-manager" ${ADDON_MANAGER_TOKEN} "localhost" "8080" "http"
-    fi
+  if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+    create-kubeconfig "addon-manager" ${ADDON_MANAGER_TOKEN} "${PROXY_RESERVED_IP}" "8888" "http"
+  elif [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
+    create-kubeconfig "addon-manager" ${ADDON_MANAGER_TOKEN} "localhost" "8080" "http"
   else
     create-kubeconfig "addon-manager" ${ADDON_MANAGER_TOKEN}
   fi
@@ -3032,12 +3013,10 @@ function start-lb-controller {
     prepare-log-file /var/log/glbc.log
     setup-addon-manifests "addons" "cluster-loadbalancing/glbc"
     setup-addon-manifests "addons" "rbac/cluster-loadbalancing/glbc"
-    if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" == "true" ]]; then
-      if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-        create-kubeconfig "l7-lb-controller" ${GCE_GLBC_TOKEN} "${PROXY_RESERVED_IP}" "8888" "http"
-      else
-        create-kubeconfig "l7-lb-controller" ${GCE_GLBC_TOKEN} "localhost" "8080" "http"
-      fi
+    if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+      create-kubeconfig "l7-lb-controller" ${GCE_GLBC_TOKEN} "${PROXY_RESERVED_IP}" "8888" "http"
+    elif [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
+      create-kubeconfig "l7-lb-controller" ${GCE_GLBC_TOKEN} "localhost" "8080" "http"
     else
       create-kubeconfig "l7-lb-controller" ${GCE_GLBC_TOKEN}
     fi
@@ -3197,12 +3176,10 @@ function ensure-master-bootstrap-kubectl-auth {
   # If the insecure port is disabled, kubectl will need to use an admin-authenticated kubeconfig.
   local master_ip=${1:-localhost}
   if [[ -n "${KUBE_BOOTSTRAP_TOKEN:-}" ]]; then
-    if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" == "true" ]]; then
-      if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-        create-kubeconfig "kube-bootstrap" "${KUBE_BOOTSTRAP_TOKEN}" "${PROXY_RESERVED_IP}" "8888" "http"
-      else
-        create-kubeconfig "kube-bootstrap" "${KUBE_BOOTSTRAP_TOKEN}" "${master_ip}" "8080" "http"
-      fi
+    if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+      create-kubeconfig "kube-bootstrap" "${KUBE_BOOTSTRAP_TOKEN}" "${PROXY_RESERVED_IP}" "8888" "http"
+    elif [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
+      create-kubeconfig "kube-bootstrap" "${KUBE_BOOTSTRAP_TOKEN}" "${master_ip}" "8080" "http"
     else
       create-kubeconfig "kube-bootstrap" "${KUBE_BOOTSTRAP_TOKEN}" "${master_ip}"
     fi

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -95,10 +95,10 @@ function main() {
     gke-master-start
   else
     create-node-pki
-    if [[ "${ENABLE_APISERVER_INSECURE_PORT:-false}" != "true" ]]; then
-      create-kubelet-kubeconfig ${KUBERNETES_MASTER_NAME}
-    else
+    if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]] || [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
       create-kubelet-kubeconfig ${KUBERNETES_MASTER_NAME} "8080" "http"
+    else
+      create-kubelet-kubeconfig ${KUBERNETES_MASTER_NAME}
     fi
     if [[ "${KUBE_PROXY_DAEMONSET:-}" != "true" ]]; then
       create-kubeproxy-user-kubeconfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Currently in master branch, ENABLE_APISERVER_SECURE_PORT is broken, kube-up does not work. This fixes the issue for scaleup architecture by passing the ENABLE_APISERVER_SECURE_PORT to master vm configuration script, and uses ports 8080/8888 appropriately for scaleout architecture while retaining normal operation for scaleup.

Tested this by deploying 1TP-1RP cluster in scale-out-poc branch, and deploying ENABLE_INSECURE_PORT set to true as well as false and successfully bringing up scaleup cluster in both cases in master branch.

**Which issue(s) this PR fixes**: 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
