### PR TITLE
fix issue 655

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
@@ -223,7 +223,7 @@ func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.Va
 
 	crd := obj.(*apiextensions.CustomResourceDefinition)
 	if IsCrdSystemForced(crd) && tenant != metav1.TenantSystem {
-		return nil, false, nil
+		return nil, false, fmt.Errorf("Forbidden: %s is a system CRD, it can only be deleted by a cluster admin.", name)
 	}
 
 	// Ensure we have a UID precondition

--- a/test/e2e/arktos/multi_tenancy/test_suites/crd/test_system_share_crd.yaml
+++ b/test/e2e/arktos/multi_tenancy/test_suites/crd/test_system_share_crd.yaml
@@ -71,6 +71,12 @@ Tests:
 #    OutputShouldContain:
 #    - "mustshareknowledges.learning.wisdom.com is a system CRD, you cannot overwrite it"
 
+  - BeforeTestMessage: Verifying system-share CRD cannot be deleted by regular tenants ...
+    Command: "${kubectl} delete crd mustshareknowledges.learning.wisdom.com --context ${first_tenant}-admin-context"
+    ShouldFail: true
+    OutputShouldContain:
+    - "Forbidden: mustshareknowledges.learning.wisdom.com is a system CRD, it can only be deleted by a cluster admin."
+
 ########################################################################################
 # Verifying regular tenants creating custom resources
 ########################################################################################


### PR DESCRIPTION
This PR fixed issue https://github.com/CentaurusInfra/arktos/issues/655: "Regular tenant does not get error when trying to delete a system forced-sharing CRD".

An e2e test case is added.

### Verification:

Verified in local env:

1. started a cluster via arktos-up.sh 
2. Created a tenant x and its admin context as follows:

```
ubuntu@ip-172-31-26-146:~/go/src/k8s.io/arktos$ kubectl create tenant x
setting storage cluster to 0
tenant/x created
ubuntu@ip-172-31-26-146:~/go/src/k8s.io/arktos$ hack/setup-multi-tenancy/setup_client.sh x admin
......
Context has been setup for tenant x/admin in /var/run/kubernetes/admin.kubeconfig.
......
```

3. Check the CRD networks.arktos.futurewei.com, which is created by arktos-up.sh in cluster bootstrap, is accessibel to the admin under tenant x.
```
ubuntu@ip-172-31-26-146:~/go/src/k8s.io/arktos$ kubectl get crds --context x-admin-context
NAME                            AGE
networks.arktos.futurewei.com   48s
```
4. verified that attempt from the regular tenant x to delete the CRD networks.arktos.futurewei.com will hit the expected error.
```
ubuntu@ip-172-31-26-146:~/go/src/k8s.io/arktos$ kubectl delete crd networks.arktos.futurewei.com --context x-admin-context
Error from server: Forbidden: networks.arktos.futurewei.com is a system CRD, it can only be deleted by a cluster admin.
```
5. It is also verfied that the new e2e test case works as expected.