### PR TITLE
Use secure communication for client <--> proxy communication, cleanup unnecessary config files

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -92,16 +92,11 @@ function create-kubeconfig() {
   )
 
   if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
-    if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-      if [[ "${PROXY_RESERVED_IP}" == "" ]]; then
-        echo "Fatal Error: proxy IP is empty!"
-        exit 1
-      fi
+    if [[ "${KUBERNETES_SCALEOUT_PROXY_KUBECFG:-false}" == "true" ]]; then
       cluster_args=(
-          "--server=${KUBE_SERVER:-http://${PROXY_RESERVED_IP}}:8888"
+          "--server=${KUBE_SERVER:-https://${PROXY_RESERVED_IP}}:443"
        )
-    fi
-    if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
+    elif [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]] || [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
       cluster_args=(
           "--server=${KUBE_SERVER:-http://${KUBE_MASTER_IP}}:8080"
        )

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1700,6 +1700,7 @@ function create-certs {
       sans="${sans}IP:${extra},"
     fi
   done
+
   sans="${sans}IP:${service_ip},DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.${DNS_DOMAIN},DNS:${MASTER_NAME}"
 
   echo "Generating certs for alternate-names: ${sans}"
@@ -1739,6 +1740,10 @@ function create-certs {
 #   CERT_DIR
 #   AGGREGATOR_CERT_DIR
 function setup-easyrsa {
+  if [ -n "${CERT_DIR+x}" ]; then
+    echo "CERT_DIR is already set to ${CERT_DIR}"
+    return 0
+  fi
   local -r cert_create_debug_output=$(mktemp "${KUBE_TEMP}/cert_create_debug_output.XXX")
   # Note: This was heavily cribbed from make-ca-cert.sh
   (set -x
@@ -1747,6 +1752,8 @@ function setup-easyrsa {
     tar xzf easy-rsa.tar.gz
     mkdir easy-rsa-master/kubelet
     cp -r easy-rsa-master/easyrsa3/* easy-rsa-master/kubelet
+    mkdir easy-rsa-master/proxy
+    cp -r easy-rsa-master/easyrsa3/* easy-rsa-master/proxy
     mkdir easy-rsa-master/aggregator
     cp -r easy-rsa-master/easyrsa3/* easy-rsa-master/aggregator) &>${cert_create_debug_output} || true
   CERT_DIR="${KUBE_TEMP}/easy-rsa-master/easyrsa3"
@@ -1756,6 +1763,91 @@ function setup-easyrsa {
     # see https://github.com/kubernetes/kubernetes/issues/55229
     cat "${cert_create_debug_output}" >&2
     echo "=== Failed to setup easy-rsa: Aborting ===" >&2
+    exit 2
+  fi
+}
+
+# Create certificate pairs for the cluster.
+# $1: The public IP for the proxy.
+#
+# The following certificate pairs are created:
+#  - ca (the cluster's certificate authority)
+#  - proxy server
+#  - kubecfg (for kubectl)
+#
+# Assumed vars
+#   CERT_DIR
+#   PROXY_NAME
+#
+# Vars set:
+#   PROXY_CA_CERT_BASE64
+#   PROXY_CA_KEY_BASE64
+#   PROXY_CERT_BASE64
+#   PROXY_KEY_BASE64
+#   PROXY_KUBECFG_CERT_BASE64
+#   PROXY_KUBECFG_KEY_BASE64
+function create-proxy-certs {
+  local -r primary_cn="${1}"
+
+  # Determine extra certificate names for master
+  local octets=($(echo "${SERVICE_CLUSTER_IP_RANGE}" | sed -e 's|/.*||' -e 's/\./ /g'))
+  ((octets[3]+=1))
+  local -r service_ip=$(echo "${octets[*]}" | sed 's/ /./g')
+  local sans=""
+  for extra in $@; do
+    if [[ -n "${extra}" ]]; then
+      sans="${sans}IP:${extra},"
+    fi
+  done
+  sans="${sans}IP:${service_ip},DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.${DNS_DOMAIN},DNS:${PROXY_NAME}"
+
+  echo "Generating proxy certs primary_cn: ${primary_cn}, proxy_name: ${PROXY_NAME}, alternate-names: ${sans}"
+
+  setup-easyrsa
+  PRIMARY_CN="${primary_cn}" SANS="${sans}" generate-proxy-certs
+
+  # By default, linux wraps base64 output every 76 cols, so we use 'tr -d' to remove whitespaces.
+  # Note 'base64 -w0' doesn't work on Mac OS X, which has different flags.
+  PROXY_CA_CERT_BASE64=$(cat "${KUBE_TEMP}/easy-rsa-master/proxy/pki/ca.crt" | base64 | tr -d '\r\n')
+  PROXY_CA_KEY_BASE64=$(cat "${KUBE_TEMP}/easy-rsa-master/proxy/pki/private/ca.key" | base64 | tr -d '\r\n')
+  PROXY_CERT_BASE64=$(cat "${KUBE_TEMP}/easy-rsa-master/proxy/pki/issued/${PROXY_NAME}.crt" | base64 | tr -d '\r\n')
+  PROXY_KEY_BASE64=$(cat "${KUBE_TEMP}/easy-rsa-master/proxy/pki/private/${PROXY_NAME}.key" | base64 | tr -d '\r\n')
+  PROXY_KUBECFG_CERT_BASE64=$(cat "${KUBE_TEMP}/easy-rsa-master/proxy/pki/issued/kubecfg.crt" | base64 | tr -d '\r\n')
+  PROXY_KUBECFG_KEY_BASE64=$(cat "${KUBE_TEMP}/easy-rsa-master/proxy/pki/private/kubecfg.key" | base64 | tr -d '\r\n')
+}
+
+function generate-proxy-certs {
+  local -r cert_create_debug_output=$(mktemp "${KUBE_TEMP}/proxy_cert_create_debug_output.XXX")
+  (set -x
+    cd "${KUBE_TEMP}/easy-rsa-master/proxy"
+    ./easyrsa init-pki
+    # this puts the cert into pki/ca.crt and the key into pki/private/ca.key
+    ./easyrsa --batch "--req-cn=${PRIMARY_CN}@$(date +%s)" build-ca nopass
+    ./easyrsa --subject-alt-name="${SANS}" build-server-full "${PROXY_NAME}" nopass
+
+    # Make a superuser client cert with subject "O=tenant:system, OU=system:masters, CN=kubecfg"
+    ./easyrsa --dn-mode=org \
+      --req-cn=kubecfg --req-org=tenant:system \
+      --req-c= --req-st= --req-city= --req-email= --req-ou=system:masters \
+      build-client-full kubecfg nopass) &>${cert_create_debug_output} || true
+  local output_file_missing=0
+  local output_file
+  for output_file in \
+    "${KUBE_TEMP}/easy-rsa-master/proxy/pki/private/ca.key" \
+    "${KUBE_TEMP}/easy-rsa-master/proxy/pki/ca.crt" \
+    "${KUBE_TEMP}/easy-rsa-master/proxy/pki/issued/${PROXY_NAME}.crt" \
+    "${KUBE_TEMP}/easy-rsa-master/proxy/pki/private/${PROXY_NAME}.key" \
+    "${KUBE_TEMP}/easy-rsa-master/proxy/pki/issued/kubecfg.crt" \
+    "${KUBE_TEMP}/easy-rsa-master/proxy/pki/private/kubecfg.key"
+  do
+    if [[ ! -s "${output_file}" ]]; then
+      echo "Expected file ${output_file} not created" >&2
+      output_file_missing=1
+    fi
+  done
+  if (( $output_file_missing )); then
+    cat "${cert_create_debug_output}" >&2
+    echo "=== Failed to generate master certificates: Aborting ===" >&2
     exit 2
   fi
 }
@@ -2373,12 +2465,6 @@ function kube-up() {
     check-cluster
 
     if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
-      if [ -z "${LOCAL_KUBECONFIG_TMP:-}" ]; then
-        echo "Local_kubeconfig_tmp not set"
-      else
-        cp -f ${KUBECONFIG} ${LOCAL_KUBECONFIG_TMP}
-        echo "DBG:" grep -i "server:" ${LOCAL_KUBECONFIG_TMP}
-      fi
       if [[ "${KUBERNETES_SCALEOUT_PROXY:-false}" == "true" ]]; then
         echo "Logging open file limits configured for $KUBERNETES_SCALEOUT_PROXY_APP"
         echo "-----------------------------"
@@ -2767,6 +2853,10 @@ function create-proxy-vm() {
     --project "${PROJECT}" --region "${REGION}" -q --format='value(address)')
   PROXY_RESERVED_INTERNAL_IP=$(gcloud compute addresses describe "${PROXY_NAME}-internalip" \
     --project "${PROJECT}" --region "${REGION}" -q --format='value(address)')
+
+  echo "PROXY_NAME: ${PROXY_NAME} PROXY_RESERVED_IP: ${PROXY_RESERVED_IP}, PROXY_RESERVED_INTERNAL_IP: ${PROXY_RESERVED_INTERNAL_IP}"
+  create-proxy-certs "${PROXY_RESERVED_IP}" "${PROXY_RESERVED_INTERNAL_IP}"
+
   local enable_ip_aliases
   if [[ "${NODE_IPAM_MODE:-}" == "CloudAllocator" ]]; then
     enable_ip_aliases=true
@@ -2793,6 +2883,7 @@ function create-proxy-vm() {
       echo "${result}" >&2
       export PROXY_RESERVED_IP
       export PROXY_RESERVED_INTERNAL_IP
+
       return 0
     else
       echo "${result}" >&2
@@ -2858,6 +2949,15 @@ function setup-proxy() {
 
   patch-haproxy-prometheus
   direct-haproxy-logging
+
+  pushd ${KUBE_TEMP}/easy-rsa-master/proxy
+  cat pki/issued/${PROXY_NAME}.crt > pki/kubemark-client-proxy.pem
+  cat pki/private/${PROXY_NAME}.key >> pki/kubemark-client-proxy.pem
+  tar -cpvzf scaleout-proxy-certs.tar.gz pki
+  popd
+  gcloud compute scp --zone="${ZONE}" "${KUBE_TEMP}/easy-rsa-master/proxy/scaleout-proxy-certs.tar.gz" "${PROXY_NAME}:~/"
+  ssh-to-node ${PROXY_NAME} "sudo tar -xpf ~/scaleout-proxy-certs.tar.gz -C /etc/haproxy/"
+  ssh-to-node ${PROXY_NAME} "sudo chmod +rx /etc/haproxy/pki"
 
   ssh-to-node ${PROXY_NAME} "sudo sed -i '/^ExecStart=.*/a ExecStartPost=/bin/bash -c \"sleep 20 && for npid in \$(pidof ${KUBERNETES_SCALEOUT_PROXY_APP}); do sudo prlimit --pid \$npid --nofile=500000:500000 ; done\"' /lib/systemd/system/${KUBERNETES_SCALEOUT_PROXY_APP}.service"
   ssh-to-node ${PROXY_NAME} "sudo systemctl daemon-reload"
@@ -3000,7 +3100,7 @@ function create-master() {
   CREATE_CERT_SERVER_IP="${MASTER_RESERVED_INTERNAL_IP}"
   ###set partition server name, ip
   set-partitionserver true
-  echo "CREATE_CERT_SERVER_IP: ${CREATE_CERT_SERVER_IP}"
+  echo "MASTER_RESERVED_IP: ${MASTER_RESERVED_IP}, CREATE_CERT_SERVER_IP: ${CREATE_CERT_SERVER_IP}"
   create-certs "${MASTER_RESERVED_IP}" "${CREATE_CERT_SERVER_IP}"
   create-etcd-certs "${MASTER_NAME}" "" "" "${CREATE_CERT_SERVER_IP}"
   create-etcd-apiserver-certs "etcd-${MASTER_NAME}" "${MASTER_NAME}" "" "" "${CREATE_CERT_SERVER_IP}"
@@ -3762,9 +3862,23 @@ function check-cluster() {
    # Update the user's kubeconfig to include credentials for this apiserver.
    create-kubeconfig
   )
-
   # ensures KUBECONFIG is set
   get-kubeconfig-basicauth
+
+  if [[ "${KUBERNETES_SCALEOUT_PROXY:-false}" == "true" ]]; then
+    export KUBE_CERT="${KUBE_TEMP}/easy-rsa-master/proxy/pki/issued/kubecfg.crt"
+    export KUBE_KEY="${KUBE_TEMP}/easy-rsa-master/proxy/pki/private/kubecfg.key"
+    export CA_CERT="${KUBE_TEMP}/easy-rsa-master/proxy/pki/ca.crt"
+    export CONTEXT="${PROJECT}_${SCALEOUT_PROXY_NAME}"
+    (
+     umask 077
+
+     # Update the user's kubeconfig to include credentials for this apiserver.
+     KUBERNETES_SCALEOUT_PROXY_KUBECFG=true KUBECONFIG=${PROXY_KUBECONFIG} create-kubeconfig
+    )
+    # ensures KUBECONFIG is set
+    get-kubeconfig-basicauth
+  fi
 
   if [[ ${GCE_UPLOAD_KUBCONFIG_TO_MASTER_METADATA:-} == "true" ]]; then
     gcloud compute instances add-metadata "${MASTER_NAME}" --zone="${ZONE}"  --metadata-from-file="kubeconfig=${KUBECONFIG}" || true

--- a/cmd/haproxy-cfg-generator/data/haproxy.cfg.template
+++ b/cmd/haproxy-cfg-generator/data/haproxy.cfg.template
@@ -63,6 +63,7 @@ KUBEMARK_ONLY:    stats refresh 10s
 
 frontend scale-out-proxy
     bind *:{{ proxy_port }} alpn h2,http/1.1
+    bind *:443 ssl crt /etc/haproxy/pki/kubemark-client-proxy.pem
 
     {{ tp_request_acl }}    
     {{ rp_request_acl }}

--- a/cmd/haproxy-cfg-generator/data/sample_four_tp_haproxy.cfg
+++ b/cmd/haproxy-cfg-generator/data/sample_four_tp_haproxy.cfg
@@ -56,6 +56,7 @@ defaults
 
 frontend scale-out-proxy
     bind *:8888 alpn h2,http/1.1
+    bind *:443 ssl crt /etc/haproxy/pki/kubemark-client-proxy.pem
 
     
     acl tp_1_request_2 path_reg ^/api/[a-z0-9_.-]+/tenants/(?!(system$|system/.*$|all$|all/.*$))([a-f].*)$

--- a/cmd/haproxy-cfg-generator/data/sample_one_tp_haproxy.cfg
+++ b/cmd/haproxy-cfg-generator/data/sample_one_tp_haproxy.cfg
@@ -56,6 +56,7 @@ defaults
 
 frontend scale-out-proxy
     bind *:8888 alpn h2,http/1.1
+    bind *:443 ssl crt /etc/haproxy/pki/kubemark-client-proxy.pem
 
     
     acl tp_1_request_2 path_reg ^/api/[a-z0-9_.-]+/tenants/(?!(system$|system/.*$|all$|all/.*$))([a-z].*)$

--- a/cmd/haproxy-cfg-generator/data/sample_three_tp_haproxy.cfg
+++ b/cmd/haproxy-cfg-generator/data/sample_three_tp_haproxy.cfg
@@ -56,6 +56,7 @@ defaults
 
 frontend scale-out-proxy
     bind *:8888 alpn h2,http/1.1
+    bind *:443 ssl crt /etc/haproxy/pki/kubemark-client-proxy.pem
 
     
     acl tp_1_request_2 path_reg ^/api/[a-z0-9_.-]+/tenants/(?!(system$|system/.*$|all$|all/.*$))([a-h].*)$

--- a/cmd/haproxy-cfg-generator/data/sample_two_tp_haproxy.cfg
+++ b/cmd/haproxy-cfg-generator/data/sample_two_tp_haproxy.cfg
@@ -56,6 +56,7 @@ defaults
 
 frontend scale-out-proxy
     bind *:8888 alpn h2,http/1.1
+    bind *:443 ssl crt /etc/haproxy/pki/kubemark-client-proxy.pem
 
     
     acl tp_1_request_2 path_reg ^/api/[a-z0-9_.-]+/tenants/(?!(system$|system/.*$|all$|all/.*$))([a-m].*)$

--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -39,18 +39,17 @@ function create-kubemark-master {
     # All calls to e2e-grow-cluster must share temp dir with initial e2e-up.sh.
     kube::util::ensure-temp-dir
     export KUBE_TEMP="${KUBE_TEMP}"
-    export LOCAL_KUBECONFIG_TMP
     export LOCAL_KUBECONFIG
 
     KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark"
     KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX:-e2e-test-${USER}}-kubemark"
     SCALEOUT_PROXY_NAME="${KUBE_GCE_INSTANCE_PREFIX}-proxy"
     if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "true" ]]; then
-      KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-rp"
+      KUBECONFIG="${RP_KUBECONFIG}"
       KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-rp"
     fi
     if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
-      KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp"
+      KUBECONFIG="${TP_KUBECONFIG}-${TENANT_PARTITION_SEQUENCE}"
       KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-tp-${TENANT_PARTITION_SEQUENCE}"
     fi
 

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -39,7 +39,6 @@ KUBECTL="${KUBE_ROOT}/cluster/kubectl.sh"
 KUBEMARK_DIRECTORY="${KUBE_ROOT}/test/kubemark"
 RESOURCE_DIRECTORY="${KUBEMARK_DIRECTORY}/resources"
 LOCAL_KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark"
-LOCAL_KUBECONFIG_TMP="${RESOURCE_DIRECTORY}/kubeconfig.kubemark.tmp"
 
 export SCALEOUT_TP_COUNT="${SCALEOUT_TP_COUNT:-1}"
 
@@ -47,13 +46,14 @@ export SCALEOUT_TP_COUNT="${SCALEOUT_TP_COUNT:-1}"
 ### those are used for targeted operations such as tenant creation etc on
 ### desired cluster directly
 ###
+PROXY_KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-proxy"
 TP_KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp"
-PROXY_KUBECONFIG_SAVED="${RESOURCE_DIRECTORY}/kubeconfig.kubemark.proxy.saved"
-RP_KUBECONFIG_SAVED="${RESOURCE_DIRECTORY}/kubeconfig.kubemark.rp.saved"
+RP_KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-rp"
 if [[ "${SCALEOUT_CLUSTER:-false}" == "false" ]]; then
   TP_KUBECONFIG="${LOCAL_KUBECONFIG}"
-  LOCAL_KUBECONFIG_TMP="${LOCAL_KUBECONFIG}"
-  RP_KUBECONFIG_SAVED="${LOCAL_KUBECONFIG}"
+  RP_KUBECONFIG="${LOCAL_KUBECONFIG}"
+else
+  LOCAL_KUBECONFIG="${RP_KUBECONFIG}"
 fi
 
 export KUBERNETES_SCALEOUT_PROXY_APP=${KUBERNETES_SCALEOUT_PROXY_APP:-haproxy}
@@ -124,17 +124,17 @@ function create-kube-hollow-node-resources {
   # It's bad that all component shares the same kubeconfig.
   # TODO(https://github.com/kubernetes/kubernetes/issues/79883): Migrate all components to separate credentials.
   "${KUBECTL}" create secret generic "kubeconfig" --type=Opaque --namespace="kubemark" \
-    --from-file=kubelet.kubeconfig="${TP_KUBECONFIG}" \
-    --from-file=kubeproxy.kubeconfig="${TP_KUBECONFIG}" \
-    --from-file=npd.kubeconfig="${RP_KUBECONFIG_SAVED}" \
-    --from-file=heapster.kubeconfig="${TP_KUBECONFIG}" \
-    --from-file=cluster_autoscaler.kubeconfig="${TP_KUBECONFIG}" \
-    --from-file=dns.kubeconfig="${TP_KUBECONFIG}"
+    --from-file=kubelet.kubeconfig="${KUBEMARK_KUBECONFIG}" \
+    --from-file=kubeproxy.kubeconfig="${KUBEMARK_KUBECONFIG}" \
+    --from-file=npd.kubeconfig="${RP_KUBECONFIG}" \
+    --from-file=heapster.kubeconfig="${KUBEMARK_KUBECONFIG}" \
+    --from-file=cluster_autoscaler.kubeconfig="${KUBEMARK_KUBECONFIG}" \
+    --from-file=dns.kubeconfig="${KUBEMARK_KUBECONFIG}"
 
   # Create addon pods.
   # Heapster.
   mkdir -p "${RESOURCE_DIRECTORY}/addons"
-  MASTER_IP=$(grep server "${LOCAL_KUBECONFIG_TMP}" | awk -F "/" '{print $3}')
+  MASTER_IP=$(grep server "${LOCAL_KUBECONFIG}" | awk -F "/" '{print $3}')
   sed "s@{{MASTER_IP}}@${MASTER_IP}@g" "${RESOURCE_DIRECTORY}/heapster_template.json" > "${RESOURCE_DIRECTORY}/addons/heapster.json"
   metrics_mem_per_node=4
   metrics_mem=$((200 + metrics_mem_per_node*NUM_NODES))
@@ -204,7 +204,7 @@ function wait-for-hollow-nodes-to-run-or-timeout {
   timeout_seconds=$1
   echo -n "Waiting for all hollow-nodes to become Running"
   start=$(date +%s)
-  nodes=$("${KUBECTL}" --kubeconfig="${TP_KUBECONFIG}" get node 2> /dev/null) || true
+  nodes=$("${KUBECTL}" --kubeconfig="${RP_KUBECONFIG}" get node 2> /dev/null) || true
   ready=$(($(echo "${nodes}" | grep -vc "NotReady") - 1))
 
   until [[ "${ready}" -ge "${NUM_REPLICAS}" ]]; do
@@ -216,7 +216,7 @@ function wait-for-hollow-nodes-to-run-or-timeout {
       # shellcheck disable=SC2154 # Color defined in sourced script
       echo -e "${color_red} Timeout waiting for all hollow-nodes to become Running. ${color_norm}"
       # Try listing nodes again - if it fails it means that API server is not responding
-      if "${KUBECTL}" --kubeconfig="${TP_KUBECONFIG}" get node &> /dev/null; then
+      if "${KUBECTL}" --kubeconfig="${RP_KUBECONFIG}" get node &> /dev/null; then
         echo "Found only ${ready} ready hollow-nodes while waiting for ${NUM_NODES}."
       else
         echo "Got error while trying to list hollow-nodes. Probably API server is down."
@@ -229,7 +229,7 @@ function wait-for-hollow-nodes-to-run-or-timeout {
       echo "${pods}" | grep -v Running
       exit 1
     fi
-    nodes=$("${KUBECTL}" --kubeconfig="${TP_KUBECONFIG}" get node 2> /dev/null) || true
+    nodes=$("${KUBECTL}" --kubeconfig="${RP_KUBECONFIG}" get node 2> /dev/null) || true
     ready=$(($(echo "${nodes}" | grep -vc "NotReady") - 1))
   done
   # shellcheck disable=SC2154 # Color defined in sourced script
@@ -264,18 +264,22 @@ detect-project &> /dev/null
 rm /tmp/saved_tenant_ips.txt >/dev/null 2>&1 || true
 
 if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
+  echo "DBG: Starting ${SCALEOUT_TP_COUNT} tenant partitions ..."
   export KUBE_ENABLE_APISERVER_INSECURE_PORT=true
   export KUBERNETES_TENANT_PARTITION=true
   export KUBERNETES_SCALEOUT_PROXY=true
+  export PROXY_KUBECONFIG
 
   for (( tp_num=1; tp_num<=${SCALEOUT_TP_COUNT}; tp_num++ ))
   do
     export TENANT_PARTITION_SEQUENCE=${tp_num}
     create-kubemark-master
 
-    MASTER_IP=$(grep server "${LOCAL_KUBECONFIG_TMP}" | awk -F "/" '{print $3}')
-    export PROXY_RESERVED_IP=$(echo ${MASTER_IP} | cut -d: -f1)
-    echo "DBG: PROXY_RESERVED_IP=$PROXY_RESERVED_IP"
+    if [[ "${KUBERNETES_SCALEOUT_PROXY}" == "true" ]]; then
+      export KUBERNETES_SCALEOUT_PROXY=false
+      PROXY_RESERVED_IP=$(grep server "${PROXY_KUBECONFIG}" | awk -F "/" '{print $3}' | cut -d: -f1)
+      export PROXY_RESERVED_IP
+    fi
 
     TP_SERVER="http://$(cat /tmp/master_reserved_ip.txt):8080"
     if [[ ${tp_num} == 1 ]]; then
@@ -283,27 +287,27 @@ if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
     else
       export TENANT_SERVERS="${TENANT_SERVERS},${TP_SERVER}"
     fi
-
-    cp -f ${LOCAL_KUBECONFIG_TMP} "${RESOURCE_DIRECTORY}/kubeconfig.kubemark.tp-${tp_num}.direct"
-    sed -i -e "s@http://${PROXY_RESERVED_IP}:8888@${TP_SERVER}@g" "${RESOURCE_DIRECTORY}/kubeconfig.kubemark.tp-${tp_num}.direct"
-    export KUBERNETES_SCALEOUT_PROXY=false
   done
-  echo "DBG: tenant-servers:  ${TENANT_SERVERS}"
-fi
 
-if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
-  echo "DBG: set tenant partition flag false"
+  echo "DBG: Starting resource partition ..."
   export KUBERNETES_TENANT_PARTITION=false
   export KUBERNETES_RESOURCE_PARTITION=true
   create-kubemark-master
   export KUBERNETES_RESOURCE_PARTITION=false
   export KUBERNETES_SCALEOUT_PROXY=false
 
-  export RESOURCE_SERVER="http://"$(grep server "${LOCAL_KUBECONFIG_TMP}" | awk -F "/" '{print $3}')
-  echo "DBG: resource-server: " ${RESOURCE_SERVER}
-  cp -f ${LOCAL_KUBECONFIG_TMP} ${RP_KUBECONFIG_SAVED}
+  export RESOURCE_SERVER="http://"$(grep server "${RP_KUBECONFIG}" | awk -F "/" '{print $3}')
+
+  echo "DBG: PROXY_RESERVED_IP=${PROXY_RESERVED_IP}"
+  echo "DBG: tenant-servers: ${TENANT_SERVERS}"
+  echo "DBG: resource-server: ${RESOURCE_SERVER}"
 else
   create-kubemark-master
+fi
+
+KUBEMARK_KUBECONFIG="${LOCAL_KUBECONFIG}"
+if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
+  KUBEMARK_KUBECONFIG="${TP_KUBECONFIG}-${TENANT_PARTITION_SEQUENCE}"
 fi
 
 # start hollow nodes with multiple tenant partition parameters
@@ -317,33 +321,25 @@ if [ "${CLOUD_PROVIDER}" = "aws" ]; then
 else
   echo "Master IP: ${MASTER_IP}"
 fi
-echo "Kubeconfig for kubemark master is written in ${LOCAL_KUBECONFIG_TMP}"
-
-# all kubectl OPs go via the proxy
-#
-### internally the TP configures are set with proxy URL, simply copy for POC phase for now
-###
-if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
-  cp -f ${TP_KUBECONFIG} ${PROXY_KUBECONFIG_SAVED}
-fi
+echo "Kubeconfig for kubemark master is written in ${LOCAL_KUBECONFIG}"
 
 sleep 5
 echo -e "\nListing kubeamrk cluster details:" >&2
 echo -e "Getting total nodes number:" >&2
-"${KUBECTL}" --kubeconfig="${TP_KUBECONFIG}" get node | wc -l
+"${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get node | wc -l
 echo
 echo -e "Getting total hollow-nodes number:" >&2
-"${KUBECTL}" --kubeconfig="${TP_KUBECONFIG}" get node | grep "hollow-node" | wc -l
+"${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get node | grep "hollow-node" | wc -l
 echo
 echo -e "Getting endpoints status:" >&2
-"${KUBECTL}" --kubeconfig="${TP_KUBECONFIG}" get endpoints -A
+"${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get endpoints -A
 echo
 echo -e "Getting workload controller co status:" >&2
-"${KUBECTL}" --kubeconfig="${TP_KUBECONFIG}" get co
+"${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get co
 echo
 echo -e "Getting apiserver data partition status:" >&2
-"${KUBECTL}" --kubeconfig="${TP_KUBECONFIG}" get datapartition
+"${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get datapartition
 echo
 echo -e "Getting ETCD data partition status:" >&2
-"${KUBECTL}" --kubeconfig="${TP_KUBECONFIG}" get etcd
+"${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get etcd
 echo

--- a/test/kubemark/stop-kubemark.sh
+++ b/test/kubemark/stop-kubemark.sh
@@ -58,12 +58,9 @@ if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
   export KUBERNETES_RESOURCE_PARTITION=true
   export KUBERNETES_SCALEOUT_PROXY=true
   delete-kubemark-master
-  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark-rp"
-  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark.proxy"
-  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp"
-  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark.*.direct"
-  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark.*.saved"
-  rm -rf "${RESOURCE_DIRECTORY}/kubeconfig.kubemark.*.tmp"
+  rm -rf ${RESOURCE_DIRECTORY}/kubeconfig.kubemark-proxy
+  rm -rf ${RESOURCE_DIRECTORY}/kubeconfig.kubemark-rp
+  rm -rf ${RESOURCE_DIRECTORY}/kubeconfig.kubemark-tp-*
 else
   delete-kubemark-master
 fi


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
/kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Currently we use insecure port 8080 for all API communication in scaleout architecture. This PR does two things:

Secures the client ---- haproxy communication to use SSL with certificates generated by proxy as CA. (Intra-scaleout communication is still insecure after this PR. Yunwen will have a PR for that after integrating with this)
Cleanup several unnecessary and confusing intermediate kubeconfigs that are generated as part of scaleout cluster deployment.
Following testing was done:
A. Deploy admin cluster (ensure no regression)
B. Deploy scaleup (normal) 100 node cluster (ensure no regression)
C. Deploy 1TP 1RP scaleout cluster and verify that port 443/https is used for client -- proxy communication.
D. Deploy 2TP 1RP scaleout cluster and verify that port 443/https is used for client -- proxy communication.

Verified get nodes, get pod all-NS, and create-pod works.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
After this change, all the unnecessary kubeconfigs are gone.
------------------------------------------------------------

...
...
Listing kubeamrk cluster details:
Getting total nodes number:
2

Getting total hollow-nodes number:
0
vin@fw0000357:~/go/src/k8s.io/kubernetes$ git status .
On branch scale-out-poc
Your branch is up-to-date with 'origin/scale-out-poc'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	test/kubemark/resources/addons/
	test/kubemark/resources/haproxy.cfg.tmp
	test/kubemark/resources/hollow-node.yaml
	test/kubemark/resources/kubeconfig.kubemark-proxy
	test/kubemark/resources/kubeconfig.kubemark-rp
	test/kubemark/resources/kubeconfig.kubemark-tp-1

nothing added to commit but untracked files present (use "git add" to track)
vin@fw0000357:~/go/src/k8s.io/kubernetes$
```
