### PR TITLE
Fix pod/service deleting issue

### DIFF
--- a/hack/make-rules/update.sh
+++ b/hack/make-rules/update.sh
@@ -86,6 +86,8 @@ MODIFIED_FILES=$(git status | grep modified:) || true
 if [[ "${MODIFIED_FILES:-}" != "" ]]; then
 	echo "Following files are updated:"
 	echo $MODIFIED_FILES
+	FILE_DIFF=$(git diff)
+	echo $FILE_DIFF
 	exit 1
 fi
 echo "Check completed."

--- a/hack/make-rules/update.sh
+++ b/hack/make-rules/update.sh
@@ -86,8 +86,6 @@ MODIFIED_FILES=$(git status | grep modified:) || true
 if [[ "${MODIFIED_FILES:-}" != "" ]]; then
 	echo "Following files are updated:"
 	echo $MODIFIED_FILES
-	FILE_DIFF=$(git diff)
-	echo $FILE_DIFF
 	exit 1
 fi
 echo "Check completed."

--- a/pkg/controller/mizar/mizar-node-controller.go
+++ b/pkg/controller/mizar/mizar-node-controller.go
@@ -174,7 +174,7 @@ func (c *MizarNodeController) handle(keyWithEventType KeyWithEventType) error {
 		klog.V(4).Infof("Finished handling %v %q (%v)", controllerForMizarNode, key, time.Since(startTime))
 	}()
 
-	tenant, namespace, name, err := cache.SplitMetaTenantNamespaceKey(key)
+	_, _, name, err := cache.SplitMetaTenantNamespaceKey(key)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/mizar/mizar-pod-controller.go
+++ b/pkg/controller/mizar/mizar-pod-controller.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -178,23 +179,25 @@ func (c *MizarPodController) handle(keyWithEventType KeyWithEventType) error {
 		return err
 	}
 
-	var obj *v1.Pod
-	if eventType == EventType_Delete {
-		obj = &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-				Tenant:    tenant,
-			},
-		}
-	} else {
-		obj, err = c.lister.PodsWithMultiTenancy(namespace, tenant).Get(name)
-		if err != nil {
+	obj, err := c.lister.PodsWithMultiTenancy(namespace, tenant).Get(name)
+	if err != nil {
+		if eventType == EventType_Delete {
+			obj = &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Tenant:    tenant,
+				},
+			}
+			if !errors.IsNotFound(err) {
+				klog.Errorf("Should get NotFound error when retrieving deleted object %s/%s/%s but got error: %v", tenant, namespace, name, err)
+			}
+		} else {
 			return err
 		}
 	}
 
-	klog.V(4).Infof("Handling %v %s/%s/%s hashkey %v for event %v", controllerForMizarPod, tenant, namespace, obj.Name, obj.HashKey, eventType)
+	klog.V(4).Infof("Handling %v %s/%s/%s for event %v", controllerForMizarPod, tenant, namespace, name, eventType)
 
 	switch eventType {
 	case EventType_Create:

--- a/pkg/controller/mizar/mizar-pod-controller.go
+++ b/pkg/controller/mizar/mizar-pod-controller.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -181,7 +181,7 @@ func (c *MizarPodController) handle(keyWithEventType KeyWithEventType) error {
 
 	obj, err := c.lister.PodsWithMultiTenancy(namespace, tenant).Get(name)
 	if err != nil {
-		if eventType == EventType_Delete && apierrors.IsNotFound(err) {
+		if eventType == EventType_Delete && errors.IsNotFound(err) {
 			obj = &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,

--- a/pkg/controller/mizar/mizar-pod-controller.go
+++ b/pkg/controller/mizar/mizar-pod-controller.go
@@ -178,9 +178,20 @@ func (c *MizarPodController) handle(keyWithEventType KeyWithEventType) error {
 		return err
 	}
 
-	obj, err := c.lister.PodsWithMultiTenancy(namespace, tenant).Get(name)
-	if err != nil {
-		return err
+	var obj *v1.Pod
+	if eventType == EventType_Delete {
+		obj = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Tenant:    tenant,
+			},
+		}
+	} else {
+		obj, err = c.lister.PodsWithMultiTenancy(namespace, tenant).Get(name)
+		if err != nil {
+			return err
+		}
 	}
 
 	klog.V(4).Infof("Handling %v %s/%s/%s hashkey %v for event %v", controllerForMizarPod, tenant, namespace, obj.Name, obj.HashKey, eventType)

--- a/pkg/controller/mizar/mizar-pod-controller.go
+++ b/pkg/controller/mizar/mizar-pod-controller.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -181,16 +181,13 @@ func (c *MizarPodController) handle(keyWithEventType KeyWithEventType) error {
 
 	obj, err := c.lister.PodsWithMultiTenancy(namespace, tenant).Get(name)
 	if err != nil {
-		if eventType == EventType_Delete {
+		if eventType == EventType_Delete && apierrors.IsNotFound(err) {
 			obj = &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: namespace,
 					Tenant:    tenant,
 				},
-			}
-			if !errors.IsNotFound(err) {
-				klog.Errorf("Should get NotFound error when retrieving deleted object %s/%s/%s but got error: %v", tenant, namespace, name, err)
 			}
 		} else {
 			return err

--- a/pkg/controller/mizar/mizar-service-controller.go
+++ b/pkg/controller/mizar/mizar-service-controller.go
@@ -182,9 +182,12 @@ func (c *MizarServiceController) syncService(eventKeyWithType KeyWithEventType) 
 		return err
 	}
 
-	svc, err := c.serviceLister.ServicesWithMultiTenancy(namespace, tenant).Get(name)
-	if err != nil {
-		return err
+	var svc *v1.Service
+	if event != EventType_Delete {
+		svc, err = c.serviceLister.ServicesWithMultiTenancy(namespace, tenant).Get(name)
+		if err != nil {
+			return err
+		}
 	}
 
 	klog.Infof("Mizar-Service-controller - get service: %#v.", svc)

--- a/pkg/controller/mizar/mizar-service-controller.go
+++ b/pkg/controller/mizar/mizar-service-controller.go
@@ -185,11 +185,7 @@ func (c *MizarServiceController) syncService(eventKeyWithType KeyWithEventType) 
 
 	svc, err := c.serviceLister.ServicesWithMultiTenancy(namespace, tenant).Get(name)
 	if err != nil {
-		if event == EventType_Delete {
-			if !apierrors.IsNotFound(err) {
-				klog.Errorf("Should get NotFound error when retrieving deleted object %s/%s/%s but got error: %v", tenant, namespace, name, err)
-			}
-		} else {
+		if event != EventType_Delete || !apierrors.IsNotFound(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
Currently in mizar pod and service controller, when deleting the object, the code will try to retrieve the object. Since the object has already been deleted, the deleting operation will always trigger an error.

The issue happens only when mizar is running because it happens in mizar controllers.

The fix: when deleting object, don't retrieve it at that time. Instead, just send the name, namespace, tenant info to mizar backend for deleting.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Current pod and service deleting will always throw error for mizar controllers.
