### PR TITLE
Read Arktos version from file instead of environment variable

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright 2014 The Kubernetes Authors.
+# Copyright 2020 Authors of Arktos - file modified.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,6 +27,9 @@
 #    KUBE_GIT_VERSION - "vX.Y" used to indicate the last release version.
 #    KUBE_GIT_MAJOR - The major part of the version
 #    KUBE_GIT_MINOR - The minor component of the version
+
+# set default KUBE_GIT_VERSION_FILE
+KUBE_GIT_VERSION_FILE="${KUBE_ROOT}/pkg/version/VERSION.sh"
 
 # Grovels through git to set a set of env variables.
 #

--- a/pkg/version/VERSION.sh
+++ b/pkg/version/VERSION.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Authors of Arktos.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export KUBE_GIT_VERSION=v0.7.0


### PR DESCRIPTION
With this change, CI tools and dev local environments no longer need to change KUBE_GIT_VERSION when Arktos version is updated.
Each Arktos release will need to update pkg/version/VERSION.sh

