### PR TITLE
Multiple RPs support in KCM

### DIFF
--- a/cmd/cloud-controller-manager/app/config/BUILD
+++ b/cmd/cloud-controller-manager/app/config/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
+        "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",

--- a/cmd/cloud-controller-manager/app/config/config.go
+++ b/cmd/cloud-controller-manager/app/config/config.go
@@ -20,6 +20,7 @@ package app
 import (
 	apiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
@@ -60,6 +61,12 @@ type Config struct {
 
 	// SharedInformers gives access to informers for the controller.
 	SharedInformers informers.SharedInformerFactory
+
+	// Resource provider client builder map (resourceProviderId->resource client)
+	ResourceProviderClientBuilders map[string]clientset.Interface
+
+	// Resource provider node informers map (resourceProviderId->nodeInformer)
+	ResourceProviderNodeInformers map[string]coreinformers.NodeInformer
 }
 
 type completedConfig struct {

--- a/cmd/cloud-controller-manager/app/core.go
+++ b/cmd/cloud-controller-manager/app/core.go
@@ -73,7 +73,7 @@ func startServiceController(ctx *cloudcontrollerconfig.CompletedConfig, cloud cl
 		cloud,
 		ctx.ClientBuilder.ClientOrDie("service-controller"),
 		ctx.SharedInformers.Core().V1().Services(),
-		ctx.SharedInformers.Core().V1().Nodes(),
+		ctx.ResourceProviderNodeInformers,
 		ctx.SharedInformers.Core().V1().Pods(),
 		ctx.ComponentConfig.KubeCloudShared.ClusterName,
 	)

--- a/cmd/kube-controller-manager/app/BUILD
+++ b/cmd/kube-controller-manager/app/BUILD
@@ -133,6 +133,7 @@ go_library(
         "//staging/src/k8s.io/client-go/discovery/cached/memory:go_default_library",
         "//staging/src/k8s.io/client-go/dynamic:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
+        "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/metadata:go_default_library",
         "//staging/src/k8s.io/client-go/metadata/metadatainformer:go_default_library",

--- a/cmd/kube-controller-manager/app/config/config.go
+++ b/cmd/kube-controller-manager/app/config/config.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -45,6 +46,9 @@ type Config struct {
 
 	// the rest config for the master
 	Kubeconfig *restclient.Config
+
+	// the rest clients for resource providers
+	ResourceProviderClients []clientset.Interface
 
 	// the event sink
 	EventRecorder record.EventRecorder

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -254,6 +254,7 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 				go controllerContext.ResourceProviderNodeInformers[rpId].Informer().Run(controllerContext.Stop)
 			}
 		} else {
+			// There is no additional resource provider, fall back to single cluster case
 			controllerContext.ResourceProviderNodeInformers = make(map[string]coreinformers.NodeInformer, 1)
 			controllerContext.ResourceProviderNodeInformers["0"] = controllerContext.InformerFactory.Core().V1().Nodes()
 		}

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -28,6 +28,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"k8s.io/client-go/datapartition"
@@ -47,6 +48,7 @@ import (
 	"k8s.io/apiserver/pkg/util/term"
 	cacheddiscovery "k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/metadata/metadatainformer"
@@ -237,6 +239,25 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 		}
 		saTokenControllerInitFunc := serviceAccountTokenControllerStarter{rootClientBuilder: rootClientBuilder}.startServiceAccountTokenController
 
+		// start client to resource providers
+		if len(c.ResourceProviderClients) > 0 {
+			controllerContext.ResourceProviderClients = make(map[string]clientset.Interface)
+			controllerContext.ResourceProviderNodeInformers = make(map[string]coreinformers.NodeInformer)
+			for i, rpClient := range c.ResourceProviderClients {
+				rpId := "rp" + strconv.Itoa(i)
+				resourceInformerFactory := informers.NewSharedInformerFactory(rpClient, 0)
+				resourceInformerFactory.Start(controllerContext.Stop)
+				controllerContext.ResourceProviderClients[rpId] = rpClient
+				controllerContext.ResourceProviderNodeInformers[rpId] = resourceInformerFactory.Core().V1().Nodes()
+				klog.V(2).Infof("Created the node informer %p from resource provider %s",
+					controllerContext.ResourceProviderNodeInformers[rpId].Informer(), rpId)
+				go controllerContext.ResourceProviderNodeInformers[rpId].Informer().Run(controllerContext.Stop)
+			}
+		} else {
+			controllerContext.ResourceProviderNodeInformers = make(map[string]coreinformers.NodeInformer, 1)
+			controllerContext.ResourceProviderNodeInformers["0"] = controllerContext.InformerFactory.Core().V1().Nodes()
+		}
+
 		if err := StartControllers(controllerContext, saTokenControllerInitFunc, NewControllerInitializers(controllerContext.LoopMode), unsecuredMux); err != nil {
 			klog.Fatalf("error starting controllers: %v", err)
 		}
@@ -341,6 +362,12 @@ type ControllerContext struct {
 	// multiple controllers don't get into lock-step and all hammer the apiserver
 	// with list requests simultaneously.
 	ResyncPeriod func() time.Duration
+
+	// Resource provider client map (resourceProviderId->resource client)
+	ResourceProviderClients map[string]clientset.Interface
+
+	// Resource provider node informers map (resourceProviderId->nodeInformer)
+	ResourceProviderNodeInformers map[string]coreinformers.NodeInformer
 }
 
 // IsControllerEnabled checks if the context's controllers enabled or not

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -76,7 +76,7 @@ func startServiceController(ctx ControllerContext) (http.Handler, bool, error) {
 		ctx.Cloud,
 		ctx.ClientBuilder.ClientOrDie("service-controller"),
 		ctx.InformerFactory.Core().V1().Services(),
-		ctx.InformerFactory.Core().V1().Nodes(),
+		ctx.ResourceProviderNodeInformers,
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.ComponentConfig.KubeCloudShared.ClusterName,
 	)
@@ -223,7 +223,7 @@ func startPersistentVolumeBinderController(ctx ControllerContext) (http.Handler,
 		ClaimInformer:             ctx.InformerFactory.Core().V1().PersistentVolumeClaims(),
 		ClassInformer:             ctx.InformerFactory.Storage().V1().StorageClasses(),
 		PodInformer:               ctx.InformerFactory.Core().V1().Pods(),
-		NodeInformer:              ctx.InformerFactory.Core().V1().Nodes(),
+		NodeInformers:             ctx.ResourceProviderNodeInformers,
 		EnableDynamicProvisioning: ctx.ComponentConfig.PersistentVolumeBinderController.VolumeConfiguration.EnableDynamicProvisioning,
 	}
 	volumeController, volumeControllerErr := persistentvolumecontroller.NewController(params)
@@ -242,8 +242,9 @@ func startAttachDetachController(ctx ControllerContext) (http.Handler, bool, err
 	attachDetachController, attachDetachControllerErr :=
 		attachdetach.NewAttachDetachController(
 			ctx.ClientBuilder.ClientOrDie("attachdetach-controller"),
+			ctx.ResourceProviderClients,
 			ctx.InformerFactory.Core().V1().Pods(),
-			ctx.InformerFactory.Core().V1().Nodes(),
+			ctx.ResourceProviderNodeInformers,
 			ctx.InformerFactory.Core().V1().PersistentVolumeClaims(),
 			ctx.InformerFactory.Core().V1().PersistentVolumes(),
 			ctx.InformerFactory.Storage().V1beta1().CSINodes(),
@@ -454,6 +455,7 @@ func startTTLController(ctx ControllerContext) (http.Handler, bool, error) {
 		ctx.InformerFactory.Core().V1().Nodes(),
 		ctx.ClientBuilder.ClientOrDie("ttl-controller"),
 	).Run(5, ctx.Stop)
+
 	return nil, true, nil
 }
 

--- a/cmd/kube-controller-manager/app/options/BUILD
+++ b/cmd/kube-controller-manager/app/options/BUILD
@@ -34,6 +34,7 @@ go_library(
     importpath = "k8s.io/kubernetes/cmd/kube-controller-manager/app/options",
     deps = [
         "//cmd/controller-manager/app/options:go_default_library",
+        "//cmd/genutils:go_default_library",
         "//cmd/kube-controller-manager/app/config:go_default_library",
         "//pkg/controller/apis/config:go_default_library",
         "//pkg/controller/apis/config/scheme:go_default_library",
@@ -70,6 +71,7 @@ go_library(
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
+        "//staging/src/k8s.io/client-go/util/clientutil:go_default_library",
         "//staging/src/k8s.io/component-base/cli/flag:go_default_library",
         "//staging/src/k8s.io/kube-controller-manager/config/v1alpha1:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -34,9 +34,11 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/clientutil"
 	cliflag "k8s.io/component-base/cli/flag"
 	kubectrlmgrconfigv1alpha1 "k8s.io/kube-controller-manager/config/v1alpha1"
 	cmoptions "k8s.io/kubernetes/cmd/controller-manager/app/options"
+	"k8s.io/kubernetes/cmd/genutils"
 	kubecontrollerconfig "k8s.io/kubernetes/cmd/kube-controller-manager/app/config"
 	kubectrlmgrconfig "k8s.io/kubernetes/pkg/controller/apis/config"
 	kubectrlmgrconfigscheme "k8s.io/kubernetes/pkg/controller/apis/config/scheme"
@@ -90,6 +92,9 @@ type KubeControllerManagerOptions struct {
 
 	Master     string
 	Kubeconfig string
+
+	// optional resource provider kubeconfig
+	ResourceProviderKubeConfig string
 }
 
 // NewKubeControllerManagerOptions creates a new KubeControllerManagerOptions with a default config.
@@ -243,6 +248,7 @@ func (s *KubeControllerManagerOptions) Flags(allControllers []string, disabledBy
 	fs := fss.FlagSet("misc")
 	fs.StringVar(&s.Master, "master", s.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig).")
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig files with authorization and master location information.")
+	fs.StringVar(&s.ResourceProviderKubeConfig, "resource-providers", s.ResourceProviderKubeConfig, "Path to kubeconfig files points to resource provider(s).")
 	utilfeature.DefaultMutableFeatureGate.AddFlag(fss.FlagSet("generic"))
 
 	return fss
@@ -412,11 +418,30 @@ func (s KubeControllerManagerOptions) Config(allControllers []string, disabledBy
 
 	eventRecorder := createRecorder(client, KubeControllerManagerUserAgent)
 
+	// get resource provider kube configs
+	var resourceProviderClients []clientset.Interface
+	if len(s.ResourceProviderKubeConfig) > 0 {
+		resourceProviderKubeConfigFiles, existed := genutils.ParseKubeConfigFiles(s.ResourceProviderKubeConfig)
+		if !existed {
+			return nil, fmt.Errorf("--resource-providers points to non existed file(s)")
+		}
+		resourceProviderClients = make([]clientset.Interface, len(resourceProviderKubeConfigFiles))
+		for i, kubeConfigFile := range resourceProviderKubeConfigFiles {
+			resourceProviderClient, err := clientutil.CreateClientFromKubeconfigFile(kubeConfigFile)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create resource provider rest client from kubeconfig [%s], error [%v]", kubeConfigFile, err)
+			}
+			resourceProviderClients[i] = resourceProviderClient
+			klog.V(3).Infof("Created resource provider client %d %p", i, resourceProviderClient)
+		}
+	}
+
 	c := &kubecontrollerconfig.Config{
-		Client:               client,
-		Kubeconfig:           kubeconfigs,
-		EventRecorder:        eventRecorder,
-		LeaderElectionClient: leaderElectionClient,
+		Client:                  client,
+		Kubeconfig:              kubeconfigs,
+		EventRecorder:           eventRecorder,
+		LeaderElectionClient:    leaderElectionClient,
+		ResourceProviderClients: resourceProviderClients,
 	}
 	if err := s.ApplyTo(c); err != nil {
 		return nil, err

--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -98,6 +98,7 @@ func NewCloudNodeController(
 // via a goroutine
 func (cnc *CloudNodeController) Run(stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
+	klog.Info("Starting CloudNodeController")
 
 	// The following loops run communicate with the APIServer with a worst case complexity
 	// of O(num_nodes) per cycle. These functions are justified here because these events fire

--- a/pkg/controller/cloud/node_lifecycle_controller.go
+++ b/pkg/controller/cloud/node_lifecycle_controller.go
@@ -106,6 +106,7 @@ func NewCloudNodeLifecycleController(
 // be called via a goroutine
 func (c *CloudNodeLifecycleController) Run(stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
+	klog.Info("Starting CloudNodeLifecycleController")
 
 	// The following loops run communicate with the APIServer with a worst case complexity
 	// of O(num_nodes) per cycle. These functions are justified here because these events fire

--- a/pkg/controller/service/BUILD
+++ b/pkg/controller/service/BUILD
@@ -17,9 +17,9 @@ go_library(
     deps = [
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/controller:go_default_library",
-        "//pkg/controller/util/node:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/util/metrics:go_default_library",
+        "//pkg/util/node:go_default_library",
         "//pkg/util/slice:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/controller/service/BUILD
+++ b/pkg/controller/service/BUILD
@@ -17,6 +17,7 @@ go_library(
     deps = [
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/controller/util/node:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/util/metrics:go_default_library",
         "//pkg/util/slice:go_default_library",

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/util/metrics"
+	nodeutil "k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/kubernetes/pkg/util/slice"
 )
 
@@ -105,8 +106,8 @@ type ServiceController struct {
 	serviceListerSynced cache.InformerSynced
 	eventBroadcaster    record.EventBroadcaster
 	eventRecorder       record.EventRecorder
-	nodeLister          corelisters.NodeLister
-	nodeListerSynced    cache.InformerSynced
+	nodeListers         map[string]corelisters.NodeLister
+	nodeListersSynced   map[string]cache.InformerSynced
 	podLister           corelisters.PodLister
 	podListerSynced     cache.InformerSynced
 	// services that need to be synced
@@ -119,7 +120,7 @@ func New(
 	cloud cloudprovider.Interface,
 	kubeClient clientset.Interface,
 	serviceInformer coreinformers.ServiceInformer,
-	nodeInformer coreinformers.NodeInformer,
+	nodeInformers map[string]coreinformers.NodeInformer,
 	podInformer coreinformers.PodInformer,
 	clusterName string,
 ) (*ServiceController, error) {
@@ -134,19 +135,22 @@ func New(
 		}
 	}
 
+	klog.V(3).Infof("Service controller initialized with %v nodeinformers", len(nodeInformers))
+	nodeListers, nodeListersSynced := nodeutil.GetNodeListersAndSyncedFromNodeInformers(nodeInformers)
+
 	s := &ServiceController{
-		cloud:            cloud,
-		knownHosts:       []*v1.Node{},
-		kubeClient:       kubeClient,
-		clusterName:      clusterName,
-		cache:            &serviceCache{serviceMap: make(map[string]*cachedService)},
-		eventBroadcaster: broadcaster,
-		eventRecorder:    recorder,
-		nodeLister:       nodeInformer.Lister(),
-		nodeListerSynced: nodeInformer.Informer().HasSynced,
-		podLister:        podInformer.Lister(),
-		podListerSynced:  podInformer.Informer().HasSynced,
-		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "service"),
+		cloud:             cloud,
+		knownHosts:        []*v1.Node{},
+		kubeClient:        kubeClient,
+		clusterName:       clusterName,
+		cache:             &serviceCache{serviceMap: make(map[string]*cachedService)},
+		eventBroadcaster:  broadcaster,
+		eventRecorder:     recorder,
+		nodeListers:       nodeListers,
+		nodeListersSynced: nodeListersSynced,
+		podLister:         podInformer.Lister(),
+		podListerSynced:   podInformer.Informer().HasSynced,
+		queue:             workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "service"),
 	}
 
 	serviceInformer.Informer().AddEventHandlerWithResyncPeriod(
@@ -211,10 +215,13 @@ func (s *ServiceController) Run(stopCh <-chan struct{}, workers int) {
 	defer runtime.HandleCrash()
 	defer s.queue.ShutDown()
 
-	klog.Info("Starting service controller")
+	klog.Infof("Starting service controller with node lister #= %d", len(s.nodeListers))
 	defer klog.Info("Shutting down service controller")
 
-	if !controller.WaitForCacheSync("service", stopCh, s.serviceListerSynced, s.nodeListerSynced) {
+	if !controller.WaitForCacheSync("service (w/o node)", stopCh, s.serviceListerSynced) {
+		return
+	}
+	if !nodeutil.WaitForNodeCacheSync("service (node)", s.nodeListersSynced) {
 		return
 	}
 
@@ -374,21 +381,27 @@ func (s *ServiceController) syncLoadBalancerIfNeeded(service *v1.Service, key st
 	return op, nil
 }
 
+// Will this work for multiple resource partition clusters?
 func (s *ServiceController) ensureLoadBalancer(service *v1.Service) (*v1.LoadBalancerStatus, error) {
-	nodes, err := s.nodeLister.ListWithPredicate(getNodeConditionPredicate())
-	if err != nil {
-		return nil, err
+	allNodes := make([]*v1.Node, 0)
+	for _, nodeLister := range s.nodeListers {
+		nodes, err := nodeLister.ListWithPredicate(getNodeConditionPredicate())
+		if err != nil {
+			// TODO - check error for RP not available, skip
+			return nil, err
+		}
+		allNodes = append(allNodes, nodes...)
 	}
 
 	// If there are no available nodes for LoadBalancer service, make a EventTypeWarning event for it.
-	if len(nodes) == 0 {
+	if len(allNodes) == 0 {
 		s.eventRecorder.Event(service, v1.EventTypeWarning, "UnAvailableLoadBalancer", "There are no available nodes for LoadBalancer")
 	}
 
 	// - Only one protocol supported per service
 	// - Not all cloud providers support all protocols and the next step is expected to return
 	//   an error for unsupported protocols
-	return s.balancer.EnsureLoadBalancer(context.TODO(), s.clusterName, service, nodes)
+	return s.balancer.EnsureLoadBalancer(context.TODO(), s.clusterName, service, allNodes)
 }
 
 // ListKeys implements the interface required by DeltaFIFO to list the keys we
@@ -660,30 +673,36 @@ func getNodeConditionPredicate() corelisters.NodeConditionPredicate {
 // nodeSyncLoop handles updating the hosts pointed to by all load
 // balancers whenever the set of nodes in the cluster changes.
 func (s *ServiceController) nodeSyncLoop() {
-	newHosts, err := s.nodeLister.ListWithPredicate(getNodeConditionPredicate())
-	if err != nil {
-		runtime.HandleError(fmt.Errorf("Failed to retrieve current set of nodes from node lister: %v", err))
-		return
+	allNewHosts := make([]*v1.Node, 0)
+	for _, nodeLister := range s.nodeListers {
+		newHosts, err := nodeLister.ListWithPredicate(getNodeConditionPredicate())
+		if err != nil {
+			// TODO - check error for RP not available, skip
+			runtime.HandleError(fmt.Errorf("Failed to retrieve current set of nodes from node lister: %v", err))
+			return
+		}
+		allNewHosts = append(allNewHosts, newHosts...)
 	}
-	if nodeSlicesEqualForLB(newHosts, s.knownHosts) {
+
+	if nodeSlicesEqualForLB(allNewHosts, s.knownHosts) {
 		// The set of nodes in the cluster hasn't changed, but we can retry
 		// updating any services that we failed to update last time around.
-		s.servicesToUpdate = s.updateLoadBalancerHosts(s.servicesToUpdate, newHosts)
+		s.servicesToUpdate = s.updateLoadBalancerHosts(s.servicesToUpdate, allNewHosts)
 		return
 	}
 
 	klog.V(2).Infof("Detected change in list of current cluster nodes. New node set: %v",
-		nodeNames(newHosts))
+		nodeNames(allNewHosts))
 
 	// Try updating all services, and save the ones that fail to try again next
 	// round.
 	s.servicesToUpdate = s.cache.allServices()
 	numServices := len(s.servicesToUpdate)
-	s.servicesToUpdate = s.updateLoadBalancerHosts(s.servicesToUpdate, newHosts)
+	s.servicesToUpdate = s.updateLoadBalancerHosts(s.servicesToUpdate, allNewHosts)
 	klog.V(2).Infof("Successfully updated %d out of %d load balancers to direct traffic to the updated set of nodes",
 		numServices-len(s.servicesToUpdate), numServices)
 
-	s.knownHosts = newHosts
+	s.knownHosts = allNewHosts
 }
 
 // updateLoadBalancerHosts updates all existing load balancers so that

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -381,7 +381,7 @@ func (s *ServiceController) syncLoadBalancerIfNeeded(service *v1.Service, key st
 	return op, nil
 }
 
-// Will this work for multiple resource partition clusters?
+// TODO - Will this work for multiple resource partition clusters?
 func (s *ServiceController) ensureLoadBalancer(service *v1.Service) (*v1.LoadBalancerStatus, error) {
 	allNodes := make([]*v1.Node, 0)
 	for _, nodeLister := range s.nodeListers {

--- a/pkg/controller/volume/attachdetach/BUILD
+++ b/pkg/controller/volume/attachdetach/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//pkg/controller/volume/attachdetach/util:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/util/mount:go_default_library",
+        "//pkg/util/node:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",
         "//pkg/volume/util/operationexecutor:go_default_library",

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller/volume/attachdetach/util"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/util/mount"
+	nodeutil "k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/kubernetes/pkg/volume"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/operationexecutor"
@@ -103,8 +104,9 @@ type AttachDetachController interface {
 // NewAttachDetachController returns a new instance of AttachDetachController.
 func NewAttachDetachController(
 	kubeClient clientset.Interface,
+	resourceProviderClients map[string]clientset.Interface,
 	podInformer coreinformers.PodInformer,
-	nodeInformer coreinformers.NodeInformer,
+	nodeInformers map[string]coreinformers.NodeInformer,
 	pvcInformer coreinformers.PersistentVolumeClaimInformer,
 	pvInformer coreinformers.PersistentVolumeInformer,
 	csiNodeInformer storageinformers.CSINodeInformer,
@@ -129,19 +131,22 @@ func NewAttachDetachController(
 	// and set a faster resync period even if it causes relist, or requeue
 	// dropped pods so they are continuously processed until it is accepted or
 	// deleted (probably can't do this with sharedInformer), etc.
+
+	nodeListers, nodeListersSynced := nodeutil.GetNodeListersAndSyncedFromNodeInformers(nodeInformers)
 	adc := &attachDetachController{
-		kubeClient:  kubeClient,
-		pvcLister:   pvcInformer.Lister(),
-		pvcsSynced:  pvcInformer.Informer().HasSynced,
-		pvLister:    pvInformer.Lister(),
-		pvsSynced:   pvInformer.Informer().HasSynced,
-		podLister:   podInformer.Lister(),
-		podsSynced:  podInformer.Informer().HasSynced,
-		podIndexer:  podInformer.Informer().GetIndexer(),
-		nodeLister:  nodeInformer.Lister(),
-		nodesSynced: nodeInformer.Informer().HasSynced,
-		cloud:       cloud,
-		pvcQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "pvcs"),
+		kubeClient:              kubeClient,
+		resourceProviderClients: resourceProviderClients,
+		pvcLister:               pvcInformer.Lister(),
+		pvcsSynced:              pvcInformer.Informer().HasSynced,
+		pvLister:                pvInformer.Lister(),
+		pvsSynced:               pvInformer.Informer().HasSynced,
+		podLister:               podInformer.Lister(),
+		podsSynced:              podInformer.Informer().HasSynced,
+		podIndexer:              podInformer.Informer().GetIndexer(),
+		nodeListers:             nodeListers,
+		nodesSynced:             nodeListersSynced,
+		cloud:                   cloud,
+		pvcQueue:                workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "pvcs"),
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.CSIMigration) &&
@@ -175,7 +180,7 @@ func NewAttachDetachController(
 			false, // flag for experimental binary check for volume mount
 			blkutil))
 	adc.nodeStatusUpdater = statusupdater.NewNodeStatusUpdater(
-		kubeClient, nodeInformer.Lister(), adc.actualStateOfWorld)
+		resourceProviderClients, nodeListers, adc.actualStateOfWorld)
 
 	// Default these to values in options
 	adc.reconciler = reconciler.NewReconciler(
@@ -210,11 +215,14 @@ func NewAttachDetachController(
 		pvcKeyIndex: indexByPVCKey,
 	})
 
-	nodeInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
-		AddFunc:    adc.nodeAdd,
-		UpdateFunc: adc.nodeUpdate,
-		DeleteFunc: adc.nodeDelete,
-	})
+	for rpId, nodeInformer := range nodeInformers {
+		nodeInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
+			AddFunc:            adc.nodeAdd,
+			UpdateFunc:         adc.nodeUpdate,
+			DeleteFunc:         adc.nodeDelete,
+			ResourceProviderId: rpId,
+		})
+	}
 
 	pvcInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}, rpId string) {
@@ -254,8 +262,13 @@ func indexByPVCKey(obj interface{}) ([]string, error) {
 
 type attachDetachController struct {
 	// kubeClient is the kube API client used by volumehost to communicate with
-	// the API server.
+	// the tenant partition API server.
 	kubeClient clientset.Interface
+
+	// resourceProviderClients is the kube API client used to communicate with
+	// resource partition API server.
+	// It is a map from resourcePartitionId to API server.
+	resourceProviderClients map[string]clientset.Interface
 
 	// pvcLister is the shared PVC lister used to fetch and store PVC
 	// objects from the API server. It is shared with other controllers and
@@ -273,8 +286,8 @@ type attachDetachController struct {
 	podsSynced kcache.InformerSynced
 	podIndexer kcache.Indexer
 
-	nodeLister  corelisters.NodeLister
-	nodesSynced kcache.InformerSynced
+	nodeListers map[string]corelisters.NodeLister
+	nodesSynced map[string]kcache.InformerSynced
 
 	csiNodeLister storagelisters.CSINodeLister
 	csiNodeSynced kcache.InformerSynced
@@ -337,7 +350,7 @@ func (adc *attachDetachController) Run(stopCh <-chan struct{}) {
 	klog.Infof("Starting attach detach controller")
 	defer klog.Infof("Shutting down attach detach controller")
 
-	synced := []kcache.InformerSynced{adc.podsSynced, adc.nodesSynced, adc.pvcsSynced, adc.pvsSynced}
+	synced := []kcache.InformerSynced{adc.podsSynced, adc.pvcsSynced, adc.pvsSynced}
 	if adc.csiNodeSynced != nil {
 		synced = append(synced, adc.csiNodeSynced)
 	}
@@ -345,7 +358,11 @@ func (adc *attachDetachController) Run(stopCh <-chan struct{}) {
 		synced = append(synced, adc.csiDriversSynced)
 	}
 
-	if !controller.WaitForCacheSync("attach detach", stopCh, synced...) {
+	if !controller.WaitForCacheSync("attach detach (w/o node)", stopCh, synced...) {
+		return
+	}
+
+	if !nodeutil.WaitForNodeCacheSync("attach detach (node)", adc.nodesSynced) {
 		return
 	}
 
@@ -372,7 +389,7 @@ func (adc *attachDetachController) Run(stopCh <-chan struct{}) {
 
 func (adc *attachDetachController) populateActualStateOfWorld() error {
 	klog.V(5).Infof("Populating ActualStateOfworld")
-	nodes, err := adc.nodeLister.List(labels.Everything())
+	nodes, err := nodeutil.ListNodes(adc.nodeListers, labels.Everything())
 	if err != nil {
 		return err
 	}
@@ -402,7 +419,7 @@ func (adc *attachDetachController) getNodeVolumeDevicePath(
 	volumeName v1.UniqueVolumeName, nodeName types.NodeName) (string, error) {
 	var devicePath string
 	var found bool
-	node, err := adc.nodeLister.Get(string(nodeName))
+	node, _, err := nodeutil.GetNodeFromNodelisters(adc.nodeListers, string(nodeName))
 	if err != nil {
 		return devicePath, err
 	}

--- a/pkg/controller/volume/persistentvolume/BUILD
+++ b/pkg/controller/volume/persistentvolume/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//pkg/util/goroutinemap:go_default_library",
         "//pkg/util/goroutinemap/exponentialbackoff:go_default_library",
         "//pkg/util/mount:go_default_library",
+        "//pkg/util/node:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",
         "//pkg/volume/util/recyclerclient:go_default_library",

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -19,6 +19,7 @@ package persistentvolume
 
 import (
 	"fmt"
+	"k8s.io/kubernetes/pkg/util/node"
 	"reflect"
 	"strings"
 	"time"
@@ -148,8 +149,8 @@ type PersistentVolumeController struct {
 	classListerSynced  cache.InformerSynced
 	podLister          corelisters.PodLister
 	podListerSynced    cache.InformerSynced
-	NodeLister         corelisters.NodeLister
-	NodeListerSynced   cache.InformerSynced
+	NodeListers        map[string]corelisters.NodeLister
+	NodeListersSynced  map[string]cache.InformerSynced
 
 	kubeClient                clientset.Interface
 	eventRecorder             record.EventRecorder
@@ -1466,7 +1467,7 @@ func (ctrl *PersistentVolumeController) provisionClaimOperation(
 
 	var selectedNode *v1.Node = nil
 	if nodeName, ok := claim.Annotations[pvutil.AnnSelectedNode]; ok {
-		selectedNode, err = ctrl.NodeLister.Get(nodeName)
+		selectedNode, _, err = node.GetNodeFromNodelisters(ctrl.NodeListers, nodeName)
 		if err != nil {
 			strerr := fmt.Sprintf("Failed to get target node: %v", err)
 			klog.V(3).Infof("unexpected error getting target node %q for claim %q: %v", nodeName, claimToClaimKey(claim), err)

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller/volume/persistentvolume/metrics"
 	pvutil "k8s.io/kubernetes/pkg/controller/volume/persistentvolume/util"
 	"k8s.io/kubernetes/pkg/util/goroutinemap"
+	nodeutil "k8s.io/kubernetes/pkg/util/node"
 	vol "k8s.io/kubernetes/pkg/volume"
 
 	"k8s.io/klog"
@@ -64,7 +65,7 @@ type ControllerParameters struct {
 	ClaimInformer             coreinformers.PersistentVolumeClaimInformer
 	ClassInformer             storageinformers.StorageClassInformer
 	PodInformer               coreinformers.PodInformer
-	NodeInformer              coreinformers.NodeInformer
+	NodeInformers             map[string]coreinformers.NodeInformer
 	EventRecorder             record.EventRecorder
 	EnableDynamicProvisioning bool
 }
@@ -125,8 +126,7 @@ func NewController(p ControllerParameters) (*PersistentVolumeController, error) 
 	controller.classListerSynced = p.ClassInformer.Informer().HasSynced
 	controller.podLister = p.PodInformer.Lister()
 	controller.podListerSynced = p.PodInformer.Informer().HasSynced
-	controller.NodeLister = p.NodeInformer.Lister()
-	controller.NodeListerSynced = p.NodeInformer.Informer().HasSynced
+	controller.NodeListers, controller.NodeListersSynced = nodeutil.GetNodeListersAndSyncedFromNodeInformers(p.NodeInformers)
 	return controller, nil
 }
 
@@ -280,10 +280,14 @@ func (ctrl *PersistentVolumeController) Run(stopCh <-chan struct{}) {
 	defer ctrl.claimQueue.ShutDown()
 	defer ctrl.volumeQueue.ShutDown()
 
-	klog.Infof("Starting persistent volume controller")
+	klog.Infof("Starting persistent volume controller. #(nodelisters)=%d", len(ctrl.NodeListers))
 	defer klog.Infof("Shutting down persistent volume controller")
 
-	if !controller.WaitForCacheSync("persistent volume", stopCh, ctrl.volumeListerSynced, ctrl.claimListerSynced, ctrl.classListerSynced, ctrl.podListerSynced, ctrl.NodeListerSynced) {
+	if !controller.WaitForCacheSync("persistent volume (w/o node)", stopCh, ctrl.volumeListerSynced, ctrl.claimListerSynced, ctrl.classListerSynced, ctrl.podListerSynced) {
+		return
+	}
+
+	if !nodeutil.WaitForNodeCacheSync("persistent volume (node)", ctrl.NodeListersSynced) {
 		return
 	}
 

--- a/pkg/util/node/BUILD
+++ b/pkg/util/node/BUILD
@@ -8,15 +8,22 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["node.go"],
+    srcs = [
+        "node.go",
+        "nodecache_utils.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/util/node",
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
+        "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/util/node/nodecache_utils.go
+++ b/pkg/util/node/nodecache_utils.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2020 Authors of Arktos.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+	"sync"
+	"time"
+)
+
+func GetNodeFromNodelisters(nodeListers map[string]corelisters.NodeLister, nodeName string) (*v1.Node, string, error) {
+	for rpId, nodeLister := range nodeListers {
+		node, err := nodeLister.Get(nodeName)
+		if err != nil {
+			// TODO - skip not found error and checking next node lister
+			return nil, "", err
+		}
+		return node, rpId, nil
+	}
+
+	return nil, "", fmt.Errorf("Node listers are empty.")
+}
+
+func GetNodeListersAndSyncedFromNodeInformers(nodeinformers map[string]coreinformers.NodeInformer) (nodeListers map[string]corelisters.NodeLister, nodeListersSynced map[string]cache.InformerSynced) {
+	nodeListers = make(map[string]corelisters.NodeLister)
+	nodeListersSynced = make(map[string]cache.InformerSynced)
+	for rpId, nodeinformer := range nodeinformers {
+		nodeListers[rpId] = nodeinformer.Lister()
+		nodeListersSynced[rpId] = nodeinformer.Informer().HasSynced
+	}
+
+	return
+}
+
+func ListNodes(nodeListers map[string]corelisters.NodeLister, selector labels.Selector) (ret []*v1.Node, err error) {
+	allNodes := make([]*v1.Node, 0)
+	for _, nodeLister := range nodeListers {
+		nodes, err := nodeLister.List(selector)
+		if err != nil {
+			//TODO - check error, allow skipping certain error such as client not initialized
+			return nil, err
+		}
+		allNodes = append(allNodes, nodes...)
+	}
+
+	return allNodes, nil
+}
+
+// TODO - add timeout and return false
+func WaitForNodeCacheSync(controllerName string, nodeListersSynced map[string]cache.InformerSynced) bool {
+	klog.Infof("Waiting for caches to sync for %s controller", controllerName)
+
+	var wg sync.WaitGroup
+	wg.Add(len(nodeListersSynced))
+	for key, nodeSynced := range nodeListersSynced {
+		go func(rpId string, cacheSync cache.InformerSynced) {
+			for {
+				if cacheSync() {
+					klog.Infof("Cache are synced for resource provider %s", rpId)
+					wg.Done()
+					break
+				}
+				klog.V(3).Infof("Wait for node sync from resource provider %s", rpId)
+				time.Sleep(5 * time.Second)
+			}
+		}(key, nodeSynced)
+	}
+	wg.Wait()
+
+	klog.Infof("Caches are synced for %s controller", controllerName)
+	return true
+}


### PR DESCRIPTION
Please ignore the first 2 commits. They are reviewed in https://github.com/CentaurusInfra/arktos/pull/1011.
-- merged and removed.

Tests done:
In TP1:
ubuntu@ip-172-30-0-148:~/go/src/arktos$ cat /tmp/kube-controller-manager.log | grep "Caches are synced for " | grep node
I0309 22:12:36.434773     979 controller_utils.go:1089] Caches are synced for attach detach (w/o node) controller
I0309 22:12:36.504194     979 controller_utils.go:1089] Caches are synced for persistent volume (w/o node) controller
I0309 22:12:56.435835     979 nodecache_utils.go:90] Caches are synced for attach detach (node) controller
I0309 22:12:56.505039     979 nodecache_utils.go:90] Caches are synced for persistent volume (node) controller

. Note service controller is not started in local cluster up.

In RPs:
ubuntu@ip-172-30-0-122:/var/run/kubernetes$ cat /tmp/kube-controller-manager.log | grep "Caches are synced for"
I0309 22:12:54.374956   30486 controller_utils.go:1089] Caches are synced for daemon sets controller
I0309 22:12:54.378205   30486 controller_utils.go:1089] Caches are synced for TTL controller
I0309 22:12:54.381359   30486 apiserverconfigmanager.go:166] Caches are synced for api server end points. [map[1:{Addresses:[{IP:172.30.0.122 Hostname: NodeName:<nil> TargetRef:nil}] NotReadyAddresses:[] Ports:[{Name:https Port:6443 Protocol:TCP}] ServiceGroupId:1}]]
