### PR TITLE
scheduler uses all nodes from multiple RPs in one big pool

### DIFF
--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -129,6 +129,24 @@ type Config struct {
 	SchedulingQueue internalqueue.SchedulingQueue
 }
 
+// AggregateNodeLister enhances the underlying Config with NodeLister behavior
+type AggregateNodeLister Config
+
+// List lists all Nodes
+func (a AggregateNodeLister) List() ([]*v1.Node, error) {
+	var allNodes []*v1.Node
+	for i, nl := range a.NodeListers {
+		nodes, err :=  nl.List()
+		if err != nil {
+			klog.Warningf("failed to list nodes from RP %d: %v", i, err)
+			continue
+		}
+		allNodes = append(allNodes, nodes...)
+	}
+
+	return allNodes, nil
+}
+
 // PodPreemptor has methods needed to delete a pod and to update 'NominatedPod'
 // field of the preemptor pod.
 type PodPreemptor interface {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -282,7 +282,7 @@ func (sched *Scheduler) recordSchedulingFailure(pod *v1.Pod, err error, reason s
 // schedule implements the scheduling algorithm and returns the suggested result(host,
 // evaluated nodes number,feasible nodes number).
 func (sched *Scheduler) schedule(pod *v1.Pod, pluginContext *framework.PluginContext) (core.ScheduleResult, error) {
-	result, err := sched.config.Algorithm.Schedule(pod, sched.config.NodeListers[0], pluginContext)
+	result, err := sched.config.Algorithm.Schedule(pod, (*factory.AggregateNodeLister)(sched.config), pluginContext)
 	if err != nil {
 		pod = pod.DeepCopy()
 		sched.recordSchedulingFailure(pod, err, v1.PodReasonUnschedulable, err.Error())


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
to enhance kube-scheduler with scheduling pods to all nodes across multiple RPs

**Which issue(s) this PR fixes**:
Fixes #1013

**Special notes for your reviewer**:
POC code; no automated testing incurred.
expect to test together with other components later, probably in 1TP/2RP env.

**Does this PR introduce a user-facing change?**:
NONE
