### PR TITLE
Take multiple RPs in Scheduler

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -211,8 +211,8 @@ func makeAPIServiceAvailableHealthCheck(name string, apiServices []*apiregistrat
 
 	// Watch add/update events for APIServices
 	apiServiceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { handleAPIServiceChange(obj.(*apiregistration.APIService)) },
-		UpdateFunc: func(old, new interface{}) { handleAPIServiceChange(new.(*apiregistration.APIService)) },
+		AddFunc:    func(obj interface{}, rpId string) { handleAPIServiceChange(obj.(*apiregistration.APIService)) },
+		UpdateFunc: func(old, new interface{}, rpId string) { handleAPIServiceChange(new.(*apiregistration.APIService)) },
 	})
 
 	// Don't return healthy until the pending list is empty

--- a/cmd/kube-scheduler/app/BUILD
+++ b/cmd/kube-scheduler/app/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/term:go_default_library",
         "//staging/src/k8s.io/client-go/datapartition:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/tools/leaderelection:go_default_library",
         "//staging/src/k8s.io/component-base/cli/flag:go_default_library",
         "//staging/src/k8s.io/component-base/cli/globalflag:go_default_library",

--- a/cmd/kube-scheduler/app/config/config.go
+++ b/cmd/kube-scheduler/app/config/config.go
@@ -44,8 +44,8 @@ type Config struct {
 	SecureServing          *apiserver.SecureServingInfo
 
 	// explictly define node informer from the resource provider client
-	ResourceProviderClient clientset.Interface
-	ResourceInformer       coreinformers.NodeInformer
+	ResourceProviderClients []clientset.Interface
+	NodeInformers           []coreinformers.NodeInformer
 
 	Client          clientset.Interface
 	InformerFactory informers.SharedInformerFactory

--- a/cmd/kube-scheduler/app/options/BUILD
+++ b/cmd/kube-scheduler/app/options/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
+        "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",

--- a/cmd/kube-scheduler/app/options/deprecated.go
+++ b/cmd/kube-scheduler/app/options/deprecated.go
@@ -20,7 +20,6 @@ package options
 import (
 	"fmt"
 	"github.com/spf13/pflag"
-
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/factory"
@@ -66,7 +65,7 @@ func (o *DeprecatedOptions) AddFlags(fs *pflag.FlagSet, cfg *kubeschedulerconfig
 		"RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule corresponding "+
 			"to every RequiredDuringScheduling affinity rule. --hard-pod-affinity-symmetric-weight represents the weight of implicit PreferredDuringScheduling affinity rule. Must be in the range 0-100.")
 	fs.MarkDeprecated("hard-pod-affinity-symmetric-weight", "This option was moved to the policy configuration file")
-	fs.StringVar(&cfg.ResourceProviderClientConnection.Kubeconfig, "resource-providers", cfg.ResourceProviderClientConnection.Kubeconfig, "string representing resource provider kubeconfig files")
+	fs.StringVar(&cfg.ResourceProviderKubeConfig, "resource-providers", cfg.ResourceProviderKubeConfig, "string representing resource provider kubeconfig files")
 }
 
 // Validate validates the deprecated scheduler options.

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -261,7 +261,7 @@ func (o *Options) Config() (*schedulerappconfig.Config, error) {
 		klog.V(2).Infof("ResourceProvider kubeConfig is not set. default to local cluster client")
 		c.NodeInformers[0] = c.InformerFactory.Core().V1().Nodes()
 	} else {
-		kubeConfigFiles, existed := kubeconfigFileExists(c.ComponentConfig.ResourceProviderKubeConfig)
+		kubeConfigFiles, existed := parseKubeConfigFiles(c.ComponentConfig.ResourceProviderKubeConfig)
 		if !existed {
 			klog.Fatalf("ResourceProvider kubeConfig is not valid. value=%s", c.ComponentConfig.ResourceProviderKubeConfig)
 		}
@@ -291,7 +291,7 @@ func (o *Options) Config() (*schedulerappconfig.Config, error) {
 	return c, nil
 }
 
-func kubeconfigFileExists(kubeConfigFilenames string) ([]string, bool) {
+func parseKubeConfigFiles(kubeConfigFilenames string) ([]string, bool) {
 	kubeConfigs := strings.Split(kubeConfigFilenames, ",")
 	for _, kubeConfig := range kubeConfigs {
 		_, err := os.Stat(kubeConfig)

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"k8s.io/client-go/datapartition"
+	"k8s.io/client-go/tools/cache"
 	"net/http"
 	"os"
 	goruntime "runtime"
@@ -167,7 +168,7 @@ func Run(cc schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}) error
 
 	// Create the scheduler.
 	sched, err := scheduler.New(cc.Client,
-		cc.ResourceInformer,
+		cc.NodeInformers,
 		cc.PodInformer,
 		cc.InformerFactory.Core().V1().PersistentVolumes(),
 		cc.InformerFactory.Core().V1().PersistentVolumeClaims(),
@@ -232,16 +233,20 @@ func Run(cc schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}) error
 	cc.InformerFactory.Start(stopCh)
 
 	// only start the ResourceInformer with the separated resource clusters
-	//
-	if cc.ResourceProviderClient != nil {
-		go cc.ResourceInformer.Informer().Run(stopCh)
-		for {
-			if cc.ResourceInformer.Informer().HasSynced() {
-				break
+	klog.V(3).Infof("Scheduler started with resource provider number=%d", len(cc.NodeInformers))
+	for i := range cc.NodeInformers {
+		go cc.NodeInformers[i].Informer().Run(stopCh)
+		go func(informer cache.SharedIndexInformer, pos int) {
+			klog.V(3).Infof("Waiting for node sync from resource partition %d. Node informer %p", pos, informer)
+			for {
+				if informer.HasSynced() {
+					klog.V(3).Infof("Node sync from resource partition %d started! Node informer %p", pos, informer)
+					break
+				}
+				klog.V(2).Infof("Wait for node sync from resource partition %d. Node informer %p", pos, informer)
+				time.Sleep(5 * time.Second)
 			}
-			klog.V(6).Infof("Wait for node sync...")
-			time.Sleep(300 * time.Millisecond)
-		}
+		}(cc.NodeInformers[i].Informer(), i)
 	}
 
 	// Wait for all caches to sync before scheduling.

--- a/docs/setup-guide/scale-out-local-dev-setup.md
+++ b/docs/setup-guide/scale-out-local-dev-setup.md
@@ -4,7 +4,7 @@
 
 1. Two Tenant Partitions
 
-1. Single Resource Partition (2/19/2021)
+1. Two Resource Partitions (3/2/2021)
 
 1. HA proxy
 
@@ -37,8 +37,7 @@ export RESOURCE_PARTITION_IP=[RP_IP]
 export SCALE_OUT_PROXY_IP=[PROXY_IP]
 export SCALE_OUT_PROXY_PORT=8888
 export IS_RESOURCE_PARTITION=false
-export RESOURCE_SERVER=[RP_IP]
-export REUSE_CERTS=true
+export RESOURCE_SERVER=[RP1_IP]<,[RP2_IP]>
 ```
 
 1. Run ./hack/arktos-up-scale-out-poc.sh
@@ -47,15 +46,7 @@ export REUSE_CERTS=true
 
 Note:
 
-1. As we start to picking up secure mode in scale out, api server certificates will be shared across all partitions in 
-development environment. The first TP that started needs to generate api server certificates and be copied over to other
-TP/RP before they start.
-
-1. To generate first set of certs, run `REUSE_CERTS=false; ./hack/arktos-up-scale-out-poc.sh`
-
-1. After the first TP started, copy all files in /var/run/kubernetes to other TP/RP hosts. To avoid recopy the certificate
-files, don't use `REUSE_CERTS=false`
-
+1. As certificates generating and sharing is confusing and time consuming in local test environment. We will use insecure mode for local test for now. Secured mode can be added back later when main goal is acchieved.
 
 ### Setting up RP
 1. Make sure hack/arktos-up.sh can be run at the box
@@ -67,7 +58,6 @@ export SCALE_OUT_PROXY_IP=[PROXY_IP]
 export SCALE_OUT_PROXY_PORT=8888
 export IS_RESOURCE_PARTITION=true
 export TENANT_SERVERS=http://[TP1_IP]:8080,http://[TP2_IP]:8080
-export REUSE_CERTS=true
 ```
 
 1. Run ./hack/arktos-up-scale-out-poc.sh
@@ -123,5 +113,8 @@ etcdctl get "" --prefix=true --keys-only | grep pods
 
 1. If there is no code changes, can use "./hack/arktos-up-scale-out-poc.sh -O" to save compile time
 
-1. Currently tested with 2TP/1RP. Pods can be scheduled for both TPs.
+1. After switched all kubeconfigs from proxy, system tenant appears in both TPs. This is not ideal. Trying to point KCM kubeconfig to HA proxy. 
 
+1. Currently tested with 2TP/2RP.
+
+1. Haven't made changes to HA proxy 2RP, kubectl get nodes only has nodes from first RP, which is expected.

--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -45,9 +45,11 @@ fi
 
 if [[ -z "${RESOURCE_SERVER}" ]]; then
   if ! [ "${IS_RESOURCE_PARTITION}" == "true" ]; then
-    echo ERROR: Please set RESOURCE_SERVER for in tenant partition for RP. For example: RESOURCE_SERVER=\"http://192.168.0.2:8080\"
+    echo ERROR: Please set RESOURCE_SERVER for in tenant partition for RP. For example: RESOURCE_SERVER=192.168.0.2 or RESOURCE_SERVER=192.168.0.2,192.168.10.123
     exit 1
   fi
+else
+  RESOURCE_SERVERS=(${RESOURCE_SERVER//,/ })
 fi
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..

--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -222,7 +222,7 @@ function kube::common::generate_certs {
       kube::util::create_signing_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" request-header '"client auth"'
 
       # serving cert for kube-apiserver
-      kube::util::create_serving_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "server-ca" kube-apiserver kubernetes.default kubernetes.default.svc "localhost" "${API_HOST_IP}" "${API_HOST}" "${FIRST_SERVICE_CLUSTER_IP}" "${API_HOST_IP_EXTERNAL}" "${RESOURCE_SERVER:-}" "${APISERVERS_EXTRA:-}" "${PUBLIC_IP:-}"
+      kube::util::create_serving_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "server-ca" kube-apiserver kubernetes.default kubernetes.default.svc "localhost" "${API_HOST_IP}" "${API_HOST}" "${FIRST_SERVICE_CLUSTER_IP}" "${API_HOST_IP_EXTERNAL}" "${APISERVERS_EXTRA:-}" "${PUBLIC_IP:-}"
     fi
 
     # Create client certs signed with client-ca, given id, given CN and a number of groups
@@ -389,25 +389,32 @@ EOF
         # Create kubeconfigs for all components, using client certs
         # TODO: Each api server has it own configuration files. However, since clients, such as controller, scheduler and etc do not support mutilple apiservers,admin.kubeconfig is kept for compability.
         ADMIN_CONFIG_API_HOST=${PUBLIC_IP:-${API_HOST}}
-        kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${ADMIN_CONFIG_API_HOST}" "$secureport" admin
+
         ${CONTROLPLANE_SUDO} chown "${USER}" "${CERT_DIR}/client-admin.key" # make readable for kubectl
 
         if [[ "${IS_SCALE_OUT}" == "true" ]]; then
           # in scale out poc, point api server to proxy
-          kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${SCALE_OUT_PROXY_IP}" "${SCALE_OUT_PROXY_PORT}" controller "" "http"
-          kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${SCALE_OUT_PROXY_IP}" "${SCALE_OUT_PROXY_PORT}" scheduler "" "http"
+          kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${ADMIN_CONFIG_API_HOST}" "${API_PORT}" admin "" "http"
+          kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${ADMIN_CONFIG_API_HOST}" "${API_PORT}" controller "" "http"
+          kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${ADMIN_CONFIG_API_HOST}" "${API_PORT}" scheduler "" "http"
           kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${SCALE_OUT_PROXY_IP}" "${SCALE_OUT_PROXY_PORT}" workload-controller "" "http"
 
           # generate kubeconfig for scheduler in TP to access api server in RP
           if [[ "${IS_RESOURCE_PARTITION}" != "true" ]]; then
-            echo "RESOURCE_SERVER: |${RESOURCE_SERVER}|"
-            kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${RESOURCE_SERVER}" "6443" resource-provider-scheduler "" "https"
+            serverCount=${#RESOURCE_SERVERS[@]}
+            for (( pos=0; pos<${serverCount}; pos++ ));
+            do
+              kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${RESOURCE_SERVERS[${pos}]}" "${API_PORT}" resource-provider-scheduler "" "http"
+              ${CONTROLPLANE_SUDO} mv "${CERT_DIR}/resource-provider-scheduler.kubeconfig" "${CERT_DIR}/resource-provider-scheduler${pos}.kubeconfig"
+              ${CONTROLPLANE_SUDO} chown "$(whoami)" "${CERT_DIR}/resource-provider-scheduler${pos}.kubeconfig"
+            done
           fi
 
           # generate kubelet/kubeproxy certs at TP as we use same cert for the entire cluster
           kube::common::generate_kubelet_certs
           kube::common::generate_kubeproxy_certs
         else
+          kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${ADMIN_CONFIG_API_HOST}" "$secureport" admin
           kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "$secureport" controller
           kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "$secureport" scheduler
           kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "$secureport" workload-controller
@@ -559,7 +566,14 @@ function kube::common::start_kubescheduler {
     SCHEDULER_LOG=${LOG_DIR}/kube-scheduler.log
 
     if [[ "${IS_SCALE_OUT}" == "true" ]]; then
-      RESOURCE_PROVIDER_KUBECONFIG_FLAGS="--resource-providers=${CERT_DIR}/resource-provider-scheduler.kubeconfig"
+      RESOURCE_PROVIDER_KUBECONFIG_FLAGS="--resource-providers="
+      serverCount=${#RESOURCE_SERVERS[@]}
+      for (( pos=0; pos<${serverCount}; pos++ ));
+      do
+        RESOURCE_PROVIDER_KUBECONFIG_FLAGS="${RESOURCE_PROVIDER_KUBECONFIG_FLAGS}${CERT_DIR}/resource-provider-scheduler${pos}.kubeconfig,"
+      done
+      RESOURCE_PROVIDER_KUBECONFIG_FLAGS=${RESOURCE_PROVIDER_KUBECONFIG_FLAGS::-1}
+
       echo RESOURCE_PROVIDER_KUBECONFIG_FLAGS for new scheduler commandline --resource-providers
       echo ${RESOURCE_PROVIDER_KUBECONFIG_FLAGS}
 
@@ -731,7 +745,7 @@ function kube::common::generate_kubelet_certs {
         CONTROLPLANE_SUDO=$(test -w "${CERT_DIR}" || echo "sudo -E")
         kube::util::create_client_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" 'client-ca' kubelet "system:node:${HOSTNAME_OVERRIDE}" system:nodes
         if [[ "${IS_SCALE_OUT}" == "true" ]]; then
-          kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${SCALE_OUT_PROXY_IP}" "${SCALE_OUT_PROXY_PORT}" kubelet "" "http"
+          kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "${API_PORT}" kubelet "" "http"
         else
           kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "${API_SECURE_PORT}" kubelet
         fi
@@ -743,7 +757,7 @@ function kube::common::generate_kubeproxy_certs {
         CONTROLPLANE_SUDO=$(test -w "${CERT_DIR}" || echo "sudo -E")
         kube::util::create_client_certkey "${CONTROLPLANE_SUDO}" "${CERT_DIR}" 'client-ca' kube-proxy system:kube-proxy system:nodes
         if [[ "${IS_SCALE_OUT}" == "true" ]]; then
-          kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${SCALE_OUT_PROXY_IP}" "${SCALE_OUT_PROXY_PORT}" kube-proxy "" "http"
+          kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "${API_PORT}" kube-proxy "" "http"
         else
           kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "${API_SECURE_PORT}" kube-proxy
         fi

--- a/pkg/cloudfabric-controller/replicaset/replica_set.go
+++ b/pkg/cloudfabric-controller/replicaset/replica_set.go
@@ -247,7 +247,7 @@ func (rsc *ReplicaSetController) resolveControllerRef(tenant, namespace string, 
 }
 
 // callback when RS is updated
-func (rsc *ReplicaSetController) updateRS(old, cur interface{}) {
+func (rsc *ReplicaSetController) updateRS(old, cur interface{}, rpId string) {
 	oldRS := old.(*apps.ReplicaSet)
 	curRS := cur.(*apps.ReplicaSet)
 	//klog.Infof("updateRS. old RS %+v, new RS %+v", oldRS, curRS)
@@ -267,17 +267,17 @@ func (rsc *ReplicaSetController) updateRS(old, cur interface{}) {
 	if *(oldRS.Spec.Replicas) != *(curRS.Spec.Replicas) {
 		klog.V(4).Infof("%v %v updated. Desired pod count change: %d->%d", rsc.Kind, curRS.Name, *(oldRS.Spec.Replicas), *(curRS.Spec.Replicas))
 	}
-	rsc.enqueueReplicaSet(cur)
+	rsc.enqueueReplicaSet(cur, rpId)
 }
 
 // When a pod is created, enqueue the replica set that manages it and update its expectations.
-func (rsc *ReplicaSetController) addPod(obj interface{}) {
+func (rsc *ReplicaSetController) addPod(obj interface{}, rpId string) {
 	pod := obj.(*v1.Pod)
 
 	if pod.DeletionTimestamp != nil {
 		// on a restart of the controller manager, it's possible a new pod shows up in a state that
 		// is already pending deletion. Prevent the pod from being a creation observation.
-		rsc.deletePod(pod)
+		rsc.deletePod(pod, rpId)
 		return
 	}
 
@@ -293,7 +293,7 @@ func (rsc *ReplicaSetController) addPod(obj interface{}) {
 		}
 		klog.V(4).Infof("Pod %s created: %#v. rv %v", pod.Name, pod, pod.ResourceVersion)
 		rsc.expectations.CreationObserved(rsKey)
-		rsc.enqueueReplicaSet(rs)
+		rsc.enqueueReplicaSet(rs, rpId)
 		return
 	}
 
@@ -307,14 +307,14 @@ func (rsc *ReplicaSetController) addPod(obj interface{}) {
 	}
 	klog.V(4).Infof("Orphan Pod %s created: %#v.", pod.Name, pod)
 	for _, rs := range rss {
-		rsc.enqueueReplicaSet(rs)
+		rsc.enqueueReplicaSet(rs, rpId)
 	}
 }
 
 // When a pod is updated, figure out what replica set/s manage it and wake them
 // up. If the labels of the pod have changed we need to awaken both the old
 // and new replica set. old and cur must be *v1.Pod types.
-func (rsc *ReplicaSetController) updatePod(old, cur interface{}) {
+func (rsc *ReplicaSetController) updatePod(old, cur interface{}, rpId string) {
 	curPod := cur.(*v1.Pod)
 	oldPod := old.(*v1.Pod)
 	if curPod.ResourceVersion == oldPod.ResourceVersion {
@@ -330,10 +330,10 @@ func (rsc *ReplicaSetController) updatePod(old, cur interface{}) {
 		// for modification of the deletion timestamp and expect an rs to create more replicas asap, not wait
 		// until the kubelet actually deletes the pod. This is different from the Phase of a pod changing, because
 		// an rs never initiates a phase change, and so is never asleep waiting for the same.
-		rsc.deletePod(curPod)
+		rsc.deletePod(curPod, rpId)
 		if labelChanged {
 			// we don't need to check the oldPod.DeletionTimestamp because DeletionTimestamp cannot be unset.
-			rsc.deletePod(oldPod)
+			rsc.deletePod(oldPod, rpId)
 		}
 		return
 	}
@@ -344,7 +344,7 @@ func (rsc *ReplicaSetController) updatePod(old, cur interface{}) {
 	if controllerRefChanged && oldControllerRef != nil {
 		// The ControllerRef was changed. Sync the old controller, if any.
 		if rs := rsc.resolveControllerRef(oldPod.Tenant, oldPod.Namespace, oldControllerRef); rs != nil {
-			rsc.enqueueReplicaSet(rs)
+			rsc.enqueueReplicaSet(rs, rpId)
 		}
 	}
 
@@ -355,7 +355,7 @@ func (rsc *ReplicaSetController) updatePod(old, cur interface{}) {
 			return
 		}
 		klog.V(4).Infof("Pod %s updated, objectMeta %+v -> %+v.", curPod.Name, oldPod.ObjectMeta, curPod.ObjectMeta)
-		rsc.enqueueReplicaSet(rs)
+		rsc.enqueueReplicaSet(rs, rpId)
 		// TODO: MinReadySeconds in the Pod will generate an Available condition to be added in
 		// the Pod status which in turn will trigger a requeue of the owning replica set thus
 		// having its status updated with the newly available replica. For now, we can fake the
@@ -381,14 +381,14 @@ func (rsc *ReplicaSetController) updatePod(old, cur interface{}) {
 		}
 		klog.V(4).Infof("Orphan Pod %s updated, objectMeta %+v -> %+v.", curPod.Name, oldPod.ObjectMeta, curPod.ObjectMeta)
 		for _, rs := range rss {
-			rsc.enqueueReplicaSet(rs)
+			rsc.enqueueReplicaSet(rs, rpId)
 		}
 	}
 }
 
 // When a pod is deleted, enqueue the replica set that manages the pod and update its expectations.
 // obj could be an *v1.Pod, or a DeletionFinalStateUnknown marker item.
-func (rsc *ReplicaSetController) deletePod(obj interface{}) {
+func (rsc *ReplicaSetController) deletePod(obj interface{}, rpId string) {
 	pod, ok := obj.(*v1.Pod)
 
 	// When a delete is dropped, the relist will notice a pod in the store not
@@ -423,11 +423,11 @@ func (rsc *ReplicaSetController) deletePod(obj interface{}) {
 	}
 	klog.V(4).Infof("Pod %s/%s/%s deleted through %v, timestamp %+v: %#v.", pod.Tenant, pod.Namespace, pod.Name, utilruntime.GetCaller(), pod.DeletionTimestamp, pod)
 	rsc.expectations.DeletionObserved(rsKey, controller.PodKey(pod))
-	rsc.enqueueReplicaSet(rs)
+	rsc.enqueueReplicaSet(rs, rpId)
 }
 
 // obj could be an *apps.ReplicaSet, or a DeletionFinalStateUnknown marker item.
-func (rsc *ReplicaSetController) enqueueReplicaSet(obj interface{}) {
+func (rsc *ReplicaSetController) enqueueReplicaSet(obj interface{}, rpId string) {
 	key, err := controller.KeyFunc(obj)
 	//klog.Infof("Replicaset enqueue. KEY %s. OBJ %+v", key, obj)
 	if err != nil {

--- a/pkg/controller/bootstrap/bootstrapsigner.go
+++ b/pkg/controller/bootstrap/bootstrapsigner.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -121,8 +122,8 @@ func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configM
 				}
 			},
 			Handler: cache.ResourceEventHandlerFuncs{
-				AddFunc:    func(_ interface{}) { e.pokeConfigMapSync() },
-				UpdateFunc: func(_, _ interface{}) { e.pokeConfigMapSync() },
+				AddFunc:    func(_ interface{}, rpId string) { e.pokeConfigMapSync() },
+				UpdateFunc: func(_, _ interface{}, rpId string) { e.pokeConfigMapSync() },
 			},
 		},
 		options.ConfigMapResync,
@@ -140,9 +141,9 @@ func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configM
 				}
 			},
 			Handler: cache.ResourceEventHandlerFuncs{
-				AddFunc:    func(_ interface{}) { e.pokeConfigMapSync() },
-				UpdateFunc: func(_, _ interface{}) { e.pokeConfigMapSync() },
-				DeleteFunc: func(_ interface{}) { e.pokeConfigMapSync() },
+				AddFunc:    func(_ interface{}, rpId string) { e.pokeConfigMapSync() },
+				UpdateFunc: func(_, _ interface{}, rpId string) { e.pokeConfigMapSync() },
+				DeleteFunc: func(_ interface{}, rpId string) { e.pokeConfigMapSync() },
 			},
 		},
 		options.SecretResync,

--- a/pkg/controller/bootstrap/tokencleaner.go
+++ b/pkg/controller/bootstrap/tokencleaner.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -99,7 +100,7 @@ func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInforme
 			},
 			Handler: cache.ResourceEventHandlerFuncs{
 				AddFunc:    e.enqueueSecrets,
-				UpdateFunc: func(oldSecret, newSecret interface{}) { e.enqueueSecrets(newSecret) },
+				UpdateFunc: func(oldSecret, newSecret interface{}, rpId string) { e.enqueueSecrets(newSecret, rpId) },
 			},
 		},
 		options.SecretResync,
@@ -125,7 +126,7 @@ func (tc *TokenCleaner) Run(stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (tc *TokenCleaner) enqueueSecrets(obj interface{}) {
+func (tc *TokenCleaner) enqueueSecrets(obj interface{}, rpId string) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(err)

--- a/pkg/controller/certificates/certificate_controller.go
+++ b/pkg/controller/certificates/certificate_controller.go
@@ -74,17 +74,17 @@ func NewCertificateController(
 
 	// Manage the addition/update of certificate requests
 	csrInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			csr := obj.(*certificates.CertificateSigningRequest)
 			klog.V(4).Infof("Adding certificate request %s", csr.Name)
 			cc.enqueueCertificateRequest(obj)
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new interface{}, rpId string) {
 			oldCSR := old.(*certificates.CertificateSigningRequest)
 			klog.V(4).Infof("Updating certificate request %s", oldCSR.Name)
 			cc.enqueueCertificateRequest(new)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj interface{}, rpId string) {
 			csr, ok := obj.(*certificates.CertificateSigningRequest)
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -109,7 +110,7 @@ func (c *Publisher) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (c *Publisher) configMapDeleted(obj interface{}) {
+func (c *Publisher) configMapDeleted(obj interface{}, rpId string) {
 	cm, err := convertToCM(obj)
 	if err != nil {
 		utilruntime.HandleError(err)
@@ -121,7 +122,7 @@ func (c *Publisher) configMapDeleted(obj interface{}) {
 	c.queue.Add(cm.Namespace)
 }
 
-func (c *Publisher) configMapUpdated(_, newObj interface{}) {
+func (c *Publisher) configMapUpdated(_, newObj interface{}, rpId string) {
 	cm, err := convertToCM(newObj)
 	if err != nil {
 		utilruntime.HandleError(err)
@@ -133,12 +134,12 @@ func (c *Publisher) configMapUpdated(_, newObj interface{}) {
 	c.queue.Add(cm.Namespace)
 }
 
-func (c *Publisher) namespaceAdded(obj interface{}) {
+func (c *Publisher) namespaceAdded(obj interface{}, rpId string) {
 	namespace := obj.(*v1.Namespace)
 	c.queue.Add(namespace.Name)
 }
 
-func (c *Publisher) namespaceUpdated(oldObj interface{}, newObj interface{}) {
+func (c *Publisher) namespaceUpdated(oldObj interface{}, newObj interface{}, rpId string) {
 	newNamespace := newObj.(*v1.Namespace)
 	if newNamespace.Status.Phase != v1.NamespaceActive {
 		return

--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -190,7 +190,7 @@ func (cnc *CloudNodeController) updateNodeAddress(node *v1.Node, instances cloud
 	}
 }
 
-func (cnc *CloudNodeController) UpdateCloudNode(_, newObj interface{}) {
+func (cnc *CloudNodeController) UpdateCloudNode(_, newObj interface{}, rpId string) {
 	node, ok := newObj.(*v1.Node)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", newObj))
@@ -207,7 +207,7 @@ func (cnc *CloudNodeController) UpdateCloudNode(_, newObj interface{}) {
 }
 
 // AddCloudNode handles initializing new nodes registered with the cloud taint.
-func (cnc *CloudNodeController) AddCloudNode(obj interface{}) {
+func (cnc *CloudNodeController) AddCloudNode(obj interface{}, rpId string) {
 	node := obj.(*v1.Node)
 
 	cloudTaint := getCloudTaint(node.Spec.Taints)

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -60,13 +61,13 @@ func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.ClusterRoleInfo
 	c.syncHandler = c.syncClusterRole
 
 	clusterRoleInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			c.enqueue()
 		},
-		UpdateFunc: func(old, cur interface{}) {
+		UpdateFunc: func(old, cur interface{}, rpId string) {
 			c.enqueue()
 		},
-		DeleteFunc: func(uncast interface{}) {
+		DeleteFunc: func(uncast interface{}, rpId string) {
 			c.enqueue()
 		},
 	})

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -173,12 +173,12 @@ func NewDaemonSetsController(
 	}
 
 	daemonSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			ds := obj.(*apps.DaemonSet)
 			klog.V(4).Infof("Adding daemon set %s/%s/%s", ds.Tenant, ds.Namespace, ds.Name)
 			dsc.enqueueDaemonSet(ds)
 		},
-		UpdateFunc: func(old, cur interface{}) {
+		UpdateFunc: func(old, cur interface{}, rpId string) {
 			oldDS := old.(*apps.DaemonSet)
 			curDS := cur.(*apps.DaemonSet)
 			klog.V(4).Infof("Updating daemon set %s/%s/%s", oldDS.Tenant, oldDS.Namespace, oldDS.Name)
@@ -242,7 +242,7 @@ func indexByPodNodeName(obj interface{}) ([]string, error) {
 	return []string{pod.Spec.NodeName}, nil
 }
 
-func (dsc *DaemonSetsController) deleteDaemonset(obj interface{}) {
+func (dsc *DaemonSetsController) deleteDaemonset(obj interface{}, rpId string) {
 	ds, ok := obj.(*apps.DaemonSet)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -370,12 +370,12 @@ func (dsc *DaemonSetsController) getDaemonSetsForHistory(history *apps.Controlle
 
 // addHistory enqueues the DaemonSet that manages a ControllerRevision when the ControllerRevision is created
 // or when the controller manager is restarted.
-func (dsc *DaemonSetsController) addHistory(obj interface{}) {
+func (dsc *DaemonSetsController) addHistory(obj interface{}, rpId string) {
 	history := obj.(*apps.ControllerRevision)
 	if history.DeletionTimestamp != nil {
 		// On a restart of the controller manager, it's possible for an object to
 		// show up in a state that is already pending deletion.
-		dsc.deleteHistory(history)
+		dsc.deleteHistory(history, rpId)
 		return
 	}
 
@@ -404,7 +404,7 @@ func (dsc *DaemonSetsController) addHistory(obj interface{}) {
 // updateHistory figures out what DaemonSet(s) manage a ControllerRevision when the ControllerRevision
 // is updated and wake them up. If anything of the ControllerRevision has changed, we need to  awaken
 // both the old and new DaemonSets.
-func (dsc *DaemonSetsController) updateHistory(old, cur interface{}) {
+func (dsc *DaemonSetsController) updateHistory(old, cur interface{}, rpId string) {
 	curHistory := cur.(*apps.ControllerRevision)
 	oldHistory := old.(*apps.ControllerRevision)
 	if curHistory.ResourceVersion == oldHistory.ResourceVersion {
@@ -451,7 +451,7 @@ func (dsc *DaemonSetsController) updateHistory(old, cur interface{}) {
 // deleteHistory enqueues the DaemonSet that manages a ControllerRevision when
 // the ControllerRevision is deleted. obj could be an *app.ControllerRevision, or
 // a DeletionFinalStateUnknown marker item.
-func (dsc *DaemonSetsController) deleteHistory(obj interface{}) {
+func (dsc *DaemonSetsController) deleteHistory(obj interface{}, rpId string) {
 	history, ok := obj.(*apps.ControllerRevision)
 
 	// When a delete is dropped, the relist will notice a ControllerRevision in the store not
@@ -484,13 +484,13 @@ func (dsc *DaemonSetsController) deleteHistory(obj interface{}) {
 	dsc.enqueueDaemonSet(ds)
 }
 
-func (dsc *DaemonSetsController) addPod(obj interface{}) {
+func (dsc *DaemonSetsController) addPod(obj interface{}, rpId string) {
 	pod := obj.(*v1.Pod)
 
 	if pod.DeletionTimestamp != nil {
 		// on a restart of the controller manager, it's possible a new pod shows up in a state that
 		// is already pending deletion. Prevent the pod from being a creation observation.
-		dsc.deletePod(pod)
+		dsc.deletePod(pod, rpId)
 		return
 	}
 
@@ -527,7 +527,7 @@ func (dsc *DaemonSetsController) addPod(obj interface{}) {
 // When a pod is updated, figure out what sets manage it and wake them
 // up. If the labels of the pod have changed we need to awaken both the old
 // and new set. old and cur must be *v1.Pod types.
-func (dsc *DaemonSetsController) updatePod(old, cur interface{}) {
+func (dsc *DaemonSetsController) updatePod(old, cur interface{}, rpId string) {
 	curPod := cur.(*v1.Pod)
 	oldPod := old.(*v1.Pod)
 	if curPod.ResourceVersion == oldPod.ResourceVersion {
@@ -541,7 +541,7 @@ func (dsc *DaemonSetsController) updatePod(old, cur interface{}) {
 		// and after such time has passed, the kubelet actually deletes it from the store. We receive an update
 		// for modification of the deletion timestamp and expect an ds to create more replicas asap, not wait
 		// until the kubelet actually deletes the pod.
-		dsc.deletePod(curPod)
+		dsc.deletePod(curPod, rpId)
 		return
 	}
 
@@ -649,7 +649,7 @@ func (dsc *DaemonSetsController) removeSuspendedDaemonPods(node, ds string) {
 	}
 }
 
-func (dsc *DaemonSetsController) deletePod(obj interface{}) {
+func (dsc *DaemonSetsController) deletePod(obj interface{}, rpId string) {
 	pod, ok := obj.(*v1.Pod)
 	// When a delete is dropped, the relist will notice a pod in the store not
 	// in the list, leading to the insertion of a tombstone object which contains
@@ -695,7 +695,7 @@ func (dsc *DaemonSetsController) deletePod(obj interface{}) {
 	dsc.enqueueDaemonSet(ds)
 }
 
-func (dsc *DaemonSetsController) addNode(obj interface{}) {
+func (dsc *DaemonSetsController) addNode(obj interface{}, rpId string) {
 	// TODO: it'd be nice to pass a hint with these enqueues, so that each ds would only examine the added node (unless it has other work to do, too).
 	dsList, err := dsc.dsLister.List(labels.Everything())
 	if err != nil {
@@ -752,7 +752,7 @@ func shouldIgnoreNodeUpdate(oldNode, curNode v1.Node) bool {
 	return apiequality.Semantic.DeepEqual(oldNode, curNode)
 }
 
-func (dsc *DaemonSetsController) updateNode(old, cur interface{}) {
+func (dsc *DaemonSetsController) updateNode(old, cur interface{}, rpId string) {
 	oldNode := old.(*v1.Node)
 	curNode := cur.(*v1.Node)
 	if shouldIgnoreNodeUpdate(*oldNode, *curNode) {
@@ -1316,6 +1316,7 @@ func (dsc *DaemonSetsController) simulate(newPod *v1.Pod, node *v1.Node, ds *app
 
 	nodeInfo := schedulernodeinfo.NewNodeInfo()
 	nodeInfo.SetNode(node)
+	// TODO: nodeInfo.SetResourceProviderId
 
 	for _, obj := range objects {
 		// Ignore pods that belong to the daemonset when taking into account whether a daemonset should bind to a node.

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -164,20 +164,20 @@ func (dc *DeploymentController) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (dc *DeploymentController) addDeployment(obj interface{}) {
+func (dc *DeploymentController) addDeployment(obj interface{}, rpId string) {
 	d := obj.(*apps.Deployment)
 	klog.V(4).Infof("Adding deployment %s", d.Name)
 	dc.enqueueDeployment(d)
 }
 
-func (dc *DeploymentController) updateDeployment(old, cur interface{}) {
+func (dc *DeploymentController) updateDeployment(old, cur interface{}, rpId string) {
 	oldD := old.(*apps.Deployment)
 	curD := cur.(*apps.Deployment)
 	klog.V(4).Infof("Updating deployment %s", oldD.Name)
 	dc.enqueueDeployment(curD)
 }
 
-func (dc *DeploymentController) deleteDeployment(obj interface{}) {
+func (dc *DeploymentController) deleteDeployment(obj interface{}, rpId string) {
 	d, ok := obj.(*apps.Deployment)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -196,13 +196,13 @@ func (dc *DeploymentController) deleteDeployment(obj interface{}) {
 }
 
 // addReplicaSet enqueues the deployment that manages a ReplicaSet when the ReplicaSet is created.
-func (dc *DeploymentController) addReplicaSet(obj interface{}) {
+func (dc *DeploymentController) addReplicaSet(obj interface{}, rpId string) {
 	rs := obj.(*apps.ReplicaSet)
 
 	if rs.DeletionTimestamp != nil {
 		// On a restart of the controller manager, it's possible for an object to
 		// show up in a state that is already pending deletion.
-		dc.deleteReplicaSet(rs)
+		dc.deleteReplicaSet(rs, rpId)
 		return
 	}
 
@@ -253,7 +253,7 @@ func (dc *DeploymentController) getDeploymentsForReplicaSet(rs *apps.ReplicaSet)
 // is updated and wake them up. If the anything of the ReplicaSets have changed, we need to
 // awaken both the old and new deployments. old and cur must be *apps.ReplicaSet
 // types.
-func (dc *DeploymentController) updateReplicaSet(old, cur interface{}) {
+func (dc *DeploymentController) updateReplicaSet(old, cur interface{}, rpId string) {
 	curRS := cur.(*apps.ReplicaSet)
 	oldRS := old.(*apps.ReplicaSet)
 	if curRS.ResourceVersion == oldRS.ResourceVersion {
@@ -301,7 +301,7 @@ func (dc *DeploymentController) updateReplicaSet(old, cur interface{}) {
 // deleteReplicaSet enqueues the deployment that manages a ReplicaSet when
 // the ReplicaSet is deleted. obj could be an *apps.ReplicaSet, or
 // a DeletionFinalStateUnknown marker item.
-func (dc *DeploymentController) deleteReplicaSet(obj interface{}) {
+func (dc *DeploymentController) deleteReplicaSet(obj interface{}, rpId string) {
 	rs, ok := obj.(*apps.ReplicaSet)
 
 	// When a delete is dropped, the relist will notice a pod in the store not
@@ -335,7 +335,7 @@ func (dc *DeploymentController) deleteReplicaSet(obj interface{}) {
 }
 
 // deletePod will enqueue a Recreate Deployment once all of its pods have stopped running.
-func (dc *DeploymentController) deletePod(obj interface{}) {
+func (dc *DeploymentController) deletePod(obj interface{}, rpId string) {
 	pod, ok := obj.(*v1.Pod)
 
 	// When a delete is dropped, the relist will notice a pod in the store not

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -350,26 +350,26 @@ func (dc *DisruptionController) Run(stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (dc *DisruptionController) addDb(obj interface{}) {
+func (dc *DisruptionController) addDb(obj interface{}, rpId string) {
 	pdb := obj.(*policy.PodDisruptionBudget)
 	klog.V(4).Infof("add DB %q", pdb.Name)
 	dc.enqueuePdb(pdb)
 }
 
-func (dc *DisruptionController) updateDb(old, cur interface{}) {
+func (dc *DisruptionController) updateDb(old, cur interface{}, rpId string) {
 	// TODO(mml) ignore updates where 'old' is equivalent to 'cur'.
 	pdb := cur.(*policy.PodDisruptionBudget)
 	klog.V(4).Infof("update DB %q", pdb.Name)
 	dc.enqueuePdb(pdb)
 }
 
-func (dc *DisruptionController) removeDb(obj interface{}) {
+func (dc *DisruptionController) removeDb(obj interface{}, rpId string) {
 	pdb := obj.(*policy.PodDisruptionBudget)
 	klog.V(4).Infof("remove DB %q", pdb.Name)
 	dc.enqueuePdb(pdb)
 }
 
-func (dc *DisruptionController) addPod(obj interface{}) {
+func (dc *DisruptionController) addPod(obj interface{}, rpId string) {
 	pod := obj.(*v1.Pod)
 	klog.V(4).Infof("addPod called on pod %q", pod.Name)
 	pdb := dc.getPdbForPod(pod)
@@ -381,7 +381,7 @@ func (dc *DisruptionController) addPod(obj interface{}) {
 	dc.enqueuePdb(pdb)
 }
 
-func (dc *DisruptionController) updatePod(old, cur interface{}) {
+func (dc *DisruptionController) updatePod(old, cur interface{}, rpId string) {
 	pod := cur.(*v1.Pod)
 	klog.V(4).Infof("updatePod called on pod %q", pod.Name)
 	pdb := dc.getPdbForPod(pod)
@@ -393,7 +393,7 @@ func (dc *DisruptionController) updatePod(old, cur interface{}) {
 	dc.enqueuePdb(pdb)
 }
 
-func (dc *DisruptionController) deletePod(obj interface{}) {
+func (dc *DisruptionController) deletePod(obj interface{}, rpId string) {
 	pod, ok := obj.(*v1.Pod)
 	// When a delete is dropped, the relist will notice a pod in the store not
 	// in the list, leading to the insertion of a tombstone object which contains

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -128,7 +128,7 @@ type monitors map[schema.GroupVersionResource]*monitor
 func (gb *GraphBuilder) controllerFor(resource schema.GroupVersionResource, kind schema.GroupVersionKind) (cache.Controller, cache.Store, error) {
 	handlers := cache.ResourceEventHandlerFuncs{
 		// add the event to the dependencyGraphBuilder's graphChanges.
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			event := &event{
 				eventType: addEvent,
 				obj:       obj,
@@ -136,7 +136,7 @@ func (gb *GraphBuilder) controllerFor(resource schema.GroupVersionResource, kind
 			}
 			gb.graphChanges.Add(event)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj interface{}, rpId string) {
 			// TODO: check if there are differences in the ownerRefs,
 			// finalizers, and DeletionTimestamp; if not, ignore the update.
 			event := &event{
@@ -147,7 +147,7 @@ func (gb *GraphBuilder) controllerFor(resource schema.GroupVersionResource, kind
 			}
 			gb.graphChanges.Add(event)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj interface{}, rpId string) {
 			// delta fifo may wrap the object in a cache.DeletedFinalStateUnknown, unwrap it
 			if deletedFinalStateUnknown, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 				obj = deletedFinalStateUnknown.Obj

--- a/pkg/controller/mizar/mizar-arktos-network-controller.go
+++ b/pkg/controller/mizar/mizar-arktos-network-controller.go
@@ -133,7 +133,7 @@ func (c *MizarArktosNetworkController) processNextWorkItem() bool {
 	return true
 }
 
-func (c *MizarArktosNetworkController) createNetwork(obj interface{}) {
+func (c *MizarArktosNetworkController) createNetwork(obj interface{}, rpId string) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", obj, err))

--- a/pkg/controller/mizar/mizar-endpoints-controller.go
+++ b/pkg/controller/mizar/mizar-endpoints-controller.go
@@ -118,7 +118,7 @@ func (c *MizarEndpointsController) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (c *MizarEndpointsController) createObj(obj interface{}) {
+func (c *MizarEndpointsController) createObj(obj interface{}, rpId string) {
 	key, _ := controller.KeyFunc(obj)
 	if shouldIgnore(key) {
 		return
@@ -127,7 +127,7 @@ func (c *MizarEndpointsController) createObj(obj interface{}) {
 }
 
 // When an object is updated.
-func (c *MizarEndpointsController) updateObj(old, cur interface{}) {
+func (c *MizarEndpointsController) updateObj(old, cur interface{}, rpId string) {
 	curObj := cur.(*v1.Endpoints)
 	oldObj := old.(*v1.Endpoints)
 	if curObj.ResourceVersion == oldObj.ResourceVersion {

--- a/pkg/controller/mizar/mizar-node-controller.go
+++ b/pkg/controller/mizar/mizar-node-controller.go
@@ -105,13 +105,13 @@ func (c *MizarNodeController) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (c *MizarNodeController) createObj(obj interface{}) {
+func (c *MizarNodeController) createObj(obj interface{}, rpId string) {
 	key, _ := controller.KeyFunc(obj)
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Create})
 }
 
 // When an object is updated.
-func (c *MizarNodeController) updateObj(old, cur interface{}) {
+func (c *MizarNodeController) updateObj(old, cur interface{}, rpId string) {
 	curObj := cur.(*v1.Node)
 	oldObj := old.(*v1.Node)
 	if curObj.ResourceVersion == oldObj.ResourceVersion {
@@ -128,7 +128,7 @@ func (c *MizarNodeController) updateObj(old, cur interface{}) {
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Update, ResourceVersion: curObj.ResourceVersion})
 }
 
-func (c *MizarNodeController) deleteObj(obj interface{}) {
+func (c *MizarNodeController) deleteObj(obj interface{}, rpId string) {
 	key, _ := controller.KeyFunc(obj)
 	klog.Infof("%v deleted. key %s.", controllerForMizarNode, key)
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Delete})

--- a/pkg/controller/mizar/mizar-pod-controller.go
+++ b/pkg/controller/mizar/mizar-pod-controller.go
@@ -105,13 +105,13 @@ func (c *MizarPodController) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (c *MizarPodController) createObj(obj interface{}) {
+func (c *MizarPodController) createObj(obj interface{}, rpId string) {
 	key, _ := controller.KeyFunc(obj)
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Create})
 }
 
 // When an object is updated.
-func (c *MizarPodController) updateObj(old, cur interface{}) {
+func (c *MizarPodController) updateObj(old, cur interface{}, rpId string) {
 	curObj := cur.(*v1.Pod)
 	oldObj := old.(*v1.Pod)
 	if curObj.ResourceVersion == oldObj.ResourceVersion {
@@ -128,7 +128,7 @@ func (c *MizarPodController) updateObj(old, cur interface{}) {
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Update, ResourceVersion: curObj.ResourceVersion})
 }
 
-func (c *MizarPodController) deleteObj(obj interface{}) {
+func (c *MizarPodController) deleteObj(obj interface{}, rpId string) {
 	key, _ := controller.KeyFunc(obj)
 	klog.Infof("%v deleted. key %s.", controllerForMizarPod, key)
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Delete})

--- a/pkg/controller/mizar/mizar-service-controller.go
+++ b/pkg/controller/mizar/mizar-service-controller.go
@@ -135,7 +135,7 @@ func (c *MizarServiceController) processNextWorkItem() bool {
 	return true
 }
 
-func (c *MizarServiceController) createService(obj interface{}) {
+func (c *MizarServiceController) createService(obj interface{}, rpId string) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for service %#v: %v", obj, err))
@@ -144,7 +144,7 @@ func (c *MizarServiceController) createService(obj interface{}) {
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Create})
 }
 
-func (c *MizarServiceController) updateService(old, cur interface{}) {
+func (c *MizarServiceController) updateService(old, cur interface{}, rpId string) {
 	new := cur.(*v1.Service)
 	pre := old.(*v1.Service)
 
@@ -160,7 +160,7 @@ func (c *MizarServiceController) updateService(old, cur interface{}) {
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Update, ResourceVersion: new.ResourceVersion})
 }
 
-func (c *MizarServiceController) deleteService(obj interface{}) {
+func (c *MizarServiceController) deleteService(obj interface{}, rpId string) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for service %#v: %v", obj, err))

--- a/pkg/controller/mizar/mizar-starter-controller.go
+++ b/pkg/controller/mizar/mizar-starter-controller.go
@@ -103,7 +103,7 @@ func (c *MizarStarterController) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (c *MizarStarterController) createObj(obj interface{}) {
+func (c *MizarStarterController) createObj(obj interface{}, rpId string) {
 	key, _ := controller.KeyFunc(obj)
 	c.queue.Add(key)
 }

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -83,11 +83,11 @@ func NewNamespaceController(
 	// configure the namespace informer event handlers
 	namespaceInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj interface{}, rpId string) {
 				namespace := obj.(*v1.Namespace)
 				namespaceController.enqueueNamespace(namespace)
 			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
+			UpdateFunc: func(oldObj, newObj interface{}, rpId string) {
 				namespace := newObj.(*v1.Namespace)
 				namespaceController.enqueueNamespace(namespace)
 			},

--- a/pkg/controller/network/network_controller.go
+++ b/pkg/controller/network/network_controller.go
@@ -141,13 +141,13 @@ func (nc *NetworkController) processNextWorkItem() bool {
 	return true
 }
 
-func (nc *NetworkController) createPort(obj interface{}) {
+func (nc *NetworkController) createPort(obj interface{}, rpId string) {
 	// When a pod is created, Scheduler seems always faster than network controller.
 	// So wait for scheduler's update to create port.
 }
 
 // When a pod is updated.
-func (nc *NetworkController) updatePort(old, cur interface{}) {
+func (nc *NetworkController) updatePort(old, cur interface{}, rpId string) {
 	new := cur.(*v1.Pod)
 	prev := old.(*v1.Pod)
 	needCreate := false
@@ -176,7 +176,7 @@ func (nc *NetworkController) updatePort(old, cur interface{}) {
 }
 
 // When a pod is deleted, delete ports.
-func (nc *NetworkController) deletePort(obj interface{}) {
+func (nc *NetworkController) deletePort(obj interface{}, rpId string) {
 	pod := obj.(*v1.Pod)
 	client := GetOpenstackClient()
 

--- a/pkg/controller/nodeipam/ipam/cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cidr_allocator.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -86,9 +87,9 @@ type CIDRAllocator interface {
 	// AllocateOrOccupyCIDR looks at the given node, assigns it a valid
 	// CIDR if it doesn't currently have one or mark the CIDR as used if
 	// the node already have one.
-	AllocateOrOccupyCIDR(node *v1.Node) error
+	AllocateOrOccupyCIDR(node *v1.Node, rpId string) error
 	// ReleaseCIDR releases the CIDR of the removed node
-	ReleaseCIDR(node *v1.Node) error
+	ReleaseCIDR(node *v1.Node, rpId string) error
 	// Run starts all the working logic of the allocator.
 	Run(stopCh <-chan struct{})
 }

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -111,16 +111,16 @@ func NewCloudCIDRAllocator(client clientset.Interface, cloud cloudprovider.Inter
 
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: nodeutil.CreateAddNodeHandler(ca.AllocateOrOccupyCIDR),
-		UpdateFunc: nodeutil.CreateUpdateNodeHandler(func(_, newNode *v1.Node) error {
+		UpdateFunc: nodeutil.CreateUpdateNodeHandler(func(_, newNode *v1.Node, rpId string) error {
 			if newNode.Spec.PodCIDR == "" {
-				return ca.AllocateOrOccupyCIDR(newNode)
+				return ca.AllocateOrOccupyCIDR(newNode, rpId)
 			}
 			// Even if PodCIDR is assigned, but NetworkUnavailable condition is
 			// set to true, we need to process the node to set the condition.
 			networkUnavailableTaint := &v1.Taint{Key: schedulerapi.TaintNodeNetworkUnavailable, Effect: v1.TaintEffectNoSchedule}
 			_, cond := nodeutil.GetNodeCondition(&newNode.Status, v1.NodeNetworkUnavailable)
 			if cond == nil || cond.Status != v1.ConditionFalse || utiltaints.TaintExists(newNode.Spec.Taints, networkUnavailableTaint) {
-				return ca.AllocateOrOccupyCIDR(newNode)
+				return ca.AllocateOrOccupyCIDR(newNode, rpId)
 			}
 			return nil
 		}),
@@ -156,7 +156,8 @@ func (ca *cloudCIDRAllocator) worker(stopChan <-chan struct{}) {
 				klog.Warning("Channel nodeCIDRUpdateChannel was unexpectedly closed")
 				return
 			}
-			if err := ca.updateCIDRAllocation(workItem); err == nil {
+			// TODO
+			if err := ca.updateCIDRAllocation(workItem, "resourceProviderId"); err == nil {
 				klog.V(3).Infof("Updated CIDR for %q", workItem)
 			} else {
 				klog.Errorf("Error updating CIDR for %q: %v", workItem, err)
@@ -226,7 +227,7 @@ func (ca *cloudCIDRAllocator) removeNodeFromProcessing(nodeName string) {
 // WARNING: If you're adding any return calls or defer any more work from this
 // function you have to make sure to update nodesInProcessing properly with the
 // disposition of the node when the work is done.
-func (ca *cloudCIDRAllocator) AllocateOrOccupyCIDR(node *v1.Node) error {
+func (ca *cloudCIDRAllocator) AllocateOrOccupyCIDR(node *v1.Node, rpId string) error {
 	if node == nil {
 		return nil
 	}
@@ -241,7 +242,7 @@ func (ca *cloudCIDRAllocator) AllocateOrOccupyCIDR(node *v1.Node) error {
 }
 
 // updateCIDRAllocation assigns CIDR to Node and sends an update to the API server.
-func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
+func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string, rpId string) error {
 	node, err := ca.nodeLister.Get(nodeName)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -304,7 +305,7 @@ func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
 	return err
 }
 
-func (ca *cloudCIDRAllocator) ReleaseCIDR(node *v1.Node) error {
+func (ca *cloudCIDRAllocator) ReleaseCIDR(node *v1.Node, rpId string) error {
 	klog.V(2).Infof("Node %v PodCIDR (%v) will be released by external cloud provider (not managed by controller)",
 		node.Name, node.Spec.PodCIDR)
 	return nil

--- a/pkg/controller/nodeipam/ipam/controller.go
+++ b/pkg/controller/nodeipam/ipam/controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -170,7 +171,7 @@ func (c *Controller) newSyncer(name string) *nodesync.NodeSync {
 	return nodesync.New(ns, c.adapter, c.adapter, c.config.Mode, name, c.set)
 }
 
-func (c *Controller) onAdd(node *v1.Node) error {
+func (c *Controller) onAdd(node *v1.Node, rpId string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -187,7 +188,7 @@ func (c *Controller) onAdd(node *v1.Node) error {
 	return nil
 }
 
-func (c *Controller) onUpdate(_, node *v1.Node) error {
+func (c *Controller) onUpdate(_, node *v1.Node, rpId string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -201,7 +202,7 @@ func (c *Controller) onUpdate(_, node *v1.Node) error {
 	return nil
 }
 
-func (c *Controller) onDelete(node *v1.Node) error {
+func (c *Controller) onDelete(node *v1.Node, rpId string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 

--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -122,7 +122,7 @@ func NewCIDRRangeAllocator(client clientset.Interface, nodeInformer informers.No
 
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: nodeutil.CreateAddNodeHandler(ra.AllocateOrOccupyCIDR),
-		UpdateFunc: nodeutil.CreateUpdateNodeHandler(func(_, newNode *v1.Node) error {
+		UpdateFunc: nodeutil.CreateUpdateNodeHandler(func(_, newNode *v1.Node, rpId string) error {
 			// If the PodCIDR is not empty we either:
 			// - already processed a Node that already had a CIDR after NC restarted
 			//   (cidr is marked as used),
@@ -143,7 +143,7 @@ func NewCIDRRangeAllocator(client clientset.Interface, nodeInformer informers.No
 			// state is correct.
 			// Restart of NC fixes the issue.
 			if newNode.Spec.PodCIDR == "" {
-				return ra.AllocateOrOccupyCIDR(newNode)
+				return ra.AllocateOrOccupyCIDR(newNode, rpId)
 			}
 			return nil
 		}),
@@ -222,7 +222,7 @@ func (r *rangeAllocator) occupyCIDR(node *v1.Node) error {
 // WARNING: If you're adding any return calls or defer any more work from this
 // function you have to make sure to update nodesInProcessing properly with the
 // disposition of the node when the work is done.
-func (r *rangeAllocator) AllocateOrOccupyCIDR(node *v1.Node) error {
+func (r *rangeAllocator) AllocateOrOccupyCIDR(node *v1.Node, rpId string) error {
 	if node == nil {
 		return nil
 	}
@@ -248,7 +248,7 @@ func (r *rangeAllocator) AllocateOrOccupyCIDR(node *v1.Node) error {
 	return nil
 }
 
-func (r *rangeAllocator) ReleaseCIDR(node *v1.Node) error {
+func (r *rangeAllocator) ReleaseCIDR(node *v1.Node, rpId string) error {
 	if node == nil || node.Spec.PodCIDR == "" {
 		return nil
 	}

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -341,20 +341,20 @@ func NewNodeLifecycleController(
 			return podLister.PodsWithMultiTenancy(namespace, tenant).Get(name)
 		}
 		podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj interface{}, rpId string) {
 				pod := obj.(*v1.Pod)
 				if nc.taintManager != nil {
 					nc.taintManager.PodUpdated(nil, pod, tenantPartitionClient, podGetter)
 				}
 			},
-			UpdateFunc: func(prev, obj interface{}) {
+			UpdateFunc: func(prev, obj interface{}, rpId string) {
 				prevPod := prev.(*v1.Pod)
 				newPod := obj.(*v1.Pod)
 				if nc.taintManager != nil {
 					nc.taintManager.PodUpdated(prevPod, newPod, tenantPartitionClient, podGetter)
 				}
 			},
-			DeleteFunc: func(obj interface{}) {
+			DeleteFunc: func(obj interface{}, rpId string) {
 				pod, isPod := obj.(*v1.Pod)
 				// We can get DeletedFinalStateUnknown instead of *v1.Pod here and we need to handle that correctly.
 				if !isPod {
@@ -390,15 +390,15 @@ func NewNodeLifecycleController(
 		nodeGetter := func(name string) (*v1.Node, error) { return nodeLister.Get(name) }
 		nc.taintManager = scheduler.NewNoExecuteTaintManager(resourcePartitionClient, tenantPartitionClients, nodeGetter)
 		nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc: nodeutil.CreateAddNodeHandler(func(node *v1.Node) error {
+			AddFunc: nodeutil.CreateAddNodeHandler(func(node *v1.Node, rpId string) error {
 				nc.taintManager.NodeUpdated(nil, node)
 				return nil
 			}),
-			UpdateFunc: nodeutil.CreateUpdateNodeHandler(func(oldNode, newNode *v1.Node) error {
+			UpdateFunc: nodeutil.CreateUpdateNodeHandler(func(oldNode, newNode *v1.Node, rpId string) error {
 				nc.taintManager.NodeUpdated(oldNode, newNode)
 				return nil
 			}),
-			DeleteFunc: nodeutil.CreateDeleteNodeHandler(func(node *v1.Node) error {
+			DeleteFunc: nodeutil.CreateDeleteNodeHandler(func(node *v1.Node, rpId string) error {
 				nc.taintManager.NodeUpdated(node, nil)
 				return nil
 			}),
@@ -407,11 +407,11 @@ func NewNodeLifecycleController(
 
 	klog.Infof("Controller will reconcile labels.")
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: nodeutil.CreateAddNodeHandler(func(node *v1.Node) error {
+		AddFunc: nodeutil.CreateAddNodeHandler(func(node *v1.Node, rpId string) error {
 			nc.nodeUpdateQueue.Add(node.Name)
 			return nil
 		}),
-		UpdateFunc: nodeutil.CreateUpdateNodeHandler(func(_, newNode *v1.Node) error {
+		UpdateFunc: nodeutil.CreateUpdateNodeHandler(func(_, newNode *v1.Node, rpId string) error {
 			nc.nodeUpdateQueue.Add(newNode.Name)
 			return nil
 		}),

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -168,12 +168,12 @@ func (a *HorizontalController) Run(stopCh <-chan struct{}) {
 }
 
 // obj could be an *v1.HorizontalPodAutoscaler, or a DeletionFinalStateUnknown marker item.
-func (a *HorizontalController) updateHPA(old, cur interface{}) {
-	a.enqueueHPA(cur)
+func (a *HorizontalController) updateHPA(old, cur interface{}, rpId string) {
+	a.enqueueHPA(cur, rpId)
 }
 
 // obj could be an *v1.HorizontalPodAutoscaler, or a DeletionFinalStateUnknown marker item.
-func (a *HorizontalController) enqueueHPA(obj interface{}) {
+func (a *HorizontalController) enqueueHPA(obj interface{}, rpId string) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
@@ -186,7 +186,7 @@ func (a *HorizontalController) enqueueHPA(obj interface{}) {
 	a.queue.AddRateLimited(key)
 }
 
-func (a *HorizontalController) deleteHPA(obj interface{}) {
+func (a *HorizontalController) deleteHPA(obj interface{}, rpId string) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -230,7 +230,7 @@ func (rsc *ReplicaSetController) resolveControllerRef(tenant, namespace string, 
 }
 
 // callback when RS is updated
-func (rsc *ReplicaSetController) updateRS(old, cur interface{}) {
+func (rsc *ReplicaSetController) updateRS(old, cur interface{}, rpId string) {
 	oldRS := old.(*apps.ReplicaSet)
 	curRS := cur.(*apps.ReplicaSet)
 
@@ -249,17 +249,17 @@ func (rsc *ReplicaSetController) updateRS(old, cur interface{}) {
 	if *(oldRS.Spec.Replicas) != *(curRS.Spec.Replicas) {
 		klog.V(4).Infof("%v %v updated. Desired pod count change: %d->%d", rsc.Kind, curRS.Name, *(oldRS.Spec.Replicas), *(curRS.Spec.Replicas))
 	}
-	rsc.enqueueReplicaSet(cur)
+	rsc.enqueueReplicaSet(cur, rpId)
 }
 
 // When a pod is created, enqueue the replica set that manages it and update its expectations.
-func (rsc *ReplicaSetController) addPod(obj interface{}) {
+func (rsc *ReplicaSetController) addPod(obj interface{}, rpId string) {
 	pod := obj.(*v1.Pod)
 
 	if pod.DeletionTimestamp != nil {
 		// on a restart of the controller manager, it's possible a new pod shows up in a state that
 		// is already pending deletion. Prevent the pod from being a creation observation.
-		rsc.deletePod(pod)
+		rsc.deletePod(pod, rpId)
 		return
 	}
 
@@ -275,7 +275,7 @@ func (rsc *ReplicaSetController) addPod(obj interface{}) {
 		}
 		klog.V(4).Infof("Pod %s created: %#v.", pod.Name, pod)
 		rsc.expectations.CreationObserved(rsKey)
-		rsc.enqueueReplicaSet(rs)
+		rsc.enqueueReplicaSet(rs, rpId)
 		return
 	}
 
@@ -289,14 +289,14 @@ func (rsc *ReplicaSetController) addPod(obj interface{}) {
 	}
 	klog.V(4).Infof("Orphan Pod %s created: %#v.", pod.Name, pod)
 	for _, rs := range rss {
-		rsc.enqueueReplicaSet(rs)
+		rsc.enqueueReplicaSet(rs, rpId)
 	}
 }
 
 // When a pod is updated, figure out what replica set/s manage it and wake them
 // up. If the labels of the pod have changed we need to awaken both the old
 // and new replica set. old and cur must be *v1.Pod types.
-func (rsc *ReplicaSetController) updatePod(old, cur interface{}) {
+func (rsc *ReplicaSetController) updatePod(old, cur interface{}, rpId string) {
 	curPod := cur.(*v1.Pod)
 	oldPod := old.(*v1.Pod)
 	if curPod.ResourceVersion == oldPod.ResourceVersion {
@@ -312,10 +312,10 @@ func (rsc *ReplicaSetController) updatePod(old, cur interface{}) {
 		// for modification of the deletion timestamp and expect an rs to create more replicas asap, not wait
 		// until the kubelet actually deletes the pod. This is different from the Phase of a pod changing, because
 		// an rs never initiates a phase change, and so is never asleep waiting for the same.
-		rsc.deletePod(curPod)
+		rsc.deletePod(curPod, rpId)
 		if labelChanged {
 			// we don't need to check the oldPod.DeletionTimestamp because DeletionTimestamp cannot be unset.
-			rsc.deletePod(oldPod)
+			rsc.deletePod(oldPod, rpId)
 		}
 		return
 	}
@@ -326,7 +326,7 @@ func (rsc *ReplicaSetController) updatePod(old, cur interface{}) {
 	if controllerRefChanged && oldControllerRef != nil {
 		// The ControllerRef was changed. Sync the old controller, if any.
 		if rs := rsc.resolveControllerRef(oldPod.Tenant, oldPod.Namespace, oldControllerRef); rs != nil {
-			rsc.enqueueReplicaSet(rs)
+			rsc.enqueueReplicaSet(rs, rpId)
 		}
 	}
 
@@ -337,7 +337,7 @@ func (rsc *ReplicaSetController) updatePod(old, cur interface{}) {
 			return
 		}
 		klog.V(4).Infof("Pod %s updated, objectMeta %+v -> %+v.", curPod.Name, oldPod.ObjectMeta, curPod.ObjectMeta)
-		rsc.enqueueReplicaSet(rs)
+		rsc.enqueueReplicaSet(rs, rpId)
 		// TODO: MinReadySeconds in the Pod will generate an Available condition to be added in
 		// the Pod status which in turn will trigger a requeue of the owning replica set thus
 		// having its status updated with the newly available replica. For now, we can fake the
@@ -363,14 +363,14 @@ func (rsc *ReplicaSetController) updatePod(old, cur interface{}) {
 		}
 		klog.V(4).Infof("Orphan Pod %s updated, objectMeta %+v -> %+v.", curPod.Name, oldPod.ObjectMeta, curPod.ObjectMeta)
 		for _, rs := range rss {
-			rsc.enqueueReplicaSet(rs)
+			rsc.enqueueReplicaSet(rs, rpId)
 		}
 	}
 }
 
 // When a pod is deleted, enqueue the replica set that manages the pod and update its expectations.
 // obj could be an *v1.Pod, or a DeletionFinalStateUnknown marker item.
-func (rsc *ReplicaSetController) deletePod(obj interface{}) {
+func (rsc *ReplicaSetController) deletePod(obj interface{}, rpId string) {
 	pod, ok := obj.(*v1.Pod)
 
 	// When a delete is dropped, the relist will notice a pod in the store not
@@ -405,11 +405,11 @@ func (rsc *ReplicaSetController) deletePod(obj interface{}) {
 	}
 	klog.V(4).Infof("Pod %s/%s/%s deleted through %v, timestamp %+v: %#v.", pod.Tenant, pod.Namespace, pod.Name, utilruntime.GetCaller(), pod.DeletionTimestamp, pod)
 	rsc.expectations.DeletionObserved(rsKey, controller.PodKey(pod))
-	rsc.enqueueReplicaSet(rs)
+	rsc.enqueueReplicaSet(rs, rpId)
 }
 
 // obj could be an *apps.ReplicaSet, or a DeletionFinalStateUnknown marker item.
-func (rsc *ReplicaSetController) enqueueReplicaSet(obj interface{}) {
+func (rsc *ReplicaSetController) enqueueReplicaSet(obj interface{}, rpId string) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -118,7 +118,7 @@ func NewResourceQuotaController(options *ResourceQuotaControllerOptions) (*Resou
 	options.ResourceQuotaInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: rq.addQuota,
-			UpdateFunc: func(old, cur interface{}) {
+			UpdateFunc: func(old, cur interface{}, rpId string) {
 				// We are only interested in observing updates to quota.spec to drive updates to quota.status.
 				// We ignore all updates to quota.Status because they are all driven by this controller.
 				// IMPORTANT:
@@ -132,7 +132,7 @@ func NewResourceQuotaController(options *ResourceQuotaControllerOptions) (*Resou
 				if quota.V1Equals(oldResourceQuota.Spec.Hard, curResourceQuota.Spec.Hard) {
 					return
 				}
-				rq.addQuota(curResourceQuota)
+				rq.addQuota(curResourceQuota, rpId)
 			},
 			// This will enter the sync loop and no-op, because the controller has been deleted from the store.
 			// Note that deleting a controller immediately after scaling it to 0 will not work. The recommended
@@ -193,7 +193,7 @@ func (rq *ResourceQuotaController) enqueueAll() {
 }
 
 // obj could be an *v1.ResourceQuota, or a DeletionFinalStateUnknown marker item.
-func (rq *ResourceQuotaController) enqueueResourceQuota(obj interface{}) {
+func (rq *ResourceQuotaController) enqueueResourceQuota(obj interface{}, rpId string) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		klog.Errorf("Couldn't get key for object %+v: %v", obj, err)
@@ -202,7 +202,7 @@ func (rq *ResourceQuotaController) enqueueResourceQuota(obj interface{}) {
 	rq.queue.Add(key)
 }
 
-func (rq *ResourceQuotaController) addQuota(obj interface{}) {
+func (rq *ResourceQuotaController) addQuota(obj interface{}, rpId string) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		klog.Errorf("Couldn't get key for object %+v: %v", obj, err)
@@ -392,7 +392,8 @@ func (rq *ResourceQuotaController) replenishQuota(groupResource schema.GroupReso
 		resourceQuotaResources := quota.ResourceNames(resourceQuota.Status.Hard)
 		if intersection := evaluator.MatchingResources(resourceQuotaResources); len(intersection) > 0 {
 			// TODO: make this support targeted replenishment to a specific kind, right now it does a full recalc on that quota.
-			rq.enqueueResourceQuota(resourceQuota)
+			// TODO: fill in RPId
+			rq.enqueueResourceQuota(resourceQuota, "resourceProviderId")
 		}
 	}
 }

--- a/pkg/controller/resourcequota/resource_quota_monitor.go
+++ b/pkg/controller/resourcequota/resource_quota_monitor.go
@@ -135,7 +135,7 @@ func (qm *QuotaMonitor) controllerFor(resource schema.GroupVersionResource) (cac
 	// TODO: pass this down
 	clock := clock.RealClock{}
 	handlers := cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj interface{}, rpId string) {
 			// TODO: leaky abstraction!  live w/ it for now, but should pass down an update filter func.
 			// we only want to queue the updates we care about though as too much noise will overwhelm queue.
 			notifyUpdate := false
@@ -159,7 +159,7 @@ func (qm *QuotaMonitor) controllerFor(resource schema.GroupVersionResource) (cac
 				qm.resourceChanges.Add(event)
 			}
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj interface{}, rpId string) {
 			// delta fifo may wrap the object in a cache.DeletedFinalStateUnknown, unwrap it
 			if deletedFinalStateUnknown, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 				obj = deletedFinalStateUnknown.Obj

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -151,7 +151,7 @@ func New(
 
 	serviceInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(cur interface{}) {
+			AddFunc: func(cur interface{}, rpId string) {
 				svc, ok := cur.(*v1.Service)
 				if ok && wantsNeutronLB(svc) {
 					s.createNeutronLB(cur)
@@ -159,14 +159,14 @@ func New(
 					s.enqueueService(cur)
 				}
 			},
-			UpdateFunc: func(old, cur interface{}) {
+			UpdateFunc: func(old, cur interface{}, rpId string) {
 				oldSvc, ok1 := old.(*v1.Service)
 				curSvc, ok2 := cur.(*v1.Service)
 				if ok1 && ok2 && (s.needsUpdate(oldSvc, curSvc) || needsCleanup(curSvc)) {
 					s.enqueueService(cur)
 				}
 			},
-			DeleteFunc: func(old interface{}) {
+			DeleteFunc: func(old interface{}, rpId string) {
 				if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.ServiceLoadBalancerFinalizer) {
 					// No need to handle deletion event if finalizer feature gate is
 					// enabled. Because the deletion would be handled by the update

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -130,7 +130,7 @@ func (c *ServiceAccountsController) Run(workers int, stopCh <-chan struct{}) {
 }
 
 // serviceAccountDeleted reacts to a ServiceAccount deletion by recreating a default ServiceAccount in the namespace if needed
-func (c *ServiceAccountsController) serviceAccountDeleted(obj interface{}) {
+func (c *ServiceAccountsController) serviceAccountDeleted(obj interface{}, rpId string) {
 	sa, ok := obj.(*v1.ServiceAccount)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -148,13 +148,13 @@ func (c *ServiceAccountsController) serviceAccountDeleted(obj interface{}) {
 }
 
 // namespaceAdded reacts to a Namespace creation by creating a default ServiceAccount object
-func (c *ServiceAccountsController) namespaceAdded(obj interface{}) {
+func (c *ServiceAccountsController) namespaceAdded(obj interface{}, rpId string) {
 	namespace := obj.(*v1.Namespace)
 	c.queue.Add(namespace.Tenant + "/" + namespace.Name)
 }
 
 // namespaceUpdated reacts to a Namespace update (or re-list) by creating a default ServiceAccount in the namespace if needed
-func (c *ServiceAccountsController) namespaceUpdated(oldObj interface{}, newObj interface{}) {
+func (c *ServiceAccountsController) namespaceUpdated(oldObj interface{}, newObj interface{}, rpId string) {
 	newNamespace := newObj.(*v1.Namespace)
 	c.queue.Add(newNamespace.Tenant + "/" + newNamespace.Name)
 }

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -184,13 +184,13 @@ func (e *TokensController) Run(workers int, stopCh <-chan struct{}) {
 	klog.V(1).Infof("Shutting down")
 }
 
-func (e *TokensController) queueServiceAccountSync(obj interface{}) {
+func (e *TokensController) queueServiceAccountSync(obj interface{}, rpId string) {
 	if serviceAccount, ok := obj.(*v1.ServiceAccount); ok {
 		e.syncServiceAccountQueue.Add(makeServiceAccountKey(serviceAccount))
 	}
 }
 
-func (e *TokensController) queueServiceAccountUpdateSync(oldObj interface{}, newObj interface{}) {
+func (e *TokensController) queueServiceAccountUpdateSync(oldObj interface{}, newObj interface{}, rpId string) {
 	if serviceAccount, ok := newObj.(*v1.ServiceAccount); ok {
 		e.syncServiceAccountQueue.Add(makeServiceAccountKey(serviceAccount))
 	}
@@ -213,13 +213,13 @@ func (e *TokensController) retryOrForget(queue workqueue.RateLimitingInterface, 
 	queue.Forget(key)
 }
 
-func (e *TokensController) queueSecretSync(obj interface{}) {
+func (e *TokensController) queueSecretSync(obj interface{}, rpId string) {
 	if secret, ok := obj.(*v1.Secret); ok {
 		e.syncSecretQueue.Add(makeSecretQueueKey(secret))
 	}
 }
 
-func (e *TokensController) queueSecretUpdateSync(oldObj interface{}, newObj interface{}) {
+func (e *TokensController) queueSecretUpdateSync(oldObj interface{}, newObj interface{}, rpId string) {
 	if secret, ok := newObj.(*v1.Secret); ok {
 		e.syncSecretQueue.Add(makeSecretQueueKey(secret))
 	}

--- a/pkg/controller/tenant/tenant_controller.go
+++ b/pkg/controller/tenant/tenant_controller.go
@@ -116,10 +116,10 @@ func NewTenantController(kubeClient clientset.Interface,
 	// configure the tenant informer event handlers
 	tenantInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj interface{}, rpId string) {
 				tenantController.enqueue(obj)
 			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
+			UpdateFunc: func(oldObj, newObj interface{}, rpId string) {
 				tenantController.enqueue(newObj)
 			},
 		},

--- a/pkg/controller/ttl/ttl_controller.go
+++ b/pkg/controller/ttl/ttl_controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -127,7 +128,7 @@ func (ttlc *TTLController) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (ttlc *TTLController) addNode(obj interface{}) {
+func (ttlc *TTLController) addNode(obj interface{}, rpId string) {
 	node, ok := obj.(*v1.Node)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
@@ -146,7 +147,7 @@ func (ttlc *TTLController) addNode(obj interface{}) {
 	ttlc.enqueueNode(node)
 }
 
-func (ttlc *TTLController) updateNode(_, newObj interface{}) {
+func (ttlc *TTLController) updateNode(_, newObj interface{}, rpId string) {
 	node, ok := newObj.(*v1.Node)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", newObj))
@@ -160,7 +161,7 @@ func (ttlc *TTLController) updateNode(_, newObj interface{}) {
 	ttlc.enqueueNode(node)
 }
 
-func (ttlc *TTLController) deleteNode(obj interface{}) {
+func (ttlc *TTLController) deleteNode(obj interface{}, rpId string) {
 	_, ok := obj.(*v1.Node)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
@@ -117,7 +117,7 @@ func (tc *Controller) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (tc *Controller) addJob(obj interface{}) {
+func (tc *Controller) addJob(obj interface{}, rpId string) {
 	job := obj.(*batch.Job)
 	klog.V(4).Infof("Adding job %s/%s", job.Namespace, job.Name)
 
@@ -126,7 +126,7 @@ func (tc *Controller) addJob(obj interface{}) {
 	}
 }
 
-func (tc *Controller) updateJob(old, cur interface{}) {
+func (tc *Controller) updateJob(old, cur interface{}, rpId string) {
 	job := cur.(*batch.Job)
 	klog.V(4).Infof("Updating job %s/%s", job.Namespace, job.Name)
 

--- a/pkg/controller/util/node/controller_utils.go
+++ b/pkg/controller/util/node/controller_utils.go
@@ -266,30 +266,30 @@ func AddOrUpdateLabelsOnNode(kubeClient clientset.Interface, labelsToUpdate map[
 }
 
 // CreateAddNodeHandler creates an add node handler.
-func CreateAddNodeHandler(f func(node *v1.Node) error) func(obj interface{}) {
-	return func(originalObj interface{}) {
+func CreateAddNodeHandler(f func(node *v1.Node, rpId string) error) func(obj interface{}, rpId string) {
+	return func(originalObj interface{}, rpId string) {
 		node := originalObj.(*v1.Node).DeepCopy()
-		if err := f(node); err != nil {
+		if err := f(node, rpId); err != nil {
 			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add: %v", err))
 		}
 	}
 }
 
 // CreateUpdateNodeHandler creates a node update handler. (Common to lifecycle and ipam)
-func CreateUpdateNodeHandler(f func(oldNode, newNode *v1.Node) error) func(oldObj, newObj interface{}) {
-	return func(origOldObj, origNewObj interface{}) {
+func CreateUpdateNodeHandler(f func(oldNode, newNode *v1.Node, rpId string) error) func(oldObj, newObj interface{}, rpId string) {
+	return func(origOldObj, origNewObj interface{}, rpId string) {
 		node := origNewObj.(*v1.Node).DeepCopy()
 		prevNode := origOldObj.(*v1.Node).DeepCopy()
 
-		if err := f(prevNode, node); err != nil {
+		if err := f(prevNode, node, rpId); err != nil {
 			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add/Delete: %v", err))
 		}
 	}
 }
 
 // CreateDeleteNodeHandler creates a delete node handler. (Common to lifecycle and ipam)
-func CreateDeleteNodeHandler(f func(node *v1.Node) error) func(obj interface{}) {
-	return func(originalObj interface{}) {
+func CreateDeleteNodeHandler(f func(node *v1.Node, rpId string) error) func(obj interface{}, rpId string) {
+	return func(originalObj interface{}, rpId string) {
 		originalNode, isNode := originalObj.(*v1.Node)
 		// We can get DeletedFinalStateUnknown instead of *v1.Node here and
 		// we need to handle that correctly. #34692
@@ -306,7 +306,7 @@ func CreateDeleteNodeHandler(f func(node *v1.Node) error) func(obj interface{}) 
 			}
 		}
 		node := originalNode.DeepCopy()
-		if err := f(node); err != nil {
+		if err := f(node, rpId); err != nil {
 			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add/Delete: %v", err))
 		}
 	}

--- a/pkg/controller/vmpod/vm_controller.go
+++ b/pkg/controller/vmpod/vm_controller.go
@@ -55,7 +55,7 @@ func NewVMPod(kubeClient clientset.Interface, podInformer coreinformers.PodInfor
 	return vmc
 }
 
-func (vmc *VMPodController) updatePod(old, cur interface{}) {
+func (vmc *VMPodController) updatePod(old, cur interface{}, rpId string) {
 	newPod := cur.(*v1.Pod)
 	oldPod := old.(*v1.Pod)
 

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -136,7 +136,7 @@ func NewExpandController(
 
 	pvcInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
 		AddFunc: expc.enqueuePVC,
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new interface{}, rpId string) {
 			oldPVC, ok := old.(*v1.PersistentVolumeClaim)
 			if !ok {
 				return
@@ -149,7 +149,7 @@ func NewExpandController(
 			}
 			newSize := newPVC.Spec.Resources.Requests[v1.ResourceStorage]
 			if newSize.Cmp(oldSize) > 0 {
-				expc.enqueuePVC(new)
+				expc.enqueuePVC(new, rpId)
 			}
 		},
 		DeleteFunc: expc.enqueuePVC,
@@ -158,7 +158,7 @@ func NewExpandController(
 	return expc, nil
 }
 
-func (expc *expandController) enqueuePVC(obj interface{}) {
+func (expc *expandController) enqueuePVC(obj interface{}, rpId string) {
 	pvc, ok := obj.(*v1.PersistentVolumeClaim)
 	if !ok {
 		return

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -103,9 +103,9 @@ func NewController(p ControllerParameters) (*PersistentVolumeController, error) 
 
 	p.VolumeInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { controller.enqueueWork(controller.volumeQueue, obj) },
-			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(controller.volumeQueue, newObj) },
-			DeleteFunc: func(obj interface{}) { controller.enqueueWork(controller.volumeQueue, obj) },
+			AddFunc:    func(obj interface{}, rpId string) { controller.enqueueWork(controller.volumeQueue, obj) },
+			UpdateFunc: func(oldObj, newObj interface{}, rpId string) { controller.enqueueWork(controller.volumeQueue, newObj) },
+			DeleteFunc: func(obj interface{}, rpId string) { controller.enqueueWork(controller.volumeQueue, obj) },
 		},
 	)
 	controller.volumeLister = p.VolumeInformer.Lister()
@@ -113,9 +113,9 @@ func NewController(p ControllerParameters) (*PersistentVolumeController, error) 
 
 	p.ClaimInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { controller.enqueueWork(controller.claimQueue, obj) },
-			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(controller.claimQueue, newObj) },
-			DeleteFunc: func(obj interface{}) { controller.enqueueWork(controller.claimQueue, obj) },
+			AddFunc:    func(obj interface{}, rpId string) { controller.enqueueWork(controller.claimQueue, obj) },
+			UpdateFunc: func(oldObj, newObj interface{}, rpId string) { controller.enqueueWork(controller.claimQueue, newObj) },
+			DeleteFunc: func(obj interface{}, rpId string) { controller.enqueueWork(controller.claimQueue, obj) },
 		},
 	)
 	controller.claimLister = p.ClaimInformer.Lister()

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -71,21 +71,21 @@ func NewPVCProtectionController(pvcInformer coreinformers.PersistentVolumeClaimI
 	e.pvcListerSynced = pvcInformer.Informer().HasSynced
 	pvcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: e.pvcAddedUpdated,
-		UpdateFunc: func(old, new interface{}) {
-			e.pvcAddedUpdated(new)
+		UpdateFunc: func(old, new interface{}, rpId string) {
+			e.pvcAddedUpdated(new, rpId)
 		},
 	})
 
 	e.podLister = podInformer.Lister()
 	e.podListerSynced = podInformer.Informer().HasSynced
 	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			e.podAddedDeletedUpdated(obj, false)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj interface{}, rpId string) {
 			e.podAddedDeletedUpdated(obj, true)
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new interface{}, rpId string) {
 			e.podAddedDeletedUpdated(new, false)
 		},
 	})
@@ -239,7 +239,7 @@ func (c *Controller) isBeingUsed(pvc *v1.PersistentVolumeClaim) (bool, error) {
 }
 
 // pvcAddedUpdated reacts to pvc added/updated/deleted events
-func (c *Controller) pvcAddedUpdated(obj interface{}) {
+func (c *Controller) pvcAddedUpdated(obj interface{}, rpId string) {
 	pvc, ok := obj.(*v1.PersistentVolumeClaim)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("PVC informer returned non-PVC object: %#v", obj))

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -67,8 +67,8 @@ func NewPVProtectionController(pvInformer coreinformers.PersistentVolumeInformer
 	e.pvListerSynced = pvInformer.Informer().HasSynced
 	pvInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: e.pvAddedUpdated,
-		UpdateFunc: func(old, new interface{}) {
-			e.pvAddedUpdated(new)
+		UpdateFunc: func(old, new interface{}, rpId string) {
+			e.pvAddedUpdated(new, rpId)
 		},
 	})
 
@@ -201,7 +201,7 @@ func (c *Controller) isBeingUsed(pv *v1.PersistentVolume) bool {
 }
 
 // pvAddedUpdated reacts to pv added/updated events
-func (c *Controller) pvAddedUpdated(obj interface{}) {
+func (c *Controller) pvAddedUpdated(obj interface{}, rpId string) {
 	pv, ok := obj.(*v1.PersistentVolume)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("PV informer returned non-PV object: %#v", obj))

--- a/pkg/controller/volume/scheduling/scheduler_assume_cache.go
+++ b/pkg/controller/volume/scheduling/scheduler_assume_cache.go
@@ -150,7 +150,7 @@ func NewAssumeCache(informer cache.SharedIndexInformer, description, indexName s
 	return c
 }
 
-func (c *assumeCache) add(obj interface{}) {
+func (c *assumeCache) add(obj interface{}, rpId string) {
 	if obj == nil {
 		return
 	}
@@ -190,11 +190,11 @@ func (c *assumeCache) add(obj interface{}) {
 	klog.V(10).Infof("Added %v %v to assume cache: %+v ", c.description, name, obj)
 }
 
-func (c *assumeCache) update(oldObj interface{}, newObj interface{}) {
-	c.add(newObj)
+func (c *assumeCache) update(oldObj interface{}, newObj interface{}, rpId string) {
+	c.add(newObj, rpId)
 }
 
-func (c *assumeCache) delete(obj interface{}) {
+func (c *assumeCache) delete(obj interface{}, rpId string) {
 	if obj == nil {
 		return
 	}

--- a/pkg/controller/volume/scheduling/scheduler_binder.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder.go
@@ -104,9 +104,9 @@ type volumeBinder struct {
 	kubeClient  clientset.Interface
 	classLister storagelisters.StorageClassLister
 
-	nodeInformer coreinformers.NodeInformer
-	pvcCache     PVCAssumeCache
-	pvCache      PVAssumeCache
+	nodeInformers []coreinformers.NodeInformer
+	pvcCache      PVCAssumeCache
+	pvCache       PVAssumeCache
 
 	// Stores binding decisions that were made in FindPodVolumes for use in AssumePodVolumes.
 	// AssumePodVolumes modifies the bindings again for use in BindPodVolumes.
@@ -119,7 +119,7 @@ type volumeBinder struct {
 // NewVolumeBinder sets up all the caches needed for the scheduler to make volume binding decisions.
 func NewVolumeBinder(
 	kubeClient clientset.Interface,
-	nodeInformer coreinformers.NodeInformer,
+	nodeInformers []coreinformers.NodeInformer,
 	pvcInformer coreinformers.PersistentVolumeClaimInformer,
 	pvInformer coreinformers.PersistentVolumeInformer,
 	storageClassInformer storageinformers.StorageClassInformer,
@@ -128,7 +128,7 @@ func NewVolumeBinder(
 	b := &volumeBinder{
 		kubeClient:      kubeClient,
 		classLister:     storageClassInformer.Lister(),
-		nodeInformer:    nodeInformer,
+		nodeInformers:   nodeInformers,
 		pvcCache:        NewPVCAssumeCache(pvcInformer.Informer()),
 		pvCache:         NewPVAssumeCache(pvInformer.Informer()),
 		podBindingCache: NewPodBindingCache(),
@@ -469,9 +469,14 @@ func (b *volumeBinder) checkBindings(pod *v1.Pod, bindings []*bindingInfo, claim
 		return false, fmt.Errorf("failed to get cached claims to provision for pod %q", podName)
 	}
 
-	node, err := b.nodeInformer.Lister().Get(pod.Spec.NodeName)
-	if err != nil {
-		return false, fmt.Errorf("failed to get node %q: %v", pod.Spec.NodeName, err)
+	var node *v1.Node
+	var err error
+	for _, nodeInformer := range b.nodeInformers {
+		node, err = nodeInformer.Lister().Get(pod.Spec.NodeName)
+		if err != nil { // TODO - check error type, continue to search next RP if no found
+			return false, fmt.Errorf("failed to get node %q: %v", pod.Spec.NodeName, err)
+		}
+		break
 	}
 
 	// Check for any conditions that might require scheduling retry

--- a/pkg/controller/volume/scheduling/scheduler_binder.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder.go
@@ -473,7 +473,8 @@ func (b *volumeBinder) checkBindings(pod *v1.Pod, bindings []*bindingInfo, claim
 	var err error
 	for _, nodeInformer := range b.nodeInformers {
 		node, err = nodeInformer.Lister().Get(pod.Spec.NodeName)
-		if err != nil { // TODO - check error type, continue to search next RP if no found
+		if err != nil { // TODO - check error type, continue to search next RP if not found
+			klog.Errorf("Error getting node from current node informer. error [%v]. TODO - check error type, continue to search next RP if not found", err)
 			return false, fmt.Errorf("failed to get node %q: %v", pod.Spec.NodeName, err)
 		}
 		break

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -454,7 +454,10 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		r := cache.NewReflector(nodeLW, &v1.Node{}, nodeIndexer, 0)
 		go r.Run(wait.NeverStop)
 	}
-	nodeInfo := &predicates.CachedNodeInfo{NodeLister: corelisters.NewNodeLister(nodeIndexer)}
+
+	cacheNodeInfos := make(map[string]corelisters.NodeLister, 1)
+	cacheNodeInfos["0"] = corelisters.NewNodeLister(nodeIndexer)
+	nodeInfo := predicates.NewCachedNodeInfo(cacheNodeInfos)
 
 	// TODO: get the real node object of ourself,
 	// and use the real node name and UID.

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -237,7 +237,8 @@ func (kl *Kubelet) GetNode() (*v1.Node, error) {
 	if !hasValidTPClients(kl.kubeTPClients) {
 		return kl.initialNode()
 	}
-	return kl.nodeInfo.GetNodeInfo(string(kl.nodeName))
+	n, _, err := kl.nodeInfo.GetNodeInfo(string(kl.nodeName))
+	return n, err
 }
 
 // getNodeAnyWay() must return a *v1.Node which is required by RunGeneralPredicates().
@@ -247,7 +248,7 @@ func (kl *Kubelet) GetNode() (*v1.Node, error) {
 // zero capacity, and the default labels.
 func (kl *Kubelet) getNodeAnyWay() (*v1.Node, error) {
 	if hasValidTPClients(kl.kubeTPClients) {
-		if n, err := kl.nodeInfo.GetNodeInfo(string(kl.nodeName)); err == nil {
+		if n, _, err := kl.nodeInfo.GetNodeInfo(string(kl.nodeName)); err == nil {
 			return n, nil
 		}
 	}

--- a/pkg/kubelet/lifecycle/predicate.go
+++ b/pkg/kubelet/lifecycle/predicate.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -66,8 +67,10 @@ func (w *predicateAdmitHandler) Admit(attrs *PodAdmitAttributes) PodAdmitResult 
 	}
 	admitPod := attrs.Pod
 	pods := attrs.OtherPods
+	// TODO - fill in resourceProviderId
 	nodeInfo := schedulernodeinfo.NewNodeInfo(pods...)
 	nodeInfo.SetNode(node)
+	// TODO: nodeInfo.SetResourceProviderId
 	// ensure the node has enough plugin resources for that required in pods
 	if err = w.pluginResourceUpdateFunc(nodeInfo, attrs); err != nil {
 		message := fmt.Sprintf("Update plugin resources failed due to %v, which is unexpected.", err)

--- a/pkg/kubemark/controller.go
+++ b/pkg/kubemark/controller.go
@@ -363,7 +363,7 @@ func (kubemarkCluster *kubemarkCluster) getHollowNodeName() (string, error) {
 	return "", fmt.Errorf("did not find any hollow nodes in the cluster")
 }
 
-func (kubemarkCluster *kubemarkCluster) removeUnneededNodes(oldObj interface{}, newObj interface{}) {
+func (kubemarkCluster *kubemarkCluster) removeUnneededNodes(oldObj interface{}, newObj interface{}, rpId string) {
 	node, ok := newObj.(*apiv1.Node)
 	if !ok {
 		return

--- a/pkg/master/controller/crdregistration/crdregistration_controller.go
+++ b/pkg/master/controller/crdregistration/crdregistration_controller.go
@@ -81,17 +81,17 @@ func NewCRDRegistrationController(crdinformer crdinformers.CustomResourceDefinit
 	c.syncHandler = c.handleVersionUpdate
 
 	crdinformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			cast := obj.(*apiextensions.CustomResourceDefinition)
 			c.enqueueCRD(cast)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj interface{}, rpId string) {
 			// Enqueue both old and new object to make sure we remove and add appropriate API services.
 			// The working queue will resolve any duplicates and only changes will stay in the queue.
 			c.enqueueCRD(oldObj.(*apiextensions.CustomResourceDefinition))
 			c.enqueueCRD(newObj.(*apiextensions.CustomResourceDefinition))
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj interface{}, rpId string) {
 			cast, ok := obj.(*apiextensions.CustomResourceDefinition)
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/pkg/proxy/config/config.go
+++ b/pkg/proxy/config/config.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -105,7 +106,7 @@ func (c *EndpointsConfig) Run(stopCh <-chan struct{}) {
 	}
 }
 
-func (c *EndpointsConfig) handleAddEndpoints(obj interface{}) {
+func (c *EndpointsConfig) handleAddEndpoints(obj interface{}, rpId string) {
 	endpoints, ok := obj.(*v1.Endpoints)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
@@ -117,7 +118,7 @@ func (c *EndpointsConfig) handleAddEndpoints(obj interface{}) {
 	}
 }
 
-func (c *EndpointsConfig) handleUpdateEndpoints(oldObj, newObj interface{}) {
+func (c *EndpointsConfig) handleUpdateEndpoints(oldObj, newObj interface{}, rpId string) {
 	oldEndpoints, ok := oldObj.(*v1.Endpoints)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", oldObj))
@@ -134,7 +135,7 @@ func (c *EndpointsConfig) handleUpdateEndpoints(oldObj, newObj interface{}) {
 	}
 }
 
-func (c *EndpointsConfig) handleDeleteEndpoints(obj interface{}) {
+func (c *EndpointsConfig) handleDeleteEndpoints(obj interface{}, rpId string) {
 	endpoints, ok := obj.(*v1.Endpoints)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -196,7 +197,7 @@ func (c *ServiceConfig) Run(stopCh <-chan struct{}) {
 	}
 }
 
-func (c *ServiceConfig) handleAddService(obj interface{}) {
+func (c *ServiceConfig) handleAddService(obj interface{}, rpId string) {
 	service, ok := obj.(*v1.Service)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
@@ -208,7 +209,7 @@ func (c *ServiceConfig) handleAddService(obj interface{}) {
 	}
 }
 
-func (c *ServiceConfig) handleUpdateService(oldObj, newObj interface{}) {
+func (c *ServiceConfig) handleUpdateService(oldObj, newObj interface{}, rpId string) {
 	oldService, ok := oldObj.(*v1.Service)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", oldObj))
@@ -225,7 +226,7 @@ func (c *ServiceConfig) handleUpdateService(oldObj, newObj interface{}) {
 	}
 }
 
-func (c *ServiceConfig) handleDeleteService(obj interface{}) {
+func (c *ServiceConfig) handleDeleteService(obj interface{}, rpId string) {
 	service, ok := obj.(*v1.Service)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/pkg/scheduler/algorithm/priorities/interpod_affinity.go
+++ b/pkg/scheduler/algorithm/priorities/interpod_affinity.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -37,7 +38,7 @@ import (
 // InterPodAffinity contains information to calculate inter pod affinity.
 type InterPodAffinity struct {
 	info                  predicates.NodeInfo
-	nodeLister            algorithm.NodeLister
+	nodeListers           []algorithm.NodeLister
 	podLister             algorithm.PodLister
 	hardPodAffinityWeight int32
 }
@@ -45,12 +46,12 @@ type InterPodAffinity struct {
 // NewInterPodAffinityPriority creates an InterPodAffinity.
 func NewInterPodAffinityPriority(
 	info predicates.NodeInfo,
-	nodeLister algorithm.NodeLister,
+	nodeListers []algorithm.NodeLister,
 	podLister algorithm.PodLister,
 	hardPodAffinityWeight int32) PriorityFunction {
 	interPodAffinity := &InterPodAffinity{
 		info:                  info,
-		nodeLister:            nodeLister,
+		nodeListers:           nodeListers,
 		podLister:             podLister,
 		hardPodAffinityWeight: hardPodAffinityWeight,
 	}
@@ -135,7 +136,7 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, node
 	var maxCount, minCount int64
 
 	processPod := func(existingPod *v1.Pod) error {
-		existingPodNode, err := ipa.info.GetNodeInfo(existingPod.Spec.NodeName)
+		existingPodNode, _, err := ipa.info.GetNodeInfo(existingPod.Spec.NodeName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				klog.Errorf("Node not found, %v", existingPod.Spec.NodeName)

--- a/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -70,7 +71,7 @@ func init() {
 		priorities.InterPodAffinityPriority,
 		factory.PriorityConfigFactory{
 			Function: func(args factory.PluginFactoryArgs) priorities.PriorityFunction {
-				return priorities.NewInterPodAffinityPriority(args.NodeInfo, args.NodeLister, args.PodLister, args.HardPodAffinitySymmetricWeight)
+				return priorities.NewInterPodAffinityPriority(args.NodeInfo, args.NodeListers, args.PodLister, args.HardPodAffinitySymmetricWeight)
 			},
 			Weight: 1,
 		},

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -102,8 +102,7 @@ type KubeSchedulerConfiguration struct {
 
 	// ResourceProviderClientConnections is the kubeconfig files to the resource providers in Arktos scaleout design
 	// optional for single cluster in Arktos deployment model
-	// TODO: make it an array for future release when multiple RP is supported
-	ResourceProviderClientConnection componentbaseconfig.ClientConnectionConfiguration
+	ResourceProviderKubeConfig string
 }
 
 // SchedulerAlgorithmSource is the source of a scheduler algorithm. One source

--- a/pkg/scheduler/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1alpha1/zz_generated.conversion.go
@@ -163,9 +163,7 @@ func autoConvert_v1alpha1_KubeSchedulerConfiguration_To_config_KubeSchedulerConf
 	out.BindTimeoutSeconds = (*int64)(unsafe.Pointer(in.BindTimeoutSeconds))
 	out.Plugins = (*config.Plugins)(unsafe.Pointer(in.Plugins))
 	out.PluginConfig = *(*[]config.PluginConfig)(unsafe.Pointer(&in.PluginConfig))
-	if err := configv1alpha1.Convert_v1alpha1_ClientConnectionConfiguration_To_config_ClientConnectionConfiguration(&in.ResourceProviderClientConnection, &out.ResourceProviderClientConnection, s); err != nil {
-		return err
-	}
+	out.ResourceProviderKubeConfig = in.ResourceProviderKubeConfig
 	return nil
 }
 
@@ -196,9 +194,7 @@ func autoConvert_config_KubeSchedulerConfiguration_To_v1alpha1_KubeSchedulerConf
 	out.BindTimeoutSeconds = (*int64)(unsafe.Pointer(in.BindTimeoutSeconds))
 	out.Plugins = (*v1alpha1.Plugins)(unsafe.Pointer(in.Plugins))
 	out.PluginConfig = *(*[]v1alpha1.PluginConfig)(unsafe.Pointer(&in.PluginConfig))
-	if err := configv1alpha1.Convert_config_ClientConnectionConfiguration_To_v1alpha1_ClientConnectionConfiguration(&in.ResourceProviderClientConnection, &out.ResourceProviderClientConnection, s); err != nil {
-		return err
-	}
+	out.ResourceProviderKubeConfig = in.ResourceProviderKubeConfig
 	return nil
 }
 

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -50,7 +50,6 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	out.ResourceProviderClientConnection = in.ResourceProviderClientConnection
 	return
 }
 

--- a/pkg/scheduler/factory/plugins.go
+++ b/pkg/scheduler/factory/plugins.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -40,7 +41,7 @@ type PluginFactoryArgs struct {
 	ControllerLister               algorithm.ControllerLister
 	ReplicaSetLister               algorithm.ReplicaSetLister
 	StatefulSetLister              algorithm.StatefulSetLister
-	NodeLister                     algorithm.NodeLister
+	NodeListers                    []algorithm.NodeLister
 	PDBLister                      algorithm.PDBLister
 	NodeInfo                       predicates.NodeInfo
 	PVInfo                         predicates.PersistentVolumeInfo

--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -86,7 +86,7 @@ type podState struct {
 	bindingFinished bool
 	// Used for scale out multiple RPs - use array row number for now
 	// Consider change to string later for universal cluster naming
-	resourceProviderId int
+	resourceProviderId string
 }
 
 type imageState struct {

--- a/pkg/scheduler/internal/cache/debugger/debugger.go
+++ b/pkg/scheduler/internal/cache/debugger/debugger.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -33,17 +34,17 @@ type CacheDebugger struct {
 
 // New creates a CacheDebugger.
 func New(
-	nodeLister corelisters.NodeLister,
+	nodeListers []corelisters.NodeLister,
 	podLister corelisters.PodLister,
 	cache internalcache.Cache,
 	podQueue internalqueue.SchedulingQueue,
 ) *CacheDebugger {
 	return &CacheDebugger{
 		Comparer: CacheComparer{
-			NodeLister: nodeLister,
-			PodLister:  podLister,
-			Cache:      cache,
-			PodQueue:   podQueue,
+			NodeListers: nodeListers,
+			PodLister:   podLister,
+			Cache:       cache,
+			PodQueue:    podQueue,
 		},
 		Dumper: CacheDumper{
 			cache:    cache,

--- a/pkg/scheduler/internal/cache/interface.go
+++ b/pkg/scheduler/internal/cache/interface.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2015 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -87,10 +88,10 @@ type Cache interface {
 	IsAssumedPod(pod *v1.Pod) (bool, error)
 
 	// AddNode adds overall information about node.
-	AddNode(node *v1.Node) error
+	AddNode(node *v1.Node, resourceProviderId string) error
 
 	// UpdateNode updates overall information about node.
-	UpdateNode(oldNode, newNode *v1.Node) error
+	UpdateNode(oldNode, newNode *v1.Node, resourceProviderId string) error
 
 	// RemoveNode removes overall information about node.
 	RemoveNode(node *v1.Node) error

--- a/pkg/scheduler/nodeinfo/node_info.go
+++ b/pkg/scheduler/nodeinfo/node_info.go
@@ -49,7 +49,8 @@ type ImageStateSummary struct {
 // NodeInfo is node level aggregated information.
 type NodeInfo struct {
 	// Overall node information.
-	node *v1.Node
+	node               *v1.Node
+	resourceProviderId string
 
 	pods             []*v1.Pod
 	podsWithAffinity []*v1.Pod
@@ -299,6 +300,20 @@ func (n *NodeInfo) Pods() []*v1.Pod {
 // SetPods sets all pods scheduled (including assumed to be) on this node.
 func (n *NodeInfo) SetPods(pods []*v1.Pod) {
 	n.pods = pods
+}
+
+func (n *NodeInfo) GetResourceProviderId() string {
+	return n.resourceProviderId
+}
+
+func (n *NodeInfo) SetResourceProviderId(rpId string) error {
+	if n.resourceProviderId != "" {
+		return fmt.Errorf("Node %s was initialized with resource provider id %s", n.Node().Name, n.resourceProviderId)
+	} else if rpId == "" {
+		return fmt.Errorf("Cannot set resource provider id as empty. Node name %s", n.Node().Name)
+	}
+	n.resourceProviderId = rpId
+	return nil
 }
 
 // UsedPorts returns used ports on this node.

--- a/pkg/scheduler/nodeinfo/util.go
+++ b/pkg/scheduler/nodeinfo/util.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2015 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -40,6 +41,7 @@ func CreateNodeNameToInfoMap(pods []*v1.Pod, nodes []*v1.Node) map[string]*NodeI
 		}
 		nodeInfo := nodeNameToInfo[node.Name]
 		nodeInfo.SetNode(node)
+		// TODO - nodeInfo.SetResourceProviderId
 		nodeInfo.imageStates = getNodeImageStates(node, imageExistenceMap)
 	}
 	return nodeNameToInfo

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -120,7 +120,7 @@ var defaultSchedulerOptions = schedulerOptions{
 
 // New returns a Scheduler
 func New(client clientset.Interface,
-	nodeInformer coreinformers.NodeInformer,
+	nodeInformers []coreinformers.NodeInformer,
 	podInformer coreinformers.PodInformer,
 	pvInformer coreinformers.PersistentVolumeInformer,
 	pvcInformer coreinformers.PersistentVolumeClaimInformer,
@@ -146,7 +146,7 @@ func New(client clientset.Interface,
 	configurator := factory.NewConfigFactory(&factory.ConfigFactoryArgs{
 		SchedulerName:                  options.schedulerName,
 		Client:                         client,
-		NodeInformer:                   nodeInformer,
+		NodeInformers:                  nodeInformers,
 		PodInformer:                    podInformer,
 		PvInformer:                     pvInformer,
 		PvcInformer:                    pvcInformer,
@@ -203,7 +203,7 @@ func New(client clientset.Interface,
 	// Create the scheduler.
 	sched := NewFromConfig(config)
 
-	AddAllEventHandlers(sched, options.schedulerName, nodeInformer, podInformer, pvInformer, pvcInformer, serviceInformer, storageClassInformer)
+	AddAllEventHandlers(sched, options.schedulerName, nodeInformers, podInformer, pvInformer, pvcInformer, serviceInformer, storageClassInformer)
 	return sched, nil
 }
 
@@ -282,7 +282,7 @@ func (sched *Scheduler) recordSchedulingFailure(pod *v1.Pod, err error, reason s
 // schedule implements the scheduling algorithm and returns the suggested result(host,
 // evaluated nodes number,feasible nodes number).
 func (sched *Scheduler) schedule(pod *v1.Pod, pluginContext *framework.PluginContext) (core.ScheduleResult, error) {
-	result, err := sched.config.Algorithm.Schedule(pod, sched.config.NodeLister, pluginContext)
+	result, err := sched.config.Algorithm.Schedule(pod, sched.config.NodeListers[0], pluginContext)
 	if err != nil {
 		pod = pod.DeepCopy()
 		sched.recordSchedulingFailure(pod, err, v1.PodReasonUnschedulable, err.Error())
@@ -301,7 +301,7 @@ func (sched *Scheduler) preempt(preemptor *v1.Pod, scheduleErr error) (string, e
 		return "", err
 	}
 
-	node, victims, nominatedPodsToClear, err := sched.config.Algorithm.Preempt(preemptor, sched.config.NodeLister, scheduleErr)
+	node, victims, nominatedPodsToClear, err := sched.config.Algorithm.Preempt(preemptor, sched.config.NodeListers[0], scheduleErr)
 	if err != nil {
 		klog.Errorf("Error preempting victims to make room for %v/%v/%v.", preemptor.Tenant, preemptor.Namespace, preemptor.Name)
 		return "", err

--- a/pkg/scheduler/volumebinder/volume_binder.go
+++ b/pkg/scheduler/volumebinder/volume_binder.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,14 +35,14 @@ type VolumeBinder struct {
 // NewVolumeBinder sets up the volume binding library and binding queue
 func NewVolumeBinder(
 	client clientset.Interface,
-	nodeInformer coreinformers.NodeInformer,
+	nodeInformers []coreinformers.NodeInformer,
 	pvcInformer coreinformers.PersistentVolumeClaimInformer,
 	pvInformer coreinformers.PersistentVolumeInformer,
 	storageClassInformer storageinformers.StorageClassInformer,
 	bindTimeout time.Duration) *VolumeBinder {
 
 	return &VolumeBinder{
-		Binder: volumescheduling.NewVolumeBinder(client, nodeInformer, pvcInformer, pvInformer, storageClassInformer, bindTimeout),
+		Binder: volumescheduling.NewVolumeBinder(client, nodeInformers, pvcInformer, pvInformer, storageClassInformer, bindTimeout),
 	}
 }
 

--- a/plugin/pkg/auth/authorizer/node/graph_populator.go
+++ b/plugin/pkg/auth/authorizer/node/graph_populator.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -73,11 +74,11 @@ func AddGraphEventHandlers(
 	}
 }
 
-func (g *graphPopulator) addNode(obj interface{}) {
-	g.updateNode(nil, obj)
+func (g *graphPopulator) addNode(obj interface{}, rpId string) {
+	g.updateNode(nil, obj, rpId)
 }
 
-func (g *graphPopulator) updateNode(oldObj, obj interface{}) {
+func (g *graphPopulator) updateNode(oldObj, obj interface{}, rpId string) {
 	node := obj.(*corev1.Node)
 	var oldNode *corev1.Node
 	if oldObj != nil {
@@ -113,7 +114,7 @@ func (g *graphPopulator) updateNode(oldObj, obj interface{}) {
 	g.graph.SetNodeConfigMap(node.Name, name, namespace)
 }
 
-func (g *graphPopulator) deleteNode(obj interface{}) {
+func (g *graphPopulator) deleteNode(obj interface{}, rpId string) {
 	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		obj = tombstone.Obj
 	}
@@ -129,11 +130,11 @@ func (g *graphPopulator) deleteNode(obj interface{}) {
 	g.graph.SetNodeConfigMap(node.Name, "", "")
 }
 
-func (g *graphPopulator) addPod(obj interface{}) {
-	g.updatePod(nil, obj)
+func (g *graphPopulator) addPod(obj interface{}, rpId string) {
+	g.updatePod(nil, obj, rpId)
 }
 
-func (g *graphPopulator) updatePod(oldObj, obj interface{}) {
+func (g *graphPopulator) updatePod(oldObj, obj interface{}, rpId string) {
 	pod := obj.(*corev1.Pod)
 	if len(pod.Spec.NodeName) == 0 {
 		// No node assigned
@@ -151,7 +152,7 @@ func (g *graphPopulator) updatePod(oldObj, obj interface{}) {
 	g.graph.AddPod(pod)
 }
 
-func (g *graphPopulator) deletePod(obj interface{}) {
+func (g *graphPopulator) deletePod(obj interface{}, rpId string) {
 	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		obj = tombstone.Obj
 	}
@@ -168,17 +169,17 @@ func (g *graphPopulator) deletePod(obj interface{}) {
 	g.graph.DeletePod(pod.Name, pod.Namespace)
 }
 
-func (g *graphPopulator) addPV(obj interface{}) {
-	g.updatePV(nil, obj)
+func (g *graphPopulator) addPV(obj interface{}, rpId string) {
+	g.updatePV(nil, obj, rpId)
 }
 
-func (g *graphPopulator) updatePV(oldObj, obj interface{}) {
+func (g *graphPopulator) updatePV(oldObj, obj interface{}, rpId string) {
 	pv := obj.(*corev1.PersistentVolume)
 	// TODO: skip add if uid, pvc, and secrets are all identical between old and new
 	g.graph.AddPV(pv)
 }
 
-func (g *graphPopulator) deletePV(obj interface{}) {
+func (g *graphPopulator) deletePV(obj interface{}, rpId string) {
 	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		obj = tombstone.Obj
 	}
@@ -190,11 +191,11 @@ func (g *graphPopulator) deletePV(obj interface{}) {
 	g.graph.DeletePV(pv.Name)
 }
 
-func (g *graphPopulator) addVolumeAttachment(obj interface{}) {
-	g.updateVolumeAttachment(nil, obj)
+func (g *graphPopulator) addVolumeAttachment(obj interface{}, rpId string) {
+	g.updateVolumeAttachment(nil, obj, rpId)
 }
 
-func (g *graphPopulator) updateVolumeAttachment(oldObj, obj interface{}) {
+func (g *graphPopulator) updateVolumeAttachment(oldObj, obj interface{}, rpId string) {
 	attachment := obj.(*storagev1.VolumeAttachment)
 	if oldObj != nil {
 		// skip add if node name is identical
@@ -206,7 +207,7 @@ func (g *graphPopulator) updateVolumeAttachment(oldObj, obj interface{}) {
 	g.graph.AddVolumeAttachment(attachment.Name, attachment.Spec.NodeName)
 }
 
-func (g *graphPopulator) deleteVolumeAttachment(obj interface{}) {
+func (g *graphPopulator) deleteVolumeAttachment(obj interface{}, rpId string) {
 	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		obj = tombstone.Obj
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
@@ -265,13 +265,13 @@ func (c *DiscoveryController) enqueue(obj *apiextensions.CustomResourceDefinitio
 	}
 }
 
-func (c *DiscoveryController) addCustomResourceDefinition(obj interface{}) {
+func (c *DiscoveryController) addCustomResourceDefinition(obj interface{}, rpId string) {
 	castObj := obj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Adding customresourcedefinition %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *DiscoveryController) updateCustomResourceDefinition(oldObj, newObj interface{}) {
+func (c *DiscoveryController) updateCustomResourceDefinition(oldObj, newObj interface{}, rpId string) {
 	castNewObj := newObj.(*apiextensions.CustomResourceDefinition)
 	castOldObj := oldObj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Updating customresourcedefinition %s", castOldObj.Name)
@@ -281,7 +281,7 @@ func (c *DiscoveryController) updateCustomResourceDefinition(oldObj, newObj inte
 	c.enqueue(castOldObj)
 }
 
-func (c *DiscoveryController) deleteCustomResourceDefinition(obj interface{}) {
+func (c *DiscoveryController) deleteCustomResourceDefinition(obj interface{}, rpId string) {
 	castObj, ok := obj.(*apiextensions.CustomResourceDefinition)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -177,7 +177,7 @@ func NewCustomResourceDefinitionHandler(
 	}
 	crdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: ret.updateCustomResourceDefinition,
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj interface{}, rpId string) {
 			ret.removeDeadStorage()
 		},
 	})
@@ -368,7 +368,7 @@ func (r *crdHandler) serveScale(w http.ResponseWriter, req *http.Request, reques
 	}
 }
 
-func (r *crdHandler) updateCustomResourceDefinition(oldObj, newObj interface{}) {
+func (r *crdHandler) updateCustomResourceDefinition(oldObj, newObj interface{}, rpId string) {
 	oldCRD := oldObj.(*apiextensions.CustomResourceDefinition)
 	newCRD := newObj.(*apiextensions.CustomResourceDefinition)
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -317,7 +317,7 @@ func (c *CRDFinalizer) enqueue(obj *apiextensions.CustomResourceDefinition) {
 	c.queue.Add(key)
 }
 
-func (c *CRDFinalizer) addCustomResourceDefinition(obj interface{}) {
+func (c *CRDFinalizer) addCustomResourceDefinition(obj interface{}, rpId string) {
 	castObj := obj.(*apiextensions.CustomResourceDefinition)
 	// only queue deleted things
 	if !castObj.DeletionTimestamp.IsZero() && apiextensions.CRDHasFinalizer(castObj, apiextensions.CustomResourceCleanupFinalizer) {
@@ -325,7 +325,7 @@ func (c *CRDFinalizer) addCustomResourceDefinition(obj interface{}) {
 	}
 }
 
-func (c *CRDFinalizer) updateCustomResourceDefinition(oldObj, newObj interface{}) {
+func (c *CRDFinalizer) updateCustomResourceDefinition(oldObj, newObj interface{}, rpId string) {
 	oldCRD := oldObj.(*apiextensions.CustomResourceDefinition)
 	newCRD := newObj.(*apiextensions.CustomResourceDefinition)
 	// only queue deleted things that haven't been finalized by us

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
@@ -243,19 +243,19 @@ func (c *ConditionController) enqueue(obj *apiextensions.CustomResourceDefinitio
 	c.queue.Add(key)
 }
 
-func (c *ConditionController) addCustomResourceDefinition(obj interface{}) {
+func (c *ConditionController) addCustomResourceDefinition(obj interface{}, rpId string) {
 	castObj := obj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Adding %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *ConditionController) updateCustomResourceDefinition(obj, _ interface{}) {
+func (c *ConditionController) updateCustomResourceDefinition(obj, _ interface{}, rpId string) {
 	castObj := obj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Updating %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *ConditionController) deleteCustomResourceDefinition(obj interface{}) {
+func (c *ConditionController) deleteCustomResourceDefinition(obj interface{}, rpId string) {
 	castObj, ok := obj.(*apiextensions.CustomResourceDefinition)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2019 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -219,19 +220,19 @@ func (c *Controller) updateSpecLocked() error {
 	return c.openAPIService.UpdateSpec(mergeSpecs(c.staticSpec, crdSpecs...))
 }
 
-func (c *Controller) addCustomResourceDefinition(obj interface{}) {
+func (c *Controller) addCustomResourceDefinition(obj interface{}, rpId string) {
 	castObj := obj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Adding customresourcedefinition %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *Controller) updateCustomResourceDefinition(oldObj, newObj interface{}) {
+func (c *Controller) updateCustomResourceDefinition(oldObj, newObj interface{}, rpId string) {
 	castNewObj := newObj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Updating customresourcedefinition %s", castNewObj.Name)
 	c.enqueue(castNewObj)
 }
 
-func (c *Controller) deleteCustomResourceDefinition(obj interface{}) {
+func (c *Controller) deleteCustomResourceDefinition(obj interface{}, rpId string) {
 	castObj, ok := obj.(*apiextensions.CustomResourceDefinition)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -336,19 +336,19 @@ func (c *NamingConditionController) enqueue(obj *apiextensions.CustomResourceDef
 	c.queue.Add(key)
 }
 
-func (c *NamingConditionController) addCustomResourceDefinition(obj interface{}) {
+func (c *NamingConditionController) addCustomResourceDefinition(obj interface{}, rpId string) {
 	castObj := obj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Adding %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *NamingConditionController) updateCustomResourceDefinition(obj, _ interface{}) {
+func (c *NamingConditionController) updateCustomResourceDefinition(obj, _ interface{}, rpId string) {
 	castObj := obj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Updating %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *NamingConditionController) deleteCustomResourceDefinition(obj interface{}) {
+func (c *NamingConditionController) deleteCustomResourceDefinition(obj interface{}, rpId string) {
 	castObj, ok := obj.(*apiextensions.CustomResourceDefinition)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -53,9 +54,9 @@ func NewMutatingWebhookConfigurationManager(f informers.SharedInformerFactory) g
 
 	// On any change, rebuild the config
 	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(_ interface{}) { manager.updateConfiguration() },
-		UpdateFunc: func(_, _ interface{}) { manager.updateConfiguration() },
-		DeleteFunc: func(_ interface{}) { manager.updateConfiguration() },
+		AddFunc:    func(_ interface{}, rpId string) { manager.updateConfiguration() },
+		UpdateFunc: func(_, _ interface{}, rpId string) { manager.updateConfiguration() },
+		DeleteFunc: func(_ interface{}, rpId string) { manager.updateConfiguration() },
 	})
 
 	return manager

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -53,9 +54,9 @@ func NewValidatingWebhookConfigurationManager(f informers.SharedInformerFactory)
 
 	// On any change, rebuild the config
 	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(_ interface{}) { manager.updateConfiguration() },
-		UpdateFunc: func(_, _ interface{}) { manager.updateConfiguration() },
-		DeleteFunc: func(_ interface{}) { manager.updateConfiguration() },
+		AddFunc:    func(_ interface{}, rpId string) { manager.updateConfiguration() },
+		UpdateFunc: func(_, _ interface{}, rpId string) { manager.updateConfiguration() },
+		DeleteFunc: func(_ interface{}, rpId string) { manager.updateConfiguration() },
 	})
 
 	return manager

--- a/staging/src/k8s.io/apiserver/pkg/storage/datapartition/datapartitionmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/datapartition/datapartitionmanager.go
@@ -126,7 +126,7 @@ func (m *DataPartitionConfigManager) syncDataPartition() error {
 	return nil
 }
 
-func (m *DataPartitionConfigManager) addDataPartition(obj interface{}) {
+func (m *DataPartitionConfigManager) addDataPartition(obj interface{}, rpId string) {
 	dp := obj.(*v1.DataPartitionConfig)
 	if dp.DeletionTimestamp != nil {
 		return
@@ -161,7 +161,7 @@ func (m *DataPartitionConfigManager) addDataPartition(obj interface{}) {
 	}
 }
 
-func (m *DataPartitionConfigManager) updateDataPartition(old, cur interface{}) {
+func (m *DataPartitionConfigManager) updateDataPartition(old, cur interface{}, rpId string) {
 	curDp := cur.(*v1.DataPartitionConfig)
 	oldDp := old.(*v1.DataPartitionConfig)
 
@@ -199,7 +199,7 @@ func (m *DataPartitionConfigManager) updateDataPartition(old, cur interface{}) {
 	}
 }
 
-func (m *DataPartitionConfigManager) deleteDataPartition(obj interface{}) {
+func (m *DataPartitionConfigManager) deleteDataPartition(obj interface{}, rpId string) {
 	dp, ok := obj.(*v1.DataPartitionConfig)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagecluster/storageclustermanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagecluster/storageclustermanager.go
@@ -130,7 +130,7 @@ func (s *StorageClusterManager) syncClusters() error {
 	return utilerrors.NewAggregate(aggErr)
 }
 
-func (s *StorageClusterManager) addCluster(obj interface{}) {
+func (s *StorageClusterManager) addCluster(obj interface{}, rpId string) {
 	c := obj.(*v1.StorageCluster)
 	if c.DeletionTimestamp != nil {
 		return
@@ -169,7 +169,7 @@ func (s *StorageClusterManager) addCluster(obj interface{}) {
 	klog.V(4).Infof("mux released addCluster.")
 }
 
-func (s *StorageClusterManager) updateCluster(old, cur interface{}) {
+func (s *StorageClusterManager) updateCluster(old, cur interface{}, rpId string) {
 	curCluster := cur.(*v1.StorageCluster)
 	oldCluster := old.(*v1.StorageCluster)
 
@@ -217,7 +217,7 @@ func (s *StorageClusterManager) updateCluster(old, cur interface{}) {
 	}
 }
 
-func (s *StorageClusterManager) deleteCluster(obj interface{}) {
+func (s *StorageClusterManager) deleteCluster(obj interface{}, rpId string) {
 	cluster, ok := obj.(*v1.StorageCluster)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagecluster/tenantstoragemapmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagecluster/tenantstoragemapmanager.go
@@ -130,7 +130,7 @@ func (ts *TenantStorageMapManager) syncTenants() error {
 	return utilerrors.NewAggregate(aggErr)
 }
 
-func (ts *TenantStorageMapManager) addTenant(obj interface{}) {
+func (ts *TenantStorageMapManager) addTenant(obj interface{}, rpId string) {
 	tenant := obj.(*v1.Tenant)
 	if tenant.DeletionTimestamp != nil {
 		return
@@ -172,7 +172,7 @@ func (ts *TenantStorageMapManager) addTenant(obj interface{}) {
 	klog.V(4).Infof("mux released addTenant.")
 }
 
-func (ts *TenantStorageMapManager) updateTenant(old, cur interface{}) {
+func (ts *TenantStorageMapManager) updateTenant(old, cur interface{}, rpId string) {
 	curTenant := cur.(*v1.Tenant)
 	oldTenant := old.(*v1.Tenant)
 
@@ -222,7 +222,7 @@ func (ts *TenantStorageMapManager) updateTenant(old, cur interface{}) {
 	}
 }
 
-func (ts *TenantStorageMapManager) deleteTenant(obj interface{}) {
+func (ts *TenantStorageMapManager) deleteTenant(obj interface{}, rpId string) {
 	tenant, ok := obj.(*v1.Tenant)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/dynamic/dynamic.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/dynamic/dynamic.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -128,13 +129,13 @@ func NewBackend(c *Config) (audit.Backend, error) {
 	manager.delegates.Store(syncedDelegates{})
 
 	c.Informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			manager.addSink(obj.(*auditregv1alpha1.AuditSink))
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj interface{}, rpId string) {
 			manager.updateSink(oldObj.(*auditregv1alpha1.AuditSink), newObj.(*auditregv1alpha1.AuditSink))
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj interface{}, rpId string) {
 			sink, ok := obj.(*auditregv1alpha1.AuditSink)
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/client-go/datapartition/apiserverconfigmanager.go
+++ b/staging/src/k8s.io/client-go/datapartition/apiserverconfigmanager.go
@@ -194,7 +194,7 @@ func syncApiServerConfig(a *APIServerConfigManager) error {
 	return nil
 }
 
-func (a *APIServerConfigManager) updateApiServer(old, cur interface{}) {
+func (a *APIServerConfigManager) updateApiServer(old, cur interface{}, rpId string) {
 	curEp := cur.(*v1.Endpoints)
 	oldEp := old.(*v1.Endpoints)
 	if !isApiServerEndpoint(curEp) || !isApiServerEndpoint(oldEp) {
@@ -226,7 +226,7 @@ func (a *APIServerConfigManager) updateApiServer(old, cur interface{}) {
 }
 
 // It's ok not to test here since Kubernetes endpoints should never be deleted
-func (a *APIServerConfigManager) deleteApiServer(obj interface{}) {
+func (a *APIServerConfigManager) deleteApiServer(obj interface{}, rpId string) {
 	ep, ok := obj.(*v1.Endpoints)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer_test.go
@@ -57,7 +57,7 @@ func TestDynamicSharedInformerFactory(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *unstructured.Unstructured) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					AddFunc: func(obj interface{}) {
+					AddFunc: func(obj interface{}, rpId string) {
 						rcvCh <- obj.(*unstructured.Unstructured)
 					},
 				}
@@ -80,7 +80,7 @@ func TestDynamicSharedInformerFactory(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *unstructured.Unstructured) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					UpdateFunc: func(old, updated interface{}) {
+					UpdateFunc: func(old, updated interface{}, rpId string) {
 						rcvCh <- updated.(*unstructured.Unstructured)
 					},
 				}
@@ -102,7 +102,7 @@ func TestDynamicSharedInformerFactory(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *unstructured.Unstructured) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					DeleteFunc: func(obj interface{}) {
+					DeleteFunc: func(obj interface{}, rpId string) {
 						rcvCh <- obj.(*unstructured.Unstructured)
 					},
 				}

--- a/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
+++ b/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,7 +43,7 @@ func TestFakeClient(t *testing.T) {
 	informers := informers.NewSharedInformerFactory(client, 0)
 	podInformer := informers.Core().V1().Pods().Informer()
 	podInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			pod := obj.(*v1.Pod)
 			t.Logf("pod added: %s/%s", pod.Namespace, pod.Name)
 			pods <- pod

--- a/staging/src/k8s.io/client-go/examples/workqueue/main.go
+++ b/staging/src/k8s.io/client-go/examples/workqueue/main.go
@@ -173,19 +173,19 @@ func main() {
 	// Note that when we finally process the item from the workqueue, we might see a newer version
 	// of the Pod than the version which was responsible for triggering the update.
 	indexer, informer := cache.NewIndexerInformer(podListWatcher, &v1.Pod{}, 0, cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			key, err := cache.MetaNamespaceKeyFunc(obj)
 			if err == nil {
 				queue.Add(key)
 			}
 		},
-		UpdateFunc: func(old interface{}, new interface{}) {
+		UpdateFunc: func(old interface{}, new interface{}, rpId string) {
 			key, err := cache.MetaNamespaceKeyFunc(new)
 			if err == nil {
 				queue.Add(key)
 			}
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj interface{}, rpId string) {
 			// IndexerInformer uses a delta queue, therefore for deletes we have to use this
 			// key function.
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_multitenancy_test.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_multitenancy_test.go
@@ -56,7 +56,7 @@ func TestMetadataSharedInformerFactoryWithMultiTenancy(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *metav1.PartialObjectMetadata) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					AddFunc: func(obj interface{}) {
+					AddFunc: func(obj interface{}, rpId string) {
 						rcvCh <- obj.(*metav1.PartialObjectMetadata)
 					},
 				}
@@ -83,7 +83,7 @@ func TestMetadataSharedInformerFactoryWithMultiTenancy(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *metav1.PartialObjectMetadata) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					UpdateFunc: func(old, updated interface{}) {
+					UpdateFunc: func(old, updated interface{}, rpId string) {
 						rcvCh <- updated.(*metav1.PartialObjectMetadata)
 					},
 				}
@@ -106,7 +106,7 @@ func TestMetadataSharedInformerFactoryWithMultiTenancy(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *metav1.PartialObjectMetadata) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					DeleteFunc: func(obj interface{}) {
+					DeleteFunc: func(obj interface{}, rpId string) {
 						rcvCh <- obj.(*metav1.PartialObjectMetadata)
 					},
 				}

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_test.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_test.go
@@ -64,7 +64,7 @@ func TestMetadataSharedInformerFactory(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *metav1.PartialObjectMetadata) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					AddFunc: func(obj interface{}) {
+					AddFunc: func(obj interface{}, rpId string) {
 						rcvCh <- obj.(*metav1.PartialObjectMetadata)
 					},
 				}
@@ -90,7 +90,7 @@ func TestMetadataSharedInformerFactory(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *metav1.PartialObjectMetadata) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					UpdateFunc: func(old, updated interface{}) {
+					UpdateFunc: func(old, updated interface{}, rpId string) {
 						rcvCh <- updated.(*metav1.PartialObjectMetadata)
 					},
 				}
@@ -112,7 +112,7 @@ func TestMetadataSharedInformerFactory(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *metav1.PartialObjectMetadata) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					DeleteFunc: func(obj interface{}) {
+					DeleteFunc: func(obj interface{}, rpId string) {
 						rcvCh <- obj.(*metav1.PartialObjectMetadata)
 					},
 				}

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -208,29 +208,30 @@ type ResourceEventHandler interface {
 // as few of the notification functions as you want while still implementing
 // ResourceEventHandler.
 type ResourceEventHandlerFuncs struct {
-	AddFunc    func(obj interface{})
-	UpdateFunc func(oldObj, newObj interface{})
-	DeleteFunc func(obj interface{})
+	AddFunc            func(obj interface{}, rpId string)
+	UpdateFunc         func(oldObj, newObj interface{}, rpId string)
+	DeleteFunc         func(obj interface{}, rpId string)
+	ResourceProviderId string
 }
 
 // OnAdd calls AddFunc if it's not nil.
 func (r ResourceEventHandlerFuncs) OnAdd(obj interface{}) {
 	if r.AddFunc != nil {
-		r.AddFunc(obj)
+		r.AddFunc(obj, r.ResourceProviderId)
 	}
 }
 
 // OnUpdate calls UpdateFunc if it's not nil.
 func (r ResourceEventHandlerFuncs) OnUpdate(oldObj, newObj interface{}) {
 	if r.UpdateFunc != nil {
-		r.UpdateFunc(oldObj, newObj)
+		r.UpdateFunc(oldObj, newObj, r.ResourceProviderId)
 	}
 }
 
 // OnDelete calls DeleteFunc if it's not nil.
 func (r ResourceEventHandlerFuncs) OnDelete(obj interface{}) {
 	if r.DeleteFunc != nil {
-		r.DeleteFunc(obj)
+		r.DeleteFunc(obj, r.ResourceProviderId)
 	}
 }
 
@@ -366,6 +367,14 @@ func newInformer(
 	// KeyLister, that way resync operations will result in the correct set
 	// of update/delete deltas.
 	fifo := NewDeltaFIFO(MetaNamespaceKeyFunc, clientState)
+
+	/*
+		rpId := ""
+		if len(resourceProviderId) == 1 {
+			rpId = resourceProviderId[0]
+		} else if len(resourceProviderId) != 0 {
+			klog.Fatalf("Resource provider id can only have one or zero value. Got [%v]", resourceProviderId)
+		}*/
 
 	cfg := &Config{
 		Queue:            fifo,

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
@@ -62,7 +62,7 @@ func TestMutationDetector(t *testing.T) {
 	}
 	informer.AddEventHandler(
 		ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+			AddFunc: func(obj interface{}, rpId string) {
 				addReceived <- true
 			},
 		},

--- a/staging/src/k8s.io/client-go/tools/cache/processor_listener_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/processor_listener_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -36,7 +37,7 @@ func BenchmarkListener(b *testing.B) {
 	b.SetParallelism(concurrencyLevel)
 	// Preallocate enough space so that benchmark does not run out of it
 	pl := newProcessListener(&ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			swg.Done()
 		},
 	}, 0, 0, time.Now(), 1024*1024)

--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -109,19 +110,19 @@ func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (
 	e := newEventProcessor(ch)
 
 	indexer, informer := cache.NewIndexerInformer(lw, objType, 0, cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			e.push(watch.Event{
 				Type:   watch.Added,
 				Object: obj.(runtime.Object),
 			})
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new interface{}, rpId string) {
 			e.push(watch.Event{
 				Type:   watch.Modified,
 				Object: new.(runtime.Object),
 			})
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj interface{}, rpId string) {
 			staleObj, stale := obj.(cache.DeletedFinalStateUnknown)
 			if stale {
 				// We have no means of passing the additional information down using

--- a/staging/src/k8s.io/client-go/tools/watch/until.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go
@@ -146,19 +146,19 @@ func (c *APIServiceRegistrationController) enqueue(obj *apiregistration.APIServi
 	c.queue.Add(key)
 }
 
-func (c *APIServiceRegistrationController) addAPIService(obj interface{}) {
+func (c *APIServiceRegistrationController) addAPIService(obj interface{}, rpId string) {
 	castObj := obj.(*apiregistration.APIService)
 	klog.V(4).Infof("Adding %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *APIServiceRegistrationController) updateAPIService(obj, _ interface{}) {
+func (c *APIServiceRegistrationController) updateAPIService(obj, _ interface{}, rpId string) {
 	castObj := obj.(*apiregistration.APIService)
 	klog.V(4).Infof("Updating %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *APIServiceRegistrationController) deleteAPIService(obj interface{}) {
+func (c *APIServiceRegistrationController) deleteAPIService(obj interface{}, rpId string) {
 	castObj, ok := obj.(*apiregistration.APIService)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller.go
@@ -103,15 +103,15 @@ func NewAutoRegisterController(apiServiceInformer informers.APIServiceInformer, 
 	c.syncHandler = c.checkAPIService
 
 	apiServiceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			cast := obj.(*apiregistration.APIService)
 			c.queue.Add(NameWithMultiTenancy(cast))
 		},
-		UpdateFunc: func(_, obj interface{}) {
+		UpdateFunc: func(_, obj interface{}, rpId string) {
 			cast := obj.(*apiregistration.APIService)
 			c.queue.Add(NameWithMultiTenancy(cast))
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj interface{}, rpId string) {
 			cast, ok := obj.(*apiregistration.APIService)
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -427,19 +427,19 @@ func (c *AvailableConditionController) enqueue(obj *apiregistration.APIService) 
 	c.queue.Add(key)
 }
 
-func (c *AvailableConditionController) addAPIService(obj interface{}) {
+func (c *AvailableConditionController) addAPIService(obj interface{}, rpId string) {
 	castObj := obj.(*apiregistration.APIService)
 	klog.V(4).Infof("Adding %s/%s", castObj.Tenant, castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *AvailableConditionController) updateAPIService(obj, _ interface{}) {
+func (c *AvailableConditionController) updateAPIService(obj, _ interface{}, rpId string) {
 	castObj := obj.(*apiregistration.APIService)
 	klog.V(4).Infof("Updating %s/%s", castObj.Tenant, castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *AvailableConditionController) deleteAPIService(obj interface{}) {
+func (c *AvailableConditionController) deleteAPIService(obj interface{}, rpId string) {
 	castObj, ok := obj.(*apiregistration.APIService)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -481,19 +481,19 @@ func (c *AvailableConditionController) getAPIServicesFor(obj runtime.Object) []*
 
 // TODO, think of a way to avoid checking on every service manipulation
 
-func (c *AvailableConditionController) addService(obj interface{}) {
+func (c *AvailableConditionController) addService(obj interface{}, rpId string) {
 	for _, apiService := range c.getAPIServicesFor(obj.(*v1.Service)) {
 		c.enqueue(apiService)
 	}
 }
 
-func (c *AvailableConditionController) updateService(obj, _ interface{}) {
+func (c *AvailableConditionController) updateService(obj, _ interface{}, rpId string) {
 	for _, apiService := range c.getAPIServicesFor(obj.(*v1.Service)) {
 		c.enqueue(apiService)
 	}
 }
 
-func (c *AvailableConditionController) deleteService(obj interface{}) {
+func (c *AvailableConditionController) deleteService(obj interface{}, rpId string) {
 	castObj, ok := obj.(*v1.Service)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -512,19 +512,19 @@ func (c *AvailableConditionController) deleteService(obj interface{}) {
 	}
 }
 
-func (c *AvailableConditionController) addEndpoints(obj interface{}) {
+func (c *AvailableConditionController) addEndpoints(obj interface{}, rpId string) {
 	for _, apiService := range c.getAPIServicesFor(obj.(*v1.Endpoints)) {
 		c.enqueue(apiService)
 	}
 }
 
-func (c *AvailableConditionController) updateEndpoints(obj, _ interface{}) {
+func (c *AvailableConditionController) updateEndpoints(obj, _ interface{}, rpId string) {
 	for _, apiService := range c.getAPIServicesFor(obj.(*v1.Endpoints)) {
 		c.enqueue(apiService)
 	}
 }
 
-func (c *AvailableConditionController) deleteEndpoints(obj interface{}) {
+func (c *AvailableConditionController) deleteEndpoints(obj interface{}, rpId string) {
 	castObj, ok := obj.(*v1.Endpoints)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
@@ -98,8 +98,7 @@ type KubeSchedulerConfiguration struct {
 
 	// ResourceProviderClientConnections is the kubeconfig files to the resource providers in Arktos scaleout design
 	// optional for single cluster in Arktos deployment model
-	// TODO: make it an array for future release when multiple RP is supported
-	ResourceProviderClientConnection componentbaseconfigv1alpha1.ClientConnectionConfiguration `json:"resourceProviderClientConnection"`
+	ResourceProviderKubeConfig string `json:"resourceProviderKubeConfig,omitempty"`
 }
 
 // SchedulerAlgorithmSource is the source of a scheduler algorithm. One source

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha1/zz_generated.deepcopy.go
@@ -50,7 +50,6 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	out.ResourceProviderClientConnection = in.ResourceProviderClientConnection
 	return
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -585,11 +585,11 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 	klog.Infof("Setting up informers for Azure cloud provider")
 	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
 	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			node := obj.(*v1.Node)
 			az.updateNodeCaches(nil, node)
 		},
-		UpdateFunc: func(prev, obj interface{}) {
+		UpdateFunc: func(prev, obj interface{}, rpId string) {
 			prevNode := prev.(*v1.Node)
 			newNode := obj.(*v1.Node)
 			if newNode.Labels[v1.LabelZoneFailureDomain] ==
@@ -598,7 +598,7 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 			}
 			az.updateNodeCaches(prevNode, newNode)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj interface{}, rpId string) {
 			node, isNode := obj.(*v1.Node)
 			// We can get DeletedFinalStateUnknown instead of *v1.Node here
 			// and we need to handle that correctly.

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go
@@ -688,11 +688,11 @@ func (g *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 	klog.Infof("Setting up informers for Cloud")
 	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
 	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			node := obj.(*v1.Node)
 			g.updateNodeZones(nil, node)
 		},
-		UpdateFunc: func(prev, obj interface{}) {
+		UpdateFunc: func(prev, obj interface{}, rpId string) {
 			prevNode := prev.(*v1.Node)
 			newNode := obj.(*v1.Node)
 			if newNode.Labels[v1.LabelZoneFailureDomain] ==
@@ -701,7 +701,7 @@ func (g *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 			}
 			g.updateNodeZones(prevNode, newNode)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj interface{}, rpId string) {
 			node, isNode := obj.(*v1.Node)
 			// We can get DeletedFinalStateUnknown instead of *v1.Node here
 			// and we need to handle that correctly.

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_clusterid.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_clusterid.go
@@ -75,7 +75,7 @@ func (g *Cloud) watchClusterID(stop <-chan struct{}) {
 	}
 
 	mapEventHandler := cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj interface{}, rpId string) {
 			m, ok := obj.(*v1.ConfigMap)
 			if !ok || m == nil {
 				klog.Errorf("Expected v1.ConfigMap, item=%+v, typeIsOk=%v", obj, ok)
@@ -89,7 +89,7 @@ func (g *Cloud) watchClusterID(stop <-chan struct{}) {
 			klog.V(4).Infof("Observed new configmap for clusteriD: %v, %v; setting local values", m.Name, m.Data)
 			g.ClusterID.update(m)
 		},
-		UpdateFunc: func(old, cur interface{}) {
+		UpdateFunc: func(old, cur interface{}, rpId string) {
 			m, ok := cur.(*v1.ConfigMap)
 			if !ok || m == nil {
 				klog.Errorf("Expected v1.ConfigMap, item=%+v, typeIsOk=%v", cur, ok)

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -1406,7 +1407,7 @@ func (vs *VSphere) HasClusterID() bool {
 }
 
 // Notification handler when node is added into k8s cluster.
-func (vs *VSphere) NodeAdded(obj interface{}) {
+func (vs *VSphere) NodeAdded(obj interface{}, rpId string) {
 	node, ok := obj.(*v1.Node)
 	if node == nil || !ok {
 		klog.Warningf("NodeAdded: unrecognized object %+v", obj)
@@ -1420,7 +1421,7 @@ func (vs *VSphere) NodeAdded(obj interface{}) {
 }
 
 // Notification handler when node is removed from k8s cluster.
-func (vs *VSphere) NodeDeleted(obj interface{}) {
+func (vs *VSphere) NodeDeleted(obj interface{}, rpId string) {
 	node, ok := obj.(*v1.Node)
 	if node == nil || !ok {
 		klog.Warningf("NodeDeleted: unrecognized object %+v", obj)


### PR DESCRIPTION
Tested with 1TP/1RP, 1TP/2RP, 2TP/2RP.

. In both TP,  %cat /tmp/kube-scheduler.log | grep "Add node"
I0302 23:35:20.921581    5965 eventhandlers.go:98] Add node to cache. node [ip-172-30-0-122], rpId [rp0]
I0302 23:36:12.868404    5965 eventhandlers.go:98] Add node to cache. node [ip-172-30-0-172], rpId [rp1]

. kubectl create pods for tenant a, z both works
. As discussed, use insecure mode for local dev test environment now
. Might needs further changes in scheduler to make sure rpId to be properly used in node evaluation
