### PR TITLE
add a switch to disable PV in load test

### DIFF
--- a/perf-tests/clusterloader2/testing/experiments/disable_pvs.yaml
+++ b/perf-tests/clusterloader2/testing/experiments/disable_pvs.yaml
@@ -1,0 +1,1 @@
+CL2_ENABLE_PVS: false

--- a/perf-tests/clusterloader2/testing/load/deployment.yaml
+++ b/perf-tests/clusterloader2/testing/load/deployment.yaml
@@ -1,5 +1,6 @@
 {{$CpuRequest := DefaultParam .CpuRequest "10m"}}
 {{$MemoryRequest := DefaultParam .MemoryRequest "10M"}}
+{{$EnablePVs := DefaultParam .CL2_ENABLE_PVS true}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -27,6 +28,7 @@ spec:
           requests:
             cpu: {{$CpuRequest}}
             memory: {{$MemoryRequest}}
+        {{if $EnablePVs}}
         volumeMounts:
           {{if (eq (Mod .Index 20) 0 19) }} # .Index % 20 in {0,19} - 10% deployments will have ConfigMap
           - name: configmap
@@ -36,6 +38,7 @@ spec:
           - name: secret
             mountPath: /var/secret
           {{end}}
+        {{end}}
       dnsPolicy: Default
       terminationGracePeriodSeconds: 1
       # Add not-ready/unreachable tolerations for 15 minutes so that node
@@ -49,6 +52,7 @@ spec:
         operator: "Exists"
         effect: "NoExecute"
         tolerationSeconds: 900
+      {{if $EnablePVs}}
       volumes:
         {{if (eq (Mod .Index 20) 0 19) }} # .Index % 20 in {0,19} - 10% deployments will have ConfigMap
         - name: configmap
@@ -60,4 +64,5 @@ spec:
           secret:
             secretName: {{.BaseName}}-{{.Index}}
         {{end}}
+      {{end}}
 


### PR DESCRIPTION
Scale-out and Scale-up load tests both failed due ot PV/PVC processing of deployments&statefulsets. The deployments/statefulset which uses volumes will never get the pods in "Running" state.  As we are continuing to solve issue (tracked in https://github.com/CentaurusInfra/arktos/issues/978), this PR provides a switch to skip this issue temporarily.

When the env var  CL2_ENABLE_PVS is set to false, the test deployments&statefulsets will be created without attaching to PVs.

### Verification:
This PR was tested on top of https://github.com/CentaurusInfra/arktos/pull/976, which fixed another error in load-test, and I got the following result:
1. Scale-up 100-node load test succeeded with commandline test-configs "--testconfig=testing/load/config.yaml --testoverrides=./testing/experiments/disable_pvs.yaml".
1. Scale-out 100-node load test succeeded with commandline test-configs "--testconfig=testing/load/config.yaml --testoverrides=./testing/experiments/disable_pvs.yaml".
3. Scale-up 100-node density test succeeded
4. Scale-out 100-node density test succeeded

