### PR TITLE
Secure client--proxy API for scaleout, and remove generation of unnecessary kubeconfig files

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -92,21 +92,16 @@ function create-kubeconfig() {
   )
 
   if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
-    if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-      if [[ "${PROXY_RESERVED_IP}" == "" ]]; then
-        echo "Fatal Error: proxy IP is empty!"
-        exit 1
-      fi
+    if [[ "${KUBERNETES_SCALEOUT_PROXY_KUBECFG:-false}" == "true" ]]; then
       cluster_args=(
-          "--server=${KUBE_SERVER:-http://${PROXY_RESERVED_IP}}:8888"
+          "--server=${KUBE_SERVER:-https://${PROXY_RESERVED_IP}}:443"
        )
-    fi
-    if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
+    elif [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]] || [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
       cluster_args=(
           "--server=${KUBE_SERVER:-http://${KUBE_MASTER_IP}}:8080"
        )
     fi
-  fi    
+  fi
 
   if [[ -z "${CA_CERT:-}" ]]; then
     cluster_args+=("--insecure-skip-tls-verify=true")

--- a/hack/scale_out_poc/config_haproxy/haproxy.cfg.template
+++ b/hack/scale_out_poc/config_haproxy/haproxy.cfg.template
@@ -63,6 +63,7 @@ KUBEMARK_ONLY:    stats refresh 10s
 
 frontend scale-out-proxy
     bind *:{{ proxy_port }} alpn h2,http/1.1
+    bind *:443 ssl crt /etc/haproxy/pki/kubemark-client-proxy.pem
 
     {{ tp_request_acl }}    
     {{ rp_request_acl }}

--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -39,18 +39,17 @@ function create-kubemark-master {
     # All calls to e2e-grow-cluster must share temp dir with initial e2e-up.sh.
     kube::util::ensure-temp-dir
     export KUBE_TEMP="${KUBE_TEMP}"
-    export LOCAL_KUBECONFIG_TMP
     export LOCAL_KUBECONFIG
 
     KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark"
     KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX:-e2e-test-${USER}}-kubemark"
     SCALEOUT_PROXY_NAME="${KUBE_GCE_INSTANCE_PREFIX}-proxy"
     if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then     
-      KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-rp"
+      KUBECONFIG="${RP_KUBECONFIG}"
       KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-rp"
     fi
     if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-      KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp"
+      KUBECONFIG="${TP_KUBECONFIG}-${TENANT_PARTITION_SEQUENCE}"
       KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-tp-${TENANT_PARTITION_SEQUENCE}"     
     fi
 

--- a/test/kubemark/stop-kubemark.sh
+++ b/test/kubemark/stop-kubemark.sh
@@ -58,12 +58,9 @@ if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
   export KUBERNETES_RESOURCE_PARTITION=true
   export KUBERNETES_SCALEOUT_PROXY=true
   delete-kubemark-master
-  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark-rp"
-  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark.proxy"
-  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp"
-  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark.*.direct"
-  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark.*.saved"
-  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark.*.tmp"
+  rm -rf ${RESOURCE_DIRECTORY}/kubeconfig.kubemark-proxy
+  rm -rf ${RESOURCE_DIRECTORY}/kubeconfig.kubemark-rp
+  rm -rf ${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp-*
 else
   delete-kubemark-master
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
/kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Currently we use insecure port 8080 for all API communication in scaleout architecture. This PR does two things:
1. Secures the client ---- haproxy communication to use SSL with certificates generated by proxy as CA. (Intra-scaleout communication is still insecure after this PR. Yunwen will have a PR for that after integrating with this)
2. Cleanup several unnecessary and confusing intermediate kubeconfigs that are generated as part of scaleout cluster deployment.

Following testing was done:
A. Deploy admin cluster (ensure no regression) 
B. Deploy scaleup (normal) 100 node cluster (ensure no regression)
C. Deploy 1TP 1RP scaleout cluster and verify that port 443/https is used for client -- proxy communication.
D. Deploy 2TP 1RP scaleout cluster and verify that port 443/https is used for client -- proxy communication.

Verified get nodes, get pod all-NS, and create-pod works.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
After this change, all the unnecessary kubeconfigs are gone.
------------------------------------------------------------

...
...
Listing kubeamrk cluster details:
Getting total nodes number:
2

Getting total hollow-nodes number:
0
vin@fw0000357:~/go/src/k8s.io/kubernetes$ git status .
On branch scale-out-poc
Your branch is up-to-date with 'origin/scale-out-poc'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	test/kubemark/resources/addons/
	test/kubemark/resources/haproxy.cfg.tmp
	test/kubemark/resources/hollow-node.yaml
	test/kubemark/resources/kubeconfig.kubemark-proxy
	test/kubemark/resources/kubeconfig.kubemark-rp
	test/kubemark/resources/kubeconfig.kubemark-tp-1

nothing added to commit but untracked files present (use "git add" to track)
vin@fw0000357:~/go/src/k8s.io/kubernetes$

```
