### PR TITLE
fix issue that causes wrong service tier in scale-out

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2241,7 +2241,7 @@ function create-node-template() {
   fi
 
   local address=""
-  if [[ ${GCE_PRIVATE_CLUSTER:-} == "true" ]]; then
+  if [[ "${SCALEOUT_CLUSTER:-false}" == "false" ]] && [[ ${GCE_PRIVATE_CLUSTER:-} == "true" ]]; then
     address="no-address"
   fi
 


### PR DESCRIPTION
### Changes
For scale-out, do not evaluate GCE_PRIVATE_CLUSTER for network

### Validation:
1. local 1-box
2. 100-node scale-up
3. 100-node scale-out