### PR TITLE
Remove rp id from event handler arg

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -211,8 +211,8 @@ func makeAPIServiceAvailableHealthCheck(name string, apiServices []*apiregistrat
 
 	// Watch add/update events for APIServices
 	apiServiceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}, rpId string) { handleAPIServiceChange(obj.(*apiregistration.APIService)) },
-		UpdateFunc: func(old, new interface{}, rpId string) { handleAPIServiceChange(new.(*apiregistration.APIService)) },
+		AddFunc:    func(obj interface{}) { handleAPIServiceChange(obj.(*apiregistration.APIService)) },
+		UpdateFunc: func(old, new interface{}) { handleAPIServiceChange(new.(*apiregistration.APIService)) },
 	})
 
 	// Don't return healthy until the pending list is empty

--- a/cmd/kube-scheduler/app/config/config.go
+++ b/cmd/kube-scheduler/app/config/config.go
@@ -44,8 +44,8 @@ type Config struct {
 	SecureServing          *apiserver.SecureServingInfo
 
 	// explictly define node informer from the resource provider client
-	ResourceProviderClients []clientset.Interface
-	NodeInformers           []coreinformers.NodeInformer
+	ResourceProviderClients map[string]clientset.Interface
+	NodeInformers           map[string]coreinformers.NodeInformer
 
 	Client          clientset.Interface
 	InformerFactory informers.SharedInformerFactory

--- a/pkg/cloudfabric-controller/controllerframework/controllerinstancemanager.go
+++ b/pkg/cloudfabric-controller/controllerframework/controllerinstancemanager.go
@@ -120,10 +120,10 @@ func GetInstanceId() types.UID {
 	}
 }
 
-func (cim *ControllerInstanceManager) addControllerInstance(obj interface{}, rpId string) {
+func (cim *ControllerInstanceManager) addControllerInstance(obj interface{}) {
 	newControllerInstance := obj.(*v1.ControllerInstance)
 	if newControllerInstance.DeletionTimestamp != nil {
-		cim.deleteControllerInstance(newControllerInstance, rpId)
+		cim.deleteControllerInstance(newControllerInstance)
 		return
 	}
 	klog.V(3).Infof("Received event for NEW controller instance %v. CIM %v", newControllerInstance.Name, cim.instanceId)
@@ -143,7 +143,7 @@ func (cim *ControllerInstanceManager) addControllerInstance(obj interface{}, rpI
 		if ok1 {
 			cim.mux.Unlock()
 			klog.V(4).Infof("mux released addControllerInstance. CIM %v", cim.instanceId)
-			cim.updateControllerInstance(&existingInstance, newControllerInstance, rpId)
+			cim.updateControllerInstance(&existingInstance, newControllerInstance)
 			klog.V(4).Infof("Got existing controller instance %s in AddFunc. CIM %v", newControllerInstance.Name, cim.instanceId)
 			return
 		}
@@ -157,7 +157,7 @@ func (cim *ControllerInstanceManager) addControllerInstance(obj interface{}, rpI
 	klog.V(4).Infof("mux released addControllerInstance. CIM %v", cim.instanceId)
 }
 
-func (cim *ControllerInstanceManager) updateControllerInstance(old, cur interface{}, rpId string) {
+func (cim *ControllerInstanceManager) updateControllerInstance(old, cur interface{}) {
 	curControllerInstance := cur.(*v1.ControllerInstance)
 	oldControllerInstance := old.(*v1.ControllerInstance)
 
@@ -187,7 +187,7 @@ func (cim *ControllerInstanceManager) updateControllerInstance(old, cur interfac
 		klog.Fatalf("Unexpected controller instance type changed from %s to %s. CIM %v", oldControllerInstance.ControllerType, curControllerInstance.ControllerType, cim.instanceId)
 	}
 	if curControllerInstance.DeletionTimestamp != nil {
-		cim.deleteControllerInstance(curControllerInstance, rpId)
+		cim.deleteControllerInstance(curControllerInstance)
 		return
 	}
 
@@ -209,7 +209,7 @@ func (cim *ControllerInstanceManager) updateControllerInstance(old, cur interfac
 	klog.V(4).Infof("mux released updateControllerInstance. CIM %v", cim.instanceId)
 }
 
-func (cim *ControllerInstanceManager) deleteControllerInstance(obj interface{}, rpId string) {
+func (cim *ControllerInstanceManager) deleteControllerInstance(obj interface{}) {
 	controllerinstance, ok := obj.(*v1.ControllerInstance)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/pkg/cloudfabric-controller/deployment/deployment_controller.go
+++ b/pkg/cloudfabric-controller/deployment/deployment_controller.go
@@ -177,20 +177,20 @@ func (dc *DeploymentController) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (dc *DeploymentController) addDeployment(obj interface{}, rpId string) {
+func (dc *DeploymentController) addDeployment(obj interface{}) {
 	d := obj.(*apps.Deployment)
 	klog.V(4).Infof("Adding deployment %s. hashkey %v. rv %s", d.Name, d.HashKey, d.ResourceVersion)
 	dc.enqueueDeployment(d)
 }
 
-func (dc *DeploymentController) updateDeployment(old, cur interface{}, rpId string) {
+func (dc *DeploymentController) updateDeployment(old, cur interface{}) {
 	oldD := old.(*apps.Deployment)
 	curD := cur.(*apps.Deployment)
 	klog.V(4).Infof("Updating deployment %s", oldD.Name)
 	dc.enqueueDeployment(curD)
 }
 
-func (dc *DeploymentController) deleteDeployment(obj interface{}, rpId string) {
+func (dc *DeploymentController) deleteDeployment(obj interface{}) {
 	d, ok := obj.(*apps.Deployment)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -209,13 +209,13 @@ func (dc *DeploymentController) deleteDeployment(obj interface{}, rpId string) {
 }
 
 // addReplicaSet enqueues the deployment that manages a ReplicaSet when the ReplicaSet is created.
-func (dc *DeploymentController) addReplicaSet(obj interface{}, rpId string) {
+func (dc *DeploymentController) addReplicaSet(obj interface{}) {
 	rs := obj.(*apps.ReplicaSet)
 
 	if rs.DeletionTimestamp != nil {
 		// On a restart of the controller manager, it's possible for an object to
 		// show up in a state that is already pending deletion.
-		dc.deleteReplicaSet(rs, rpId)
+		dc.deleteReplicaSet(rs)
 		return
 	}
 
@@ -266,7 +266,7 @@ func (dc *DeploymentController) getDeploymentsForReplicaSet(rs *apps.ReplicaSet)
 // is updated and wake them up. If the anything of the ReplicaSets have changed, we need to
 // awaken both the old and new deployments. old and cur must be *apps.ReplicaSet
 // types.
-func (dc *DeploymentController) updateReplicaSet(old, cur interface{}, rpId string) {
+func (dc *DeploymentController) updateReplicaSet(old, cur interface{}) {
 	curRS := cur.(*apps.ReplicaSet)
 	oldRS := old.(*apps.ReplicaSet)
 	if curRS.ResourceVersion == oldRS.ResourceVersion {
@@ -314,7 +314,7 @@ func (dc *DeploymentController) updateReplicaSet(old, cur interface{}, rpId stri
 // deleteReplicaSet enqueues the deployment that manages a ReplicaSet when
 // the ReplicaSet is deleted. obj could be an *apps.ReplicaSet, or
 // a DeletionFinalStateUnknown marker item.
-func (dc *DeploymentController) deleteReplicaSet(obj interface{}, rpId string) {
+func (dc *DeploymentController) deleteReplicaSet(obj interface{}) {
 	rs, ok := obj.(*apps.ReplicaSet)
 
 	// When a delete is dropped, the relist will notice a pod in the store not
@@ -348,7 +348,7 @@ func (dc *DeploymentController) deleteReplicaSet(obj interface{}, rpId string) {
 }
 
 // deletePod will enqueue a Recreate Deployment once all of its pods have stopped running.
-func (dc *DeploymentController) deletePod(obj interface{}, rpId string) {
+func (dc *DeploymentController) deletePod(obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
 
 	// When a delete is dropped, the relist will notice a pod in the store not

--- a/pkg/controller/bootstrap/bootstrapsigner.go
+++ b/pkg/controller/bootstrap/bootstrapsigner.go
@@ -122,8 +122,8 @@ func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configM
 				}
 			},
 			Handler: cache.ResourceEventHandlerFuncs{
-				AddFunc:    func(_ interface{}, rpId string) { e.pokeConfigMapSync() },
-				UpdateFunc: func(_, _ interface{}, rpId string) { e.pokeConfigMapSync() },
+				AddFunc:    func(_ interface{}) { e.pokeConfigMapSync() },
+				UpdateFunc: func(_, _ interface{}) { e.pokeConfigMapSync() },
 			},
 		},
 		options.ConfigMapResync,
@@ -141,9 +141,9 @@ func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configM
 				}
 			},
 			Handler: cache.ResourceEventHandlerFuncs{
-				AddFunc:    func(_ interface{}, rpId string) { e.pokeConfigMapSync() },
-				UpdateFunc: func(_, _ interface{}, rpId string) { e.pokeConfigMapSync() },
-				DeleteFunc: func(_ interface{}, rpId string) { e.pokeConfigMapSync() },
+				AddFunc:    func(_ interface{}) { e.pokeConfigMapSync() },
+				UpdateFunc: func(_, _ interface{}) { e.pokeConfigMapSync() },
+				DeleteFunc: func(_ interface{}) { e.pokeConfigMapSync() },
 			},
 		},
 		options.SecretResync,

--- a/pkg/controller/bootstrap/tokencleaner.go
+++ b/pkg/controller/bootstrap/tokencleaner.go
@@ -100,7 +100,7 @@ func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInforme
 			},
 			Handler: cache.ResourceEventHandlerFuncs{
 				AddFunc:    e.enqueueSecrets,
-				UpdateFunc: func(oldSecret, newSecret interface{}, rpId string) { e.enqueueSecrets(newSecret, rpId) },
+				UpdateFunc: func(oldSecret, newSecret interface{}) { e.enqueueSecrets(newSecret) },
 			},
 		},
 		options.SecretResync,
@@ -126,7 +126,7 @@ func (tc *TokenCleaner) Run(stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (tc *TokenCleaner) enqueueSecrets(obj interface{}, rpId string) {
+func (tc *TokenCleaner) enqueueSecrets(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(err)

--- a/pkg/controller/certificates/certificate_controller.go
+++ b/pkg/controller/certificates/certificate_controller.go
@@ -74,17 +74,17 @@ func NewCertificateController(
 
 	// Manage the addition/update of certificate requests
 	csrInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			csr := obj.(*certificates.CertificateSigningRequest)
 			klog.V(4).Infof("Adding certificate request %s", csr.Name)
 			cc.enqueueCertificateRequest(obj)
 		},
-		UpdateFunc: func(old, new interface{}, rpId string) {
+		UpdateFunc: func(old, new interface{}) {
 			oldCSR := old.(*certificates.CertificateSigningRequest)
 			klog.V(4).Infof("Updating certificate request %s", oldCSR.Name)
 			cc.enqueueCertificateRequest(new)
 		},
-		DeleteFunc: func(obj interface{}, rpId string) {
+		DeleteFunc: func(obj interface{}) {
 			csr, ok := obj.(*certificates.CertificateSigningRequest)
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -110,7 +110,7 @@ func (c *Publisher) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (c *Publisher) configMapDeleted(obj interface{}, rpId string) {
+func (c *Publisher) configMapDeleted(obj interface{}) {
 	cm, err := convertToCM(obj)
 	if err != nil {
 		utilruntime.HandleError(err)
@@ -122,7 +122,7 @@ func (c *Publisher) configMapDeleted(obj interface{}, rpId string) {
 	c.queue.Add(cm.Namespace)
 }
 
-func (c *Publisher) configMapUpdated(_, newObj interface{}, rpId string) {
+func (c *Publisher) configMapUpdated(_, newObj interface{}) {
 	cm, err := convertToCM(newObj)
 	if err != nil {
 		utilruntime.HandleError(err)
@@ -134,12 +134,12 @@ func (c *Publisher) configMapUpdated(_, newObj interface{}, rpId string) {
 	c.queue.Add(cm.Namespace)
 }
 
-func (c *Publisher) namespaceAdded(obj interface{}, rpId string) {
+func (c *Publisher) namespaceAdded(obj interface{}) {
 	namespace := obj.(*v1.Namespace)
 	c.queue.Add(namespace.Name)
 }
 
-func (c *Publisher) namespaceUpdated(oldObj interface{}, newObj interface{}, rpId string) {
+func (c *Publisher) namespaceUpdated(oldObj interface{}, newObj interface{}) {
 	newNamespace := newObj.(*v1.Namespace)
 	if newNamespace.Status.Phase != v1.NamespaceActive {
 		return

--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -191,7 +191,7 @@ func (cnc *CloudNodeController) updateNodeAddress(node *v1.Node, instances cloud
 	}
 }
 
-func (cnc *CloudNodeController) UpdateCloudNode(_, newObj interface{}, rpId string) {
+func (cnc *CloudNodeController) UpdateCloudNode(_, newObj interface{}) {
 	node, ok := newObj.(*v1.Node)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", newObj))
@@ -208,7 +208,7 @@ func (cnc *CloudNodeController) UpdateCloudNode(_, newObj interface{}, rpId stri
 }
 
 // AddCloudNode handles initializing new nodes registered with the cloud taint.
-func (cnc *CloudNodeController) AddCloudNode(obj interface{}, rpId string) {
+func (cnc *CloudNodeController) AddCloudNode(obj interface{}) {
 	node := obj.(*v1.Node)
 
 	cloudTaint := getCloudTaint(node.Spec.Taints)

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -61,13 +61,13 @@ func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.ClusterRoleInfo
 	c.syncHandler = c.syncClusterRole
 
 	clusterRoleInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			c.enqueue()
 		},
-		UpdateFunc: func(old, cur interface{}, rpId string) {
+		UpdateFunc: func(old, cur interface{}) {
 			c.enqueue()
 		},
-		DeleteFunc: func(uncast interface{}, rpId string) {
+		DeleteFunc: func(uncast interface{}) {
 			c.enqueue()
 		},
 	})

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -164,20 +164,20 @@ func (dc *DeploymentController) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (dc *DeploymentController) addDeployment(obj interface{}, rpId string) {
+func (dc *DeploymentController) addDeployment(obj interface{}) {
 	d := obj.(*apps.Deployment)
 	klog.V(4).Infof("Adding deployment %s", d.Name)
 	dc.enqueueDeployment(d)
 }
 
-func (dc *DeploymentController) updateDeployment(old, cur interface{}, rpId string) {
+func (dc *DeploymentController) updateDeployment(old, cur interface{}) {
 	oldD := old.(*apps.Deployment)
 	curD := cur.(*apps.Deployment)
 	klog.V(4).Infof("Updating deployment %s", oldD.Name)
 	dc.enqueueDeployment(curD)
 }
 
-func (dc *DeploymentController) deleteDeployment(obj interface{}, rpId string) {
+func (dc *DeploymentController) deleteDeployment(obj interface{}) {
 	d, ok := obj.(*apps.Deployment)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -196,13 +196,13 @@ func (dc *DeploymentController) deleteDeployment(obj interface{}, rpId string) {
 }
 
 // addReplicaSet enqueues the deployment that manages a ReplicaSet when the ReplicaSet is created.
-func (dc *DeploymentController) addReplicaSet(obj interface{}, rpId string) {
+func (dc *DeploymentController) addReplicaSet(obj interface{}) {
 	rs := obj.(*apps.ReplicaSet)
 
 	if rs.DeletionTimestamp != nil {
 		// On a restart of the controller manager, it's possible for an object to
 		// show up in a state that is already pending deletion.
-		dc.deleteReplicaSet(rs, rpId)
+		dc.deleteReplicaSet(rs)
 		return
 	}
 
@@ -253,7 +253,7 @@ func (dc *DeploymentController) getDeploymentsForReplicaSet(rs *apps.ReplicaSet)
 // is updated and wake them up. If the anything of the ReplicaSets have changed, we need to
 // awaken both the old and new deployments. old and cur must be *apps.ReplicaSet
 // types.
-func (dc *DeploymentController) updateReplicaSet(old, cur interface{}, rpId string) {
+func (dc *DeploymentController) updateReplicaSet(old, cur interface{}) {
 	curRS := cur.(*apps.ReplicaSet)
 	oldRS := old.(*apps.ReplicaSet)
 	if curRS.ResourceVersion == oldRS.ResourceVersion {
@@ -301,7 +301,7 @@ func (dc *DeploymentController) updateReplicaSet(old, cur interface{}, rpId stri
 // deleteReplicaSet enqueues the deployment that manages a ReplicaSet when
 // the ReplicaSet is deleted. obj could be an *apps.ReplicaSet, or
 // a DeletionFinalStateUnknown marker item.
-func (dc *DeploymentController) deleteReplicaSet(obj interface{}, rpId string) {
+func (dc *DeploymentController) deleteReplicaSet(obj interface{}) {
 	rs, ok := obj.(*apps.ReplicaSet)
 
 	// When a delete is dropped, the relist will notice a pod in the store not
@@ -335,7 +335,7 @@ func (dc *DeploymentController) deleteReplicaSet(obj interface{}, rpId string) {
 }
 
 // deletePod will enqueue a Recreate Deployment once all of its pods have stopped running.
-func (dc *DeploymentController) deletePod(obj interface{}, rpId string) {
+func (dc *DeploymentController) deletePod(obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
 
 	// When a delete is dropped, the relist will notice a pod in the store not

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -350,26 +350,26 @@ func (dc *DisruptionController) Run(stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (dc *DisruptionController) addDb(obj interface{}, rpId string) {
+func (dc *DisruptionController) addDb(obj interface{}) {
 	pdb := obj.(*policy.PodDisruptionBudget)
 	klog.V(4).Infof("add DB %q", pdb.Name)
 	dc.enqueuePdb(pdb)
 }
 
-func (dc *DisruptionController) updateDb(old, cur interface{}, rpId string) {
+func (dc *DisruptionController) updateDb(old, cur interface{}) {
 	// TODO(mml) ignore updates where 'old' is equivalent to 'cur'.
 	pdb := cur.(*policy.PodDisruptionBudget)
 	klog.V(4).Infof("update DB %q", pdb.Name)
 	dc.enqueuePdb(pdb)
 }
 
-func (dc *DisruptionController) removeDb(obj interface{}, rpId string) {
+func (dc *DisruptionController) removeDb(obj interface{}) {
 	pdb := obj.(*policy.PodDisruptionBudget)
 	klog.V(4).Infof("remove DB %q", pdb.Name)
 	dc.enqueuePdb(pdb)
 }
 
-func (dc *DisruptionController) addPod(obj interface{}, rpId string) {
+func (dc *DisruptionController) addPod(obj interface{}) {
 	pod := obj.(*v1.Pod)
 	klog.V(4).Infof("addPod called on pod %q", pod.Name)
 	pdb := dc.getPdbForPod(pod)
@@ -381,7 +381,7 @@ func (dc *DisruptionController) addPod(obj interface{}, rpId string) {
 	dc.enqueuePdb(pdb)
 }
 
-func (dc *DisruptionController) updatePod(old, cur interface{}, rpId string) {
+func (dc *DisruptionController) updatePod(old, cur interface{}) {
 	pod := cur.(*v1.Pod)
 	klog.V(4).Infof("updatePod called on pod %q", pod.Name)
 	pdb := dc.getPdbForPod(pod)
@@ -393,7 +393,7 @@ func (dc *DisruptionController) updatePod(old, cur interface{}, rpId string) {
 	dc.enqueuePdb(pdb)
 }
 
-func (dc *DisruptionController) deletePod(obj interface{}, rpId string) {
+func (dc *DisruptionController) deletePod(obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
 	// When a delete is dropped, the relist will notice a pod in the store not
 	// in the list, leading to the insertion of a tombstone object which contains

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -90,8 +90,8 @@ func NewEndpointController(podInformer coreinformers.PodInformer, serviceInforme
 
 	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: e.enqueueService,
-		UpdateFunc: func(old, cur interface{}, rpId string) {
-			e.enqueueService(cur, rpId)
+		UpdateFunc: func(old, cur interface{}) {
+			e.enqueueService(cur)
 		},
 		DeleteFunc: e.enqueueService,
 	})
@@ -203,7 +203,7 @@ func (e *EndpointController) getPodServiceMemberships(pod *v1.Pod) (sets.String,
 
 // When a pod is added, figure out what services it will be a member of and
 // enqueue them. obj must have *v1.Pod type.
-func (e *EndpointController) addPod(obj interface{}, rpId string) {
+func (e *EndpointController) addPod(obj interface{}) {
 	pod := obj.(*v1.Pod)
 	services, err := e.getPodServiceMemberships(pod)
 	if err != nil {
@@ -273,7 +273,7 @@ func determineNeededServiceUpdates(oldServices, services sets.String, podChanged
 // When a pod is updated, figure out what services it used to be a member of
 // and what services it will be a member of, and enqueue the union of these.
 // old and cur must be *v1.Pod types.
-func (e *EndpointController) updatePod(old, cur interface{}, rpId string) {
+func (e *EndpointController) updatePod(old, cur interface{}) {
 	newPod := cur.(*v1.Pod)
 	oldPod := old.(*v1.Pod)
 	if newPod.ResourceVersion == oldPod.ResourceVersion {
@@ -324,12 +324,12 @@ func hostNameAndDomainAreEqual(pod1, pod2 *v1.Pod) bool {
 
 // When a pod is deleted, enqueue the services the pod used to be a member of.
 // obj could be an *v1.Pod, or a DeletionFinalStateUnknown marker item.
-func (e *EndpointController) deletePod(obj interface{}, rpId string) {
+func (e *EndpointController) deletePod(obj interface{}) {
 	if _, ok := obj.(*v1.Pod); ok {
 		// Enqueue all the services that the pod used to be a member
 		// of. This happens to be exactly the same thing we do when a
 		// pod is added.
-		e.addPod(obj, rpId)
+		e.addPod(obj)
 		return
 	}
 	// If we reached here it means the pod was deleted but its final state is unrecorded.
@@ -344,11 +344,11 @@ func (e *EndpointController) deletePod(obj interface{}, rpId string) {
 		return
 	}
 	klog.V(4).Infof("Enqueuing services of deleted pod %s/%s/%s having final state unrecorded", pod.Tenant, pod.Namespace, pod.Name)
-	e.addPod(pod, rpId)
+	e.addPod(pod)
 }
 
 // obj could be an *v1.Service, or a DeletionFinalStateUnknown marker item.
-func (e *EndpointController) enqueueService(obj interface{}, rpId string) {
+func (e *EndpointController) enqueueService(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -128,7 +128,7 @@ type monitors map[schema.GroupVersionResource]*monitor
 func (gb *GraphBuilder) controllerFor(resource schema.GroupVersionResource, kind schema.GroupVersionKind) (cache.Controller, cache.Store, error) {
 	handlers := cache.ResourceEventHandlerFuncs{
 		// add the event to the dependencyGraphBuilder's graphChanges.
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			event := &event{
 				eventType: addEvent,
 				obj:       obj,
@@ -136,7 +136,7 @@ func (gb *GraphBuilder) controllerFor(resource schema.GroupVersionResource, kind
 			}
 			gb.graphChanges.Add(event)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}, rpId string) {
+		UpdateFunc: func(oldObj, newObj interface{}) {
 			// TODO: check if there are differences in the ownerRefs,
 			// finalizers, and DeletionTimestamp; if not, ignore the update.
 			event := &event{
@@ -147,7 +147,7 @@ func (gb *GraphBuilder) controllerFor(resource schema.GroupVersionResource, kind
 			}
 			gb.graphChanges.Add(event)
 		},
-		DeleteFunc: func(obj interface{}, rpId string) {
+		DeleteFunc: func(obj interface{}) {
 			// delta fifo may wrap the object in a cache.DeletedFinalStateUnknown, unwrap it
 			if deletedFinalStateUnknown, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 				obj = deletedFinalStateUnknown.Obj

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -111,11 +111,11 @@ func NewJobController(podInformer coreinformers.PodInformer, jobInformer batchin
 	}
 
 	jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			jm.enqueueController(obj, true)
 		},
 		UpdateFunc: jm.updateJob,
-		DeleteFunc: func(obj interface{}, rpId string) {
+		DeleteFunc: func(obj interface{}) {
 			jm.enqueueController(obj, true)
 		},
 	})
@@ -195,12 +195,12 @@ func (jm *JobController) resolveControllerRef(tenant, namespace string, controll
 }
 
 // When a pod is created, enqueue the controller that manages it and update it's expectations.
-func (jm *JobController) addPod(obj interface{}, rpId string) {
+func (jm *JobController) addPod(obj interface{}) {
 	pod := obj.(*v1.Pod)
 	if pod.DeletionTimestamp != nil {
 		// on a restart of the controller controller, it's possible a new pod shows up in a state that
 		// is already pending deletion. Prevent the pod from being a creation observation.
-		jm.deletePod(pod, rpId)
+		jm.deletePod(pod)
 		return
 	}
 
@@ -231,7 +231,7 @@ func (jm *JobController) addPod(obj interface{}, rpId string) {
 // When a pod is updated, figure out what job/s manage it and wake them up.
 // If the labels of the pod have changed we need to awaken both the old
 // and new job. old and cur must be *v1.Pod types.
-func (jm *JobController) updatePod(old, cur interface{}, rpId string) {
+func (jm *JobController) updatePod(old, cur interface{}) {
 	curPod := cur.(*v1.Pod)
 	oldPod := old.(*v1.Pod)
 	if curPod.ResourceVersion == oldPod.ResourceVersion {
@@ -244,7 +244,7 @@ func (jm *JobController) updatePod(old, cur interface{}, rpId string) {
 		// and after such time has passed, the kubelet actually deletes it from the store. We receive an update
 		// for modification of the deletion timestamp and expect an job to create more pods asap, not wait
 		// until the kubelet actually deletes the pod.
-		jm.deletePod(curPod, rpId)
+		jm.deletePod(curPod)
 		return
 	}
 
@@ -283,7 +283,7 @@ func (jm *JobController) updatePod(old, cur interface{}, rpId string) {
 
 // When a pod is deleted, enqueue the job that manages the pod and update its expectations.
 // obj could be an *v1.Pod, or a DeletionFinalStateUnknown marker item.
-func (jm *JobController) deletePod(obj interface{}, rpId string) {
+func (jm *JobController) deletePod(obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
 
 	// When a delete is dropped, the relist will notice a pod in the store not
@@ -320,7 +320,7 @@ func (jm *JobController) deletePod(obj interface{}, rpId string) {
 	jm.enqueueController(job, true)
 }
 
-func (jm *JobController) updateJob(old, cur interface{}, rpId string) {
+func (jm *JobController) updateJob(old, cur interface{}) {
 	oldJob := old.(*batch.Job)
 	curJob := cur.(*batch.Job)
 

--- a/pkg/controller/mizar/mizar-arktos-network-controller.go
+++ b/pkg/controller/mizar/mizar-arktos-network-controller.go
@@ -133,7 +133,7 @@ func (c *MizarArktosNetworkController) processNextWorkItem() bool {
 	return true
 }
 
-func (c *MizarArktosNetworkController) createNetwork(obj interface{}, rpId string) {
+func (c *MizarArktosNetworkController) createNetwork(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", obj, err))

--- a/pkg/controller/mizar/mizar-endpoints-controller.go
+++ b/pkg/controller/mizar/mizar-endpoints-controller.go
@@ -118,7 +118,7 @@ func (c *MizarEndpointsController) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (c *MizarEndpointsController) createObj(obj interface{}, rpId string) {
+func (c *MizarEndpointsController) createObj(obj interface{}) {
 	key, _ := controller.KeyFunc(obj)
 	if shouldIgnore(key) {
 		return
@@ -127,7 +127,7 @@ func (c *MizarEndpointsController) createObj(obj interface{}, rpId string) {
 }
 
 // When an object is updated.
-func (c *MizarEndpointsController) updateObj(old, cur interface{}, rpId string) {
+func (c *MizarEndpointsController) updateObj(old, cur interface{}) {
 	curObj := cur.(*v1.Endpoints)
 	oldObj := old.(*v1.Endpoints)
 	if curObj.ResourceVersion == oldObj.ResourceVersion {

--- a/pkg/controller/mizar/mizar-node-controller.go
+++ b/pkg/controller/mizar/mizar-node-controller.go
@@ -105,13 +105,13 @@ func (c *MizarNodeController) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (c *MizarNodeController) createObj(obj interface{}, rpId string) {
+func (c *MizarNodeController) createObj(obj interface{}) {
 	key, _ := controller.KeyFunc(obj)
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Create})
 }
 
 // When an object is updated.
-func (c *MizarNodeController) updateObj(old, cur interface{}, rpId string) {
+func (c *MizarNodeController) updateObj(old, cur interface{}) {
 	curObj := cur.(*v1.Node)
 	oldObj := old.(*v1.Node)
 	if curObj.ResourceVersion == oldObj.ResourceVersion {
@@ -128,7 +128,7 @@ func (c *MizarNodeController) updateObj(old, cur interface{}, rpId string) {
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Update, ResourceVersion: curObj.ResourceVersion})
 }
 
-func (c *MizarNodeController) deleteObj(obj interface{}, rpId string) {
+func (c *MizarNodeController) deleteObj(obj interface{}) {
 	key, _ := controller.KeyFunc(obj)
 	klog.Infof("%v deleted. key %s.", controllerForMizarNode, key)
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Delete})

--- a/pkg/controller/mizar/mizar-pod-controller.go
+++ b/pkg/controller/mizar/mizar-pod-controller.go
@@ -105,13 +105,13 @@ func (c *MizarPodController) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (c *MizarPodController) createObj(obj interface{}, rpId string) {
+func (c *MizarPodController) createObj(obj interface{}) {
 	key, _ := controller.KeyFunc(obj)
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Create})
 }
 
 // When an object is updated.
-func (c *MizarPodController) updateObj(old, cur interface{}, rpId string) {
+func (c *MizarPodController) updateObj(old, cur interface{}) {
 	curObj := cur.(*v1.Pod)
 	oldObj := old.(*v1.Pod)
 	if curObj.ResourceVersion == oldObj.ResourceVersion {
@@ -128,7 +128,7 @@ func (c *MizarPodController) updateObj(old, cur interface{}, rpId string) {
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Update, ResourceVersion: curObj.ResourceVersion})
 }
 
-func (c *MizarPodController) deleteObj(obj interface{}, rpId string) {
+func (c *MizarPodController) deleteObj(obj interface{}) {
 	key, _ := controller.KeyFunc(obj)
 	klog.Infof("%v deleted. key %s.", controllerForMizarPod, key)
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Delete})

--- a/pkg/controller/mizar/mizar-service-controller.go
+++ b/pkg/controller/mizar/mizar-service-controller.go
@@ -135,7 +135,7 @@ func (c *MizarServiceController) processNextWorkItem() bool {
 	return true
 }
 
-func (c *MizarServiceController) createService(obj interface{}, rpId string) {
+func (c *MizarServiceController) createService(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for service %#v: %v", obj, err))
@@ -144,7 +144,7 @@ func (c *MizarServiceController) createService(obj interface{}, rpId string) {
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Create})
 }
 
-func (c *MizarServiceController) updateService(old, cur interface{}, rpId string) {
+func (c *MizarServiceController) updateService(old, cur interface{}) {
 	new := cur.(*v1.Service)
 	pre := old.(*v1.Service)
 
@@ -160,7 +160,7 @@ func (c *MizarServiceController) updateService(old, cur interface{}, rpId string
 	c.queue.Add(KeyWithEventType{Key: key, EventType: EventType_Update, ResourceVersion: new.ResourceVersion})
 }
 
-func (c *MizarServiceController) deleteService(obj interface{}, rpId string) {
+func (c *MizarServiceController) deleteService(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for service %#v: %v", obj, err))

--- a/pkg/controller/mizar/mizar-starter-controller.go
+++ b/pkg/controller/mizar/mizar-starter-controller.go
@@ -103,7 +103,7 @@ func (c *MizarStarterController) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (c *MizarStarterController) createObj(obj interface{}, rpId string) {
+func (c *MizarStarterController) createObj(obj interface{}) {
 	key, _ := controller.KeyFunc(obj)
 	c.queue.Add(key)
 }

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -83,11 +83,11 @@ func NewNamespaceController(
 	// configure the namespace informer event handlers
 	namespaceInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}, rpId string) {
+			AddFunc: func(obj interface{}) {
 				namespace := obj.(*v1.Namespace)
 				namespaceController.enqueueNamespace(namespace)
 			},
-			UpdateFunc: func(oldObj, newObj interface{}, rpId string) {
+			UpdateFunc: func(oldObj, newObj interface{}) {
 				namespace := newObj.(*v1.Namespace)
 				namespaceController.enqueueNamespace(namespace)
 			},

--- a/pkg/controller/network/network_controller.go
+++ b/pkg/controller/network/network_controller.go
@@ -141,13 +141,13 @@ func (nc *NetworkController) processNextWorkItem() bool {
 	return true
 }
 
-func (nc *NetworkController) createPort(obj interface{}, rpId string) {
+func (nc *NetworkController) createPort(obj interface{}) {
 	// When a pod is created, Scheduler seems always faster than network controller.
 	// So wait for scheduler's update to create port.
 }
 
 // When a pod is updated.
-func (nc *NetworkController) updatePort(old, cur interface{}, rpId string) {
+func (nc *NetworkController) updatePort(old, cur interface{}) {
 	new := cur.(*v1.Pod)
 	prev := old.(*v1.Pod)
 	needCreate := false
@@ -176,7 +176,7 @@ func (nc *NetworkController) updatePort(old, cur interface{}, rpId string) {
 }
 
 // When a pod is deleted, delete ports.
-func (nc *NetworkController) deletePort(obj interface{}, rpId string) {
+func (nc *NetworkController) deletePort(obj interface{}) {
 	pod := obj.(*v1.Pod)
 	client := GetOpenstackClient()
 

--- a/pkg/controller/nodeipam/ipam/cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cidr_allocator.go
@@ -87,9 +87,9 @@ type CIDRAllocator interface {
 	// AllocateOrOccupyCIDR looks at the given node, assigns it a valid
 	// CIDR if it doesn't currently have one or mark the CIDR as used if
 	// the node already have one.
-	AllocateOrOccupyCIDR(node *v1.Node, rpId string) error
+	AllocateOrOccupyCIDR(node *v1.Node) error
 	// ReleaseCIDR releases the CIDR of the removed node
-	ReleaseCIDR(node *v1.Node, rpId string) error
+	ReleaseCIDR(node *v1.Node) error
 	// Run starts all the working logic of the allocator.
 	Run(stopCh <-chan struct{})
 }

--- a/pkg/controller/nodeipam/ipam/controller.go
+++ b/pkg/controller/nodeipam/ipam/controller.go
@@ -171,7 +171,7 @@ func (c *Controller) newSyncer(name string) *nodesync.NodeSync {
 	return nodesync.New(ns, c.adapter, c.adapter, c.config.Mode, name, c.set)
 }
 
-func (c *Controller) onAdd(node *v1.Node, rpId string) error {
+func (c *Controller) onAdd(node *v1.Node) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -188,7 +188,7 @@ func (c *Controller) onAdd(node *v1.Node, rpId string) error {
 	return nil
 }
 
-func (c *Controller) onUpdate(_, node *v1.Node, rpId string) error {
+func (c *Controller) onUpdate(_, node *v1.Node) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -202,7 +202,7 @@ func (c *Controller) onUpdate(_, node *v1.Node, rpId string) error {
 	return nil
 }
 
-func (c *Controller) onDelete(node *v1.Node, rpId string) error {
+func (c *Controller) onDelete(node *v1.Node) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 

--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -122,7 +122,7 @@ func NewCIDRRangeAllocator(client clientset.Interface, nodeInformer informers.No
 
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: nodeutil.CreateAddNodeHandler(ra.AllocateOrOccupyCIDR),
-		UpdateFunc: nodeutil.CreateUpdateNodeHandler(func(_, newNode *v1.Node, rpId string) error {
+		UpdateFunc: nodeutil.CreateUpdateNodeHandler(func(_, newNode *v1.Node) error {
 			// If the PodCIDR is not empty we either:
 			// - already processed a Node that already had a CIDR after NC restarted
 			//   (cidr is marked as used),
@@ -143,7 +143,7 @@ func NewCIDRRangeAllocator(client clientset.Interface, nodeInformer informers.No
 			// state is correct.
 			// Restart of NC fixes the issue.
 			if newNode.Spec.PodCIDR == "" {
-				return ra.AllocateOrOccupyCIDR(newNode, rpId)
+				return ra.AllocateOrOccupyCIDR(newNode)
 			}
 			return nil
 		}),
@@ -222,7 +222,7 @@ func (r *rangeAllocator) occupyCIDR(node *v1.Node) error {
 // WARNING: If you're adding any return calls or defer any more work from this
 // function you have to make sure to update nodesInProcessing properly with the
 // disposition of the node when the work is done.
-func (r *rangeAllocator) AllocateOrOccupyCIDR(node *v1.Node, rpId string) error {
+func (r *rangeAllocator) AllocateOrOccupyCIDR(node *v1.Node) error {
 	if node == nil {
 		return nil
 	}
@@ -248,7 +248,7 @@ func (r *rangeAllocator) AllocateOrOccupyCIDR(node *v1.Node, rpId string) error 
 	return nil
 }
 
-func (r *rangeAllocator) ReleaseCIDR(node *v1.Node, rpId string) error {
+func (r *rangeAllocator) ReleaseCIDR(node *v1.Node) error {
 	if node == nil || node.Spec.PodCIDR == "" {
 		return nil
 	}

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -168,12 +168,12 @@ func (a *HorizontalController) Run(stopCh <-chan struct{}) {
 }
 
 // obj could be an *v1.HorizontalPodAutoscaler, or a DeletionFinalStateUnknown marker item.
-func (a *HorizontalController) updateHPA(old, cur interface{}, rpId string) {
-	a.enqueueHPA(cur, rpId)
+func (a *HorizontalController) updateHPA(old, cur interface{}) {
+	a.enqueueHPA(cur)
 }
 
 // obj could be an *v1.HorizontalPodAutoscaler, or a DeletionFinalStateUnknown marker item.
-func (a *HorizontalController) enqueueHPA(obj interface{}, rpId string) {
+func (a *HorizontalController) enqueueHPA(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))
@@ -186,7 +186,7 @@ func (a *HorizontalController) enqueueHPA(obj interface{}, rpId string) {
 	a.queue.AddRateLimited(key)
 }
 
-func (a *HorizontalController) deleteHPA(obj interface{}, rpId string) {
+func (a *HorizontalController) deleteHPA(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -230,7 +230,7 @@ func (rsc *ReplicaSetController) resolveControllerRef(tenant, namespace string, 
 }
 
 // callback when RS is updated
-func (rsc *ReplicaSetController) updateRS(old, cur interface{}, rpId string) {
+func (rsc *ReplicaSetController) updateRS(old, cur interface{}) {
 	oldRS := old.(*apps.ReplicaSet)
 	curRS := cur.(*apps.ReplicaSet)
 
@@ -249,17 +249,17 @@ func (rsc *ReplicaSetController) updateRS(old, cur interface{}, rpId string) {
 	if *(oldRS.Spec.Replicas) != *(curRS.Spec.Replicas) {
 		klog.V(4).Infof("%v %v updated. Desired pod count change: %d->%d", rsc.Kind, curRS.Name, *(oldRS.Spec.Replicas), *(curRS.Spec.Replicas))
 	}
-	rsc.enqueueReplicaSet(cur, rpId)
+	rsc.enqueueReplicaSet(cur)
 }
 
 // When a pod is created, enqueue the replica set that manages it and update its expectations.
-func (rsc *ReplicaSetController) addPod(obj interface{}, rpId string) {
+func (rsc *ReplicaSetController) addPod(obj interface{}) {
 	pod := obj.(*v1.Pod)
 
 	if pod.DeletionTimestamp != nil {
 		// on a restart of the controller manager, it's possible a new pod shows up in a state that
 		// is already pending deletion. Prevent the pod from being a creation observation.
-		rsc.deletePod(pod, rpId)
+		rsc.deletePod(pod)
 		return
 	}
 
@@ -275,7 +275,7 @@ func (rsc *ReplicaSetController) addPod(obj interface{}, rpId string) {
 		}
 		klog.V(4).Infof("Pod %s created: %#v.", pod.Name, pod)
 		rsc.expectations.CreationObserved(rsKey)
-		rsc.enqueueReplicaSet(rs, rpId)
+		rsc.enqueueReplicaSet(rs)
 		return
 	}
 
@@ -289,14 +289,14 @@ func (rsc *ReplicaSetController) addPod(obj interface{}, rpId string) {
 	}
 	klog.V(4).Infof("Orphan Pod %s created: %#v.", pod.Name, pod)
 	for _, rs := range rss {
-		rsc.enqueueReplicaSet(rs, rpId)
+		rsc.enqueueReplicaSet(rs)
 	}
 }
 
 // When a pod is updated, figure out what replica set/s manage it and wake them
 // up. If the labels of the pod have changed we need to awaken both the old
 // and new replica set. old and cur must be *v1.Pod types.
-func (rsc *ReplicaSetController) updatePod(old, cur interface{}, rpId string) {
+func (rsc *ReplicaSetController) updatePod(old, cur interface{}) {
 	curPod := cur.(*v1.Pod)
 	oldPod := old.(*v1.Pod)
 	if curPod.ResourceVersion == oldPod.ResourceVersion {
@@ -312,10 +312,10 @@ func (rsc *ReplicaSetController) updatePod(old, cur interface{}, rpId string) {
 		// for modification of the deletion timestamp and expect an rs to create more replicas asap, not wait
 		// until the kubelet actually deletes the pod. This is different from the Phase of a pod changing, because
 		// an rs never initiates a phase change, and so is never asleep waiting for the same.
-		rsc.deletePod(curPod, rpId)
+		rsc.deletePod(curPod)
 		if labelChanged {
 			// we don't need to check the oldPod.DeletionTimestamp because DeletionTimestamp cannot be unset.
-			rsc.deletePod(oldPod, rpId)
+			rsc.deletePod(oldPod)
 		}
 		return
 	}
@@ -326,7 +326,7 @@ func (rsc *ReplicaSetController) updatePod(old, cur interface{}, rpId string) {
 	if controllerRefChanged && oldControllerRef != nil {
 		// The ControllerRef was changed. Sync the old controller, if any.
 		if rs := rsc.resolveControllerRef(oldPod.Tenant, oldPod.Namespace, oldControllerRef); rs != nil {
-			rsc.enqueueReplicaSet(rs, rpId)
+			rsc.enqueueReplicaSet(rs)
 		}
 	}
 
@@ -337,7 +337,7 @@ func (rsc *ReplicaSetController) updatePod(old, cur interface{}, rpId string) {
 			return
 		}
 		klog.V(4).Infof("Pod %s updated, objectMeta %+v -> %+v.", curPod.Name, oldPod.ObjectMeta, curPod.ObjectMeta)
-		rsc.enqueueReplicaSet(rs, rpId)
+		rsc.enqueueReplicaSet(rs)
 		// TODO: MinReadySeconds in the Pod will generate an Available condition to be added in
 		// the Pod status which in turn will trigger a requeue of the owning replica set thus
 		// having its status updated with the newly available replica. For now, we can fake the
@@ -363,14 +363,14 @@ func (rsc *ReplicaSetController) updatePod(old, cur interface{}, rpId string) {
 		}
 		klog.V(4).Infof("Orphan Pod %s updated, objectMeta %+v -> %+v.", curPod.Name, oldPod.ObjectMeta, curPod.ObjectMeta)
 		for _, rs := range rss {
-			rsc.enqueueReplicaSet(rs, rpId)
+			rsc.enqueueReplicaSet(rs)
 		}
 	}
 }
 
 // When a pod is deleted, enqueue the replica set that manages the pod and update its expectations.
 // obj could be an *v1.Pod, or a DeletionFinalStateUnknown marker item.
-func (rsc *ReplicaSetController) deletePod(obj interface{}, rpId string) {
+func (rsc *ReplicaSetController) deletePod(obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
 
 	// When a delete is dropped, the relist will notice a pod in the store not
@@ -405,11 +405,11 @@ func (rsc *ReplicaSetController) deletePod(obj interface{}, rpId string) {
 	}
 	klog.V(4).Infof("Pod %s/%s/%s deleted through %v, timestamp %+v: %#v.", pod.Tenant, pod.Namespace, pod.Name, utilruntime.GetCaller(), pod.DeletionTimestamp, pod)
 	rsc.expectations.DeletionObserved(rsKey, controller.PodKey(pod))
-	rsc.enqueueReplicaSet(rs, rpId)
+	rsc.enqueueReplicaSet(rs)
 }
 
 // obj could be an *apps.ReplicaSet, or a DeletionFinalStateUnknown marker item.
-func (rsc *ReplicaSetController) enqueueReplicaSet(obj interface{}, rpId string) {
+func (rsc *ReplicaSetController) enqueueReplicaSet(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %+v: %v", obj, err))

--- a/pkg/controller/resourcequota/resource_quota_monitor.go
+++ b/pkg/controller/resourcequota/resource_quota_monitor.go
@@ -135,7 +135,7 @@ func (qm *QuotaMonitor) controllerFor(resource schema.GroupVersionResource) (cac
 	// TODO: pass this down
 	clock := clock.RealClock{}
 	handlers := cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(oldObj, newObj interface{}, rpId string) {
+		UpdateFunc: func(oldObj, newObj interface{}) {
 			// TODO: leaky abstraction!  live w/ it for now, but should pass down an update filter func.
 			// we only want to queue the updates we care about though as too much noise will overwhelm queue.
 			notifyUpdate := false
@@ -159,7 +159,7 @@ func (qm *QuotaMonitor) controllerFor(resource schema.GroupVersionResource) (cac
 				qm.resourceChanges.Add(event)
 			}
 		},
-		DeleteFunc: func(obj interface{}, rpId string) {
+		DeleteFunc: func(obj interface{}) {
 			// delta fifo may wrap the object in a cache.DeletedFinalStateUnknown, unwrap it
 			if deletedFinalStateUnknown, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 				obj = deletedFinalStateUnknown.Obj

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -155,7 +155,7 @@ func New(
 
 	serviceInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(cur interface{}, rpId string) {
+			AddFunc: func(cur interface{}) {
 				svc, ok := cur.(*v1.Service)
 				if ok && wantsNeutronLB(svc) {
 					s.createNeutronLB(cur)
@@ -163,14 +163,14 @@ func New(
 					s.enqueueService(cur)
 				}
 			},
-			UpdateFunc: func(old, cur interface{}, rpId string) {
+			UpdateFunc: func(old, cur interface{}) {
 				oldSvc, ok1 := old.(*v1.Service)
 				curSvc, ok2 := cur.(*v1.Service)
 				if ok1 && ok2 && (s.needsUpdate(oldSvc, curSvc) || needsCleanup(curSvc)) {
 					s.enqueueService(cur)
 				}
 			},
-			DeleteFunc: func(old interface{}, rpId string) {
+			DeleteFunc: func(old interface{}) {
 				if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.ServiceLoadBalancerFinalizer) {
 					// No need to handle deletion event if finalizer feature gate is
 					// enabled. Because the deletion would be handled by the update

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -130,7 +130,7 @@ func (c *ServiceAccountsController) Run(workers int, stopCh <-chan struct{}) {
 }
 
 // serviceAccountDeleted reacts to a ServiceAccount deletion by recreating a default ServiceAccount in the namespace if needed
-func (c *ServiceAccountsController) serviceAccountDeleted(obj interface{}, rpId string) {
+func (c *ServiceAccountsController) serviceAccountDeleted(obj interface{}) {
 	sa, ok := obj.(*v1.ServiceAccount)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -148,13 +148,13 @@ func (c *ServiceAccountsController) serviceAccountDeleted(obj interface{}, rpId 
 }
 
 // namespaceAdded reacts to a Namespace creation by creating a default ServiceAccount object
-func (c *ServiceAccountsController) namespaceAdded(obj interface{}, rpId string) {
+func (c *ServiceAccountsController) namespaceAdded(obj interface{}) {
 	namespace := obj.(*v1.Namespace)
 	c.queue.Add(namespace.Tenant + "/" + namespace.Name)
 }
 
 // namespaceUpdated reacts to a Namespace update (or re-list) by creating a default ServiceAccount in the namespace if needed
-func (c *ServiceAccountsController) namespaceUpdated(oldObj interface{}, newObj interface{}, rpId string) {
+func (c *ServiceAccountsController) namespaceUpdated(oldObj interface{}, newObj interface{}) {
 	newNamespace := newObj.(*v1.Namespace)
 	c.queue.Add(newNamespace.Tenant + "/" + newNamespace.Name)
 }

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -184,13 +184,13 @@ func (e *TokensController) Run(workers int, stopCh <-chan struct{}) {
 	klog.V(1).Infof("Shutting down")
 }
 
-func (e *TokensController) queueServiceAccountSync(obj interface{}, rpId string) {
+func (e *TokensController) queueServiceAccountSync(obj interface{}) {
 	if serviceAccount, ok := obj.(*v1.ServiceAccount); ok {
 		e.syncServiceAccountQueue.Add(makeServiceAccountKey(serviceAccount))
 	}
 }
 
-func (e *TokensController) queueServiceAccountUpdateSync(oldObj interface{}, newObj interface{}, rpId string) {
+func (e *TokensController) queueServiceAccountUpdateSync(oldObj interface{}, newObj interface{}) {
 	if serviceAccount, ok := newObj.(*v1.ServiceAccount); ok {
 		e.syncServiceAccountQueue.Add(makeServiceAccountKey(serviceAccount))
 	}
@@ -213,13 +213,13 @@ func (e *TokensController) retryOrForget(queue workqueue.RateLimitingInterface, 
 	queue.Forget(key)
 }
 
-func (e *TokensController) queueSecretSync(obj interface{}, rpId string) {
+func (e *TokensController) queueSecretSync(obj interface{}) {
 	if secret, ok := obj.(*v1.Secret); ok {
 		e.syncSecretQueue.Add(makeSecretQueueKey(secret))
 	}
 }
 
-func (e *TokensController) queueSecretUpdateSync(oldObj interface{}, newObj interface{}, rpId string) {
+func (e *TokensController) queueSecretUpdateSync(oldObj interface{}, newObj interface{}) {
 	if secret, ok := newObj.(*v1.Secret); ok {
 		e.syncSecretQueue.Add(makeSecretQueueKey(secret))
 	}

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -120,13 +120,13 @@ func NewStatefulSetController(
 	setInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: ssc.enqueueStatefulSet,
-			UpdateFunc: func(old, cur interface{}, rpId string) {
+			UpdateFunc: func(old, cur interface{}) {
 				oldPS := old.(*apps.StatefulSet)
 				curPS := cur.(*apps.StatefulSet)
 				if oldPS.Status.Replicas != curPS.Status.Replicas {
 					klog.V(4).Infof("Observed updated replica count for StatefulSet: %v, %d->%d", curPS.Name, oldPS.Status.Replicas, curPS.Status.Replicas)
 				}
-				ssc.enqueueStatefulSet(cur, rpId)
+				ssc.enqueueStatefulSet(cur)
 			},
 			DeleteFunc: ssc.enqueueStatefulSet,
 		},
@@ -158,13 +158,13 @@ func (ssc *StatefulSetController) Run(workers int, stopCh <-chan struct{}) {
 }
 
 // addPod adds the statefulset for the pod to the sync queue
-func (ssc *StatefulSetController) addPod(obj interface{}, rpId string) {
+func (ssc *StatefulSetController) addPod(obj interface{}) {
 	pod := obj.(*v1.Pod)
 
 	if pod.DeletionTimestamp != nil {
 		// on a restart of the controller manager, it's possible a new pod shows up in a state that
 		// is already pending deletion. Prevent the pod from being a creation observation.
-		ssc.deletePod(pod, rpId)
+		ssc.deletePod(pod)
 		return
 	}
 
@@ -175,7 +175,7 @@ func (ssc *StatefulSetController) addPod(obj interface{}, rpId string) {
 			return
 		}
 		klog.V(4).Infof("Pod %s created, labels: %+v", pod.Name, pod.Labels)
-		ssc.enqueueStatefulSet(set, rpId)
+		ssc.enqueueStatefulSet(set)
 		return
 	}
 
@@ -187,12 +187,12 @@ func (ssc *StatefulSetController) addPod(obj interface{}, rpId string) {
 	}
 	klog.V(4).Infof("Orphan Pod %s created, labels: %+v", pod.Name, pod.Labels)
 	for _, set := range sets {
-		ssc.enqueueStatefulSet(set, rpId)
+		ssc.enqueueStatefulSet(set)
 	}
 }
 
 // updatePod adds the statefulset for the current and old pods to the sync queue.
-func (ssc *StatefulSetController) updatePod(old, cur interface{}, rpId string) {
+func (ssc *StatefulSetController) updatePod(old, cur interface{}) {
 	curPod := cur.(*v1.Pod)
 	oldPod := old.(*v1.Pod)
 	if curPod.ResourceVersion == oldPod.ResourceVersion {
@@ -209,7 +209,7 @@ func (ssc *StatefulSetController) updatePod(old, cur interface{}, rpId string) {
 	if controllerRefChanged && oldControllerRef != nil {
 		// The ControllerRef was changed. Sync the old controller, if any.
 		if set := ssc.resolveControllerRef(oldPod.Tenant, oldPod.Namespace, oldControllerRef); set != nil {
-			ssc.enqueueStatefulSet(set, rpId)
+			ssc.enqueueStatefulSet(set)
 		}
 	}
 
@@ -220,7 +220,7 @@ func (ssc *StatefulSetController) updatePod(old, cur interface{}, rpId string) {
 			return
 		}
 		klog.V(4).Infof("Pod %s updated, objectMeta %+v -> %+v.", curPod.Name, oldPod.ObjectMeta, curPod.ObjectMeta)
-		ssc.enqueueStatefulSet(set, rpId)
+		ssc.enqueueStatefulSet(set)
 		return
 	}
 
@@ -233,13 +233,13 @@ func (ssc *StatefulSetController) updatePod(old, cur interface{}, rpId string) {
 		}
 		klog.V(4).Infof("Orphan Pod %s updated, objectMeta %+v -> %+v.", curPod.Name, oldPod.ObjectMeta, curPod.ObjectMeta)
 		for _, set := range sets {
-			ssc.enqueueStatefulSet(set, rpId)
+			ssc.enqueueStatefulSet(set)
 		}
 	}
 }
 
 // deletePod enqueues the statefulset for the pod accounting for deletion tombstones.
-func (ssc *StatefulSetController) deletePod(obj interface{}, rpId string) {
+func (ssc *StatefulSetController) deletePod(obj interface{}) {
 	pod, ok := obj.(*v1.Pod)
 
 	// When a delete is dropped, the relist will notice a pod in the store not
@@ -268,7 +268,7 @@ func (ssc *StatefulSetController) deletePod(obj interface{}, rpId string) {
 		return
 	}
 	klog.V(4).Infof("Pod %s/%s deleted through %v.", pod.Namespace, pod.Name, utilruntime.GetCaller())
-	ssc.enqueueStatefulSet(set, rpId)
+	ssc.enqueueStatefulSet(set)
 }
 
 // getPodsForStatefulSet returns the Pods that a given StatefulSet should manage.
@@ -373,7 +373,7 @@ func (ssc *StatefulSetController) resolveControllerRef(tenant string, namespace 
 }
 
 // enqueueStatefulSet enqueues the given statefulset in the work queue.
-func (ssc *StatefulSetController) enqueueStatefulSet(obj interface{}, rpId string) {
+func (ssc *StatefulSetController) enqueueStatefulSet(obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))

--- a/pkg/controller/tenant/tenant_controller.go
+++ b/pkg/controller/tenant/tenant_controller.go
@@ -116,10 +116,10 @@ func NewTenantController(kubeClient clientset.Interface,
 	// configure the tenant informer event handlers
 	tenantInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}, rpId string) {
+			AddFunc: func(obj interface{}) {
 				tenantController.enqueue(obj)
 			},
-			UpdateFunc: func(oldObj, newObj interface{}, rpId string) {
+			UpdateFunc: func(oldObj, newObj interface{}) {
 				tenantController.enqueue(newObj)
 			},
 		},

--- a/pkg/controller/ttl/ttl_controller.go
+++ b/pkg/controller/ttl/ttl_controller.go
@@ -128,7 +128,7 @@ func (ttlc *TTLController) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (ttlc *TTLController) addNode(obj interface{}, rpId string) {
+func (ttlc *TTLController) addNode(obj interface{}) {
 	node, ok := obj.(*v1.Node)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
@@ -147,7 +147,7 @@ func (ttlc *TTLController) addNode(obj interface{}, rpId string) {
 	ttlc.enqueueNode(node)
 }
 
-func (ttlc *TTLController) updateNode(_, newObj interface{}, rpId string) {
+func (ttlc *TTLController) updateNode(_, newObj interface{}) {
 	node, ok := newObj.(*v1.Node)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", newObj))
@@ -161,7 +161,7 @@ func (ttlc *TTLController) updateNode(_, newObj interface{}, rpId string) {
 	ttlc.enqueueNode(node)
 }
 
-func (ttlc *TTLController) deleteNode(obj interface{}, rpId string) {
+func (ttlc *TTLController) deleteNode(obj interface{}) {
 	_, ok := obj.(*v1.Node)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
@@ -117,7 +117,7 @@ func (tc *Controller) Run(workers int, stopCh <-chan struct{}) {
 	<-stopCh
 }
 
-func (tc *Controller) addJob(obj interface{}, rpId string) {
+func (tc *Controller) addJob(obj interface{}) {
 	job := obj.(*batch.Job)
 	klog.V(4).Infof("Adding job %s/%s", job.Namespace, job.Name)
 
@@ -126,7 +126,7 @@ func (tc *Controller) addJob(obj interface{}, rpId string) {
 	}
 }
 
-func (tc *Controller) updateJob(old, cur interface{}, rpId string) {
+func (tc *Controller) updateJob(old, cur interface{}) {
 	job := cur.(*batch.Job)
 	klog.V(4).Infof("Updating job %s/%s", job.Namespace, job.Name)
 

--- a/pkg/controller/util/node/controller_utils.go
+++ b/pkg/controller/util/node/controller_utils.go
@@ -262,30 +262,30 @@ func AddOrUpdateLabelsOnNode(kubeClient clientset.Interface, labelsToUpdate map[
 }
 
 // CreateAddNodeHandler creates an add node handler.
-func CreateAddNodeHandler(f func(node *v1.Node, rpId string) error) func(obj interface{}, rpId string) {
-	return func(originalObj interface{}, rpId string) {
+func CreateAddNodeHandler(f func(node *v1.Node) error) func(obj interface{}) {
+	return func(originalObj interface{}) {
 		node := originalObj.(*v1.Node).DeepCopy()
-		if err := f(node, rpId); err != nil {
+		if err := f(node); err != nil {
 			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add: %v", err))
 		}
 	}
 }
 
 // CreateUpdateNodeHandler creates a node update handler. (Common to lifecycle and ipam)
-func CreateUpdateNodeHandler(f func(oldNode, newNode *v1.Node, rpId string) error) func(oldObj, newObj interface{}, rpId string) {
-	return func(origOldObj, origNewObj interface{}, rpId string) {
+func CreateUpdateNodeHandler(f func(oldNode, newNode *v1.Node) error) func(oldObj, newObj interface{}) {
+	return func(origOldObj, origNewObj interface{}) {
 		node := origNewObj.(*v1.Node).DeepCopy()
 		prevNode := origOldObj.(*v1.Node).DeepCopy()
 
-		if err := f(prevNode, node, rpId); err != nil {
+		if err := f(prevNode, node); err != nil {
 			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add/Delete: %v", err))
 		}
 	}
 }
 
 // CreateDeleteNodeHandler creates a delete node handler. (Common to lifecycle and ipam)
-func CreateDeleteNodeHandler(f func(node *v1.Node, rpId string) error) func(obj interface{}, rpId string) {
-	return func(originalObj interface{}, rpId string) {
+func CreateDeleteNodeHandler(f func(node *v1.Node) error) func(obj interface{}) {
+	return func(originalObj interface{}) {
 		originalNode, isNode := originalObj.(*v1.Node)
 		// We can get DeletedFinalStateUnknown instead of *v1.Node here and
 		// we need to handle that correctly. #34692
@@ -302,7 +302,7 @@ func CreateDeleteNodeHandler(f func(node *v1.Node, rpId string) error) func(obj 
 			}
 		}
 		node := originalNode.DeepCopy()
-		if err := f(node, rpId); err != nil {
+		if err := f(node); err != nil {
 			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add/Delete: %v", err))
 		}
 	}

--- a/pkg/controller/vmpod/vm_controller.go
+++ b/pkg/controller/vmpod/vm_controller.go
@@ -55,7 +55,7 @@ func NewVMPod(kubeClient clientset.Interface, podInformer coreinformers.PodInfor
 	return vmc
 }
 
-func (vmc *VMPodController) updatePod(old, cur interface{}, rpId string) {
+func (vmc *VMPodController) updatePod(old, cur interface{}) {
 	newPod := cur.(*v1.Pod)
 	oldPod := old.(*v1.Pod)
 

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -136,7 +136,7 @@ func NewExpandController(
 
 	pvcInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
 		AddFunc: expc.enqueuePVC,
-		UpdateFunc: func(old, new interface{}, rpId string) {
+		UpdateFunc: func(old, new interface{}) {
 			oldPVC, ok := old.(*v1.PersistentVolumeClaim)
 			if !ok {
 				return
@@ -149,7 +149,7 @@ func NewExpandController(
 			}
 			newSize := newPVC.Spec.Resources.Requests[v1.ResourceStorage]
 			if newSize.Cmp(oldSize) > 0 {
-				expc.enqueuePVC(new, rpId)
+				expc.enqueuePVC(new)
 			}
 		},
 		DeleteFunc: expc.enqueuePVC,
@@ -158,7 +158,7 @@ func NewExpandController(
 	return expc, nil
 }
 
-func (expc *expandController) enqueuePVC(obj interface{}, rpId string) {
+func (expc *expandController) enqueuePVC(obj interface{}) {
 	pvc, ok := obj.(*v1.PersistentVolumeClaim)
 	if !ok {
 		return

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -104,9 +104,9 @@ func NewController(p ControllerParameters) (*PersistentVolumeController, error) 
 
 	p.VolumeInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}, rpId string) { controller.enqueueWork(controller.volumeQueue, obj) },
-			UpdateFunc: func(oldObj, newObj interface{}, rpId string) { controller.enqueueWork(controller.volumeQueue, newObj) },
-			DeleteFunc: func(obj interface{}, rpId string) { controller.enqueueWork(controller.volumeQueue, obj) },
+			AddFunc:    func(obj interface{}) { controller.enqueueWork(controller.volumeQueue, obj) },
+			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(controller.volumeQueue, newObj) },
+			DeleteFunc: func(obj interface{}) { controller.enqueueWork(controller.volumeQueue, obj) },
 		},
 	)
 	controller.volumeLister = p.VolumeInformer.Lister()
@@ -114,9 +114,9 @@ func NewController(p ControllerParameters) (*PersistentVolumeController, error) 
 
 	p.ClaimInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}, rpId string) { controller.enqueueWork(controller.claimQueue, obj) },
-			UpdateFunc: func(oldObj, newObj interface{}, rpId string) { controller.enqueueWork(controller.claimQueue, newObj) },
-			DeleteFunc: func(obj interface{}, rpId string) { controller.enqueueWork(controller.claimQueue, obj) },
+			AddFunc:    func(obj interface{}) { controller.enqueueWork(controller.claimQueue, obj) },
+			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(controller.claimQueue, newObj) },
+			DeleteFunc: func(obj interface{}) { controller.enqueueWork(controller.claimQueue, obj) },
 		},
 	)
 	controller.claimLister = p.ClaimInformer.Lister()

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -71,21 +71,21 @@ func NewPVCProtectionController(pvcInformer coreinformers.PersistentVolumeClaimI
 	e.pvcListerSynced = pvcInformer.Informer().HasSynced
 	pvcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: e.pvcAddedUpdated,
-		UpdateFunc: func(old, new interface{}, rpId string) {
-			e.pvcAddedUpdated(new, rpId)
+		UpdateFunc: func(old, new interface{}) {
+			e.pvcAddedUpdated(new)
 		},
 	})
 
 	e.podLister = podInformer.Lister()
 	e.podListerSynced = podInformer.Informer().HasSynced
 	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			e.podAddedDeletedUpdated(obj, false)
 		},
-		DeleteFunc: func(obj interface{}, rpId string) {
+		DeleteFunc: func(obj interface{}) {
 			e.podAddedDeletedUpdated(obj, true)
 		},
-		UpdateFunc: func(old, new interface{}, rpId string) {
+		UpdateFunc: func(old, new interface{}) {
 			e.podAddedDeletedUpdated(new, false)
 		},
 	})
@@ -239,7 +239,7 @@ func (c *Controller) isBeingUsed(pvc *v1.PersistentVolumeClaim) (bool, error) {
 }
 
 // pvcAddedUpdated reacts to pvc added/updated/deleted events
-func (c *Controller) pvcAddedUpdated(obj interface{}, rpId string) {
+func (c *Controller) pvcAddedUpdated(obj interface{}) {
 	pvc, ok := obj.(*v1.PersistentVolumeClaim)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("PVC informer returned non-PVC object: %#v", obj))

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -67,8 +67,8 @@ func NewPVProtectionController(pvInformer coreinformers.PersistentVolumeInformer
 	e.pvListerSynced = pvInformer.Informer().HasSynced
 	pvInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: e.pvAddedUpdated,
-		UpdateFunc: func(old, new interface{}, rpId string) {
-			e.pvAddedUpdated(new, rpId)
+		UpdateFunc: func(old, new interface{}) {
+			e.pvAddedUpdated(new)
 		},
 	})
 
@@ -201,7 +201,7 @@ func (c *Controller) isBeingUsed(pv *v1.PersistentVolume) bool {
 }
 
 // pvAddedUpdated reacts to pv added/updated events
-func (c *Controller) pvAddedUpdated(obj interface{}, rpId string) {
+func (c *Controller) pvAddedUpdated(obj interface{}) {
 	pv, ok := obj.(*v1.PersistentVolume)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("PV informer returned non-PV object: %#v", obj))

--- a/pkg/controller/volume/scheduling/scheduler_assume_cache.go
+++ b/pkg/controller/volume/scheduling/scheduler_assume_cache.go
@@ -150,7 +150,7 @@ func NewAssumeCache(informer cache.SharedIndexInformer, description, indexName s
 	return c
 }
 
-func (c *assumeCache) add(obj interface{}, rpId string) {
+func (c *assumeCache) add(obj interface{}) {
 	if obj == nil {
 		return
 	}
@@ -190,11 +190,11 @@ func (c *assumeCache) add(obj interface{}, rpId string) {
 	klog.V(10).Infof("Added %v %v to assume cache: %+v ", c.description, name, obj)
 }
 
-func (c *assumeCache) update(oldObj interface{}, newObj interface{}, rpId string) {
-	c.add(newObj, rpId)
+func (c *assumeCache) update(oldObj interface{}, newObj interface{}) {
+	c.add(newObj)
 }
 
-func (c *assumeCache) delete(obj interface{}, rpId string) {
+func (c *assumeCache) delete(obj interface{}) {
 	if obj == nil {
 		return
 	}

--- a/pkg/controller/volume/scheduling/scheduler_binder.go
+++ b/pkg/controller/volume/scheduling/scheduler_binder.go
@@ -104,7 +104,7 @@ type volumeBinder struct {
 	kubeClient  clientset.Interface
 	classLister storagelisters.StorageClassLister
 
-	nodeInformers []coreinformers.NodeInformer
+	nodeInformers map[string]coreinformers.NodeInformer
 	pvcCache      PVCAssumeCache
 	pvCache       PVAssumeCache
 
@@ -119,7 +119,7 @@ type volumeBinder struct {
 // NewVolumeBinder sets up all the caches needed for the scheduler to make volume binding decisions.
 func NewVolumeBinder(
 	kubeClient clientset.Interface,
-	nodeInformers []coreinformers.NodeInformer,
+	nodeInformers map[string]coreinformers.NodeInformer,
 	pvcInformer coreinformers.PersistentVolumeClaimInformer,
 	pvInformer coreinformers.PersistentVolumeInformer,
 	storageClassInformer storageinformers.StorageClassInformer,

--- a/pkg/kubelet/kubeletconfig/watch.go
+++ b/pkg/kubelet/kubeletconfig/watch.go
@@ -35,9 +35,9 @@ import (
 // newSharedNodeInformer returns a shared informer that uses `client` to watch the Node with
 // `nodeName` for changes and respond with `addFunc`, `updateFunc`, and `deleteFunc`.
 func newSharedNodeInformer(client clientset.Interface, nodeName string,
-	addFunc func(newObj interface{}, rpId string),
-	updateFunc func(oldObj interface{}, newObj interface{}, rpId string),
-	deleteFunc func(deletedObj interface{}, rpId string)) cache.SharedInformer {
+	addFunc func(newObj interface{}),
+	updateFunc func(oldObj interface{}, newObj interface{}),
+	deleteFunc func(deletedObj interface{})) cache.SharedInformer {
 	// select nodes by name
 	fieldselector := fields.OneTermEqualSelector("metadata.name", nodeName)
 
@@ -73,13 +73,13 @@ func newSharedNodeInformer(client clientset.Interface, nodeName string,
 }
 
 // onAddNodeEvent calls onUpdateNodeEvent with the new object and a nil old object
-func (cc *Controller) onAddNodeEvent(newObj interface{}, rpId string) {
-	cc.onUpdateNodeEvent(nil, newObj, rpId)
+func (cc *Controller) onAddNodeEvent(newObj interface{}) {
+	cc.onUpdateNodeEvent(nil, newObj)
 }
 
 // onUpdateNodeEvent checks whether the configSource changed between oldObj and newObj, and pokes the
 // configuration sync worker if there was a change
-func (cc *Controller) onUpdateNodeEvent(oldObj interface{}, newObj interface{}, rpId string) {
+func (cc *Controller) onUpdateNodeEvent(oldObj interface{}, newObj interface{}) {
 	newNode, ok := newObj.(*apiv1.Node)
 	if !ok {
 		utillog.Errorf("failed to cast new object to Node, couldn't handle event")
@@ -107,7 +107,7 @@ func (cc *Controller) onUpdateNodeEvent(oldObj interface{}, newObj interface{}, 
 // a Node with unexpected externalID and is attempting to delete and re-create the Node
 // (see pkg/kubelet/kubelet_node_status.go), or that someone accidentally deleted the Node
 // (the Kubelet will re-create it).
-func (cc *Controller) onDeleteNodeEvent(deletedObj interface{}, rpId string) {
+func (cc *Controller) onDeleteNodeEvent(deletedObj interface{}) {
 	// For this case, we just log the event.
 	// We don't want to poke the worker, because a temporary deletion isn't worth reporting an error for.
 	// If the Node is deleted because the VM is being deleted, then the Kubelet has nothing to do.
@@ -115,13 +115,13 @@ func (cc *Controller) onDeleteNodeEvent(deletedObj interface{}, rpId string) {
 }
 
 // onAddRemoteConfigSourceEvent calls onUpdateConfigMapEvent with the new object and a nil old object
-func (cc *Controller) onAddRemoteConfigSourceEvent(newObj interface{}, rpId string) {
-	cc.onUpdateRemoteConfigSourceEvent(nil, newObj, rpId)
+func (cc *Controller) onAddRemoteConfigSourceEvent(newObj interface{}) {
+	cc.onUpdateRemoteConfigSourceEvent(nil, newObj)
 }
 
 // onUpdateRemoteConfigSourceEvent checks whether the configSource changed between oldObj and newObj,
 // and pokes the sync worker if there was a change
-func (cc *Controller) onUpdateRemoteConfigSourceEvent(oldObj interface{}, newObj interface{}, rpId string) {
+func (cc *Controller) onUpdateRemoteConfigSourceEvent(oldObj interface{}, newObj interface{}) {
 	// since ConfigMap is currently the only source type, we handle that here
 	newConfigMap, ok := newObj.(*apiv1.ConfigMap)
 	if !ok {
@@ -146,7 +146,7 @@ func (cc *Controller) onUpdateRemoteConfigSourceEvent(oldObj interface{}, newObj
 }
 
 // onDeleteRemoteConfigSourceEvent logs a message if the ConfigMap was deleted and pokes the sync worker
-func (cc *Controller) onDeleteRemoteConfigSourceEvent(deletedObj interface{}, rpId string) {
+func (cc *Controller) onDeleteRemoteConfigSourceEvent(deletedObj interface{}) {
 	// If the ConfigMap we're watching is deleted, we log the event and poke the sync worker.
 	// This requires a sync, because if the Node is still configured to use the deleted ConfigMap,
 	// the Kubelet should report a DownloadError.

--- a/pkg/kubemark/controller.go
+++ b/pkg/kubemark/controller.go
@@ -363,7 +363,7 @@ func (kubemarkCluster *kubemarkCluster) getHollowNodeName() (string, error) {
 	return "", fmt.Errorf("did not find any hollow nodes in the cluster")
 }
 
-func (kubemarkCluster *kubemarkCluster) removeUnneededNodes(oldObj interface{}, newObj interface{}, rpId string) {
+func (kubemarkCluster *kubemarkCluster) removeUnneededNodes(oldObj interface{}, newObj interface{}) {
 	node, ok := newObj.(*apiv1.Node)
 	if !ok {
 		return

--- a/pkg/master/controller/crdregistration/crdregistration_controller.go
+++ b/pkg/master/controller/crdregistration/crdregistration_controller.go
@@ -81,17 +81,17 @@ func NewCRDRegistrationController(crdinformer crdinformers.CustomResourceDefinit
 	c.syncHandler = c.handleVersionUpdate
 
 	crdinformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			cast := obj.(*apiextensions.CustomResourceDefinition)
 			c.enqueueCRD(cast)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}, rpId string) {
+		UpdateFunc: func(oldObj, newObj interface{}) {
 			// Enqueue both old and new object to make sure we remove and add appropriate API services.
 			// The working queue will resolve any duplicates and only changes will stay in the queue.
 			c.enqueueCRD(oldObj.(*apiextensions.CustomResourceDefinition))
 			c.enqueueCRD(newObj.(*apiextensions.CustomResourceDefinition))
 		},
-		DeleteFunc: func(obj interface{}, rpId string) {
+		DeleteFunc: func(obj interface{}) {
 			cast, ok := obj.(*apiextensions.CustomResourceDefinition)
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/pkg/proxy/config/config.go
+++ b/pkg/proxy/config/config.go
@@ -106,7 +106,7 @@ func (c *EndpointsConfig) Run(stopCh <-chan struct{}) {
 	}
 }
 
-func (c *EndpointsConfig) handleAddEndpoints(obj interface{}, rpId string) {
+func (c *EndpointsConfig) handleAddEndpoints(obj interface{}) {
 	endpoints, ok := obj.(*v1.Endpoints)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
@@ -118,7 +118,7 @@ func (c *EndpointsConfig) handleAddEndpoints(obj interface{}, rpId string) {
 	}
 }
 
-func (c *EndpointsConfig) handleUpdateEndpoints(oldObj, newObj interface{}, rpId string) {
+func (c *EndpointsConfig) handleUpdateEndpoints(oldObj, newObj interface{}) {
 	oldEndpoints, ok := oldObj.(*v1.Endpoints)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", oldObj))
@@ -135,7 +135,7 @@ func (c *EndpointsConfig) handleUpdateEndpoints(oldObj, newObj interface{}, rpId
 	}
 }
 
-func (c *EndpointsConfig) handleDeleteEndpoints(obj interface{}, rpId string) {
+func (c *EndpointsConfig) handleDeleteEndpoints(obj interface{}) {
 	endpoints, ok := obj.(*v1.Endpoints)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -197,7 +197,7 @@ func (c *ServiceConfig) Run(stopCh <-chan struct{}) {
 	}
 }
 
-func (c *ServiceConfig) handleAddService(obj interface{}, rpId string) {
+func (c *ServiceConfig) handleAddService(obj interface{}) {
 	service, ok := obj.(*v1.Service)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
@@ -209,7 +209,7 @@ func (c *ServiceConfig) handleAddService(obj interface{}, rpId string) {
 	}
 }
 
-func (c *ServiceConfig) handleUpdateService(oldObj, newObj interface{}, rpId string) {
+func (c *ServiceConfig) handleUpdateService(oldObj, newObj interface{}) {
 	oldService, ok := oldObj.(*v1.Service)
 	if !ok {
 		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", oldObj))
@@ -226,7 +226,7 @@ func (c *ServiceConfig) handleUpdateService(oldObj, newObj interface{}, rpId str
 	}
 }
 
-func (c *ServiceConfig) handleDeleteService(obj interface{}, rpId string) {
+func (c *ServiceConfig) handleDeleteService(obj interface{}) {
 	service, ok := obj.(*v1.Service)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/pkg/scheduler/internal/cache/debugger/debugger.go
+++ b/pkg/scheduler/internal/cache/debugger/debugger.go
@@ -34,7 +34,7 @@ type CacheDebugger struct {
 
 // New creates a CacheDebugger.
 func New(
-	nodeListers []corelisters.NodeLister,
+	nodeListers map[string]corelisters.NodeLister,
 	podLister corelisters.PodLister,
 	cache internalcache.Cache,
 	podQueue internalqueue.SchedulingQueue,

--- a/pkg/scheduler/internal/cache/interface.go
+++ b/pkg/scheduler/internal/cache/interface.go
@@ -20,6 +20,7 @@ package cache
 import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
@@ -91,7 +92,8 @@ type Cache interface {
 	AddNode(node *v1.Node, resourceProviderId string) error
 
 	// UpdateNode updates overall information about node.
-	UpdateNode(oldNode, newNode *v1.Node, resourceProviderId string) error
+	// Here pass nodeLister map instead of resource provider id to skip unnecessary searches
+	UpdateNode(oldNode, newNode *v1.Node, nodeListers map[string]corelisters.NodeLister) error
 
 	// RemoveNode removes overall information about node.
 	RemoveNode(node *v1.Node) error

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -120,7 +120,7 @@ var defaultSchedulerOptions = schedulerOptions{
 
 // New returns a Scheduler
 func New(client clientset.Interface,
-	nodeInformers []coreinformers.NodeInformer,
+	nodeInformers map[string]coreinformers.NodeInformer,
 	podInformer coreinformers.PodInformer,
 	pvInformer coreinformers.PersistentVolumeInformer,
 	pvcInformer coreinformers.PersistentVolumeClaimInformer,

--- a/pkg/scheduler/volumebinder/volume_binder.go
+++ b/pkg/scheduler/volumebinder/volume_binder.go
@@ -35,7 +35,7 @@ type VolumeBinder struct {
 // NewVolumeBinder sets up the volume binding library and binding queue
 func NewVolumeBinder(
 	client clientset.Interface,
-	nodeInformers []coreinformers.NodeInformer,
+	nodeInformers map[string]coreinformers.NodeInformer,
 	pvcInformer coreinformers.PersistentVolumeClaimInformer,
 	pvInformer coreinformers.PersistentVolumeInformer,
 	storageClassInformer storageinformers.StorageClassInformer,

--- a/plugin/pkg/auth/authorizer/node/graph_populator.go
+++ b/plugin/pkg/auth/authorizer/node/graph_populator.go
@@ -74,11 +74,11 @@ func AddGraphEventHandlers(
 	}
 }
 
-func (g *graphPopulator) addNode(obj interface{}, rpId string) {
-	g.updateNode(nil, obj, rpId)
+func (g *graphPopulator) addNode(obj interface{}) {
+	g.updateNode(nil, obj)
 }
 
-func (g *graphPopulator) updateNode(oldObj, obj interface{}, rpId string) {
+func (g *graphPopulator) updateNode(oldObj, obj interface{}) {
 	node := obj.(*corev1.Node)
 	var oldNode *corev1.Node
 	if oldObj != nil {
@@ -114,7 +114,7 @@ func (g *graphPopulator) updateNode(oldObj, obj interface{}, rpId string) {
 	g.graph.SetNodeConfigMap(node.Name, name, namespace)
 }
 
-func (g *graphPopulator) deleteNode(obj interface{}, rpId string) {
+func (g *graphPopulator) deleteNode(obj interface{}) {
 	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		obj = tombstone.Obj
 	}
@@ -130,11 +130,11 @@ func (g *graphPopulator) deleteNode(obj interface{}, rpId string) {
 	g.graph.SetNodeConfigMap(node.Name, "", "")
 }
 
-func (g *graphPopulator) addPod(obj interface{}, rpId string) {
-	g.updatePod(nil, obj, rpId)
+func (g *graphPopulator) addPod(obj interface{}) {
+	g.updatePod(nil, obj)
 }
 
-func (g *graphPopulator) updatePod(oldObj, obj interface{}, rpId string) {
+func (g *graphPopulator) updatePod(oldObj, obj interface{}) {
 	pod := obj.(*corev1.Pod)
 	if len(pod.Spec.NodeName) == 0 {
 		// No node assigned
@@ -152,7 +152,7 @@ func (g *graphPopulator) updatePod(oldObj, obj interface{}, rpId string) {
 	g.graph.AddPod(pod)
 }
 
-func (g *graphPopulator) deletePod(obj interface{}, rpId string) {
+func (g *graphPopulator) deletePod(obj interface{}) {
 	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		obj = tombstone.Obj
 	}
@@ -169,17 +169,17 @@ func (g *graphPopulator) deletePod(obj interface{}, rpId string) {
 	g.graph.DeletePod(pod.Name, pod.Namespace)
 }
 
-func (g *graphPopulator) addPV(obj interface{}, rpId string) {
-	g.updatePV(nil, obj, rpId)
+func (g *graphPopulator) addPV(obj interface{}) {
+	g.updatePV(nil, obj)
 }
 
-func (g *graphPopulator) updatePV(oldObj, obj interface{}, rpId string) {
+func (g *graphPopulator) updatePV(oldObj, obj interface{}) {
 	pv := obj.(*corev1.PersistentVolume)
 	// TODO: skip add if uid, pvc, and secrets are all identical between old and new
 	g.graph.AddPV(pv)
 }
 
-func (g *graphPopulator) deletePV(obj interface{}, rpId string) {
+func (g *graphPopulator) deletePV(obj interface{}) {
 	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		obj = tombstone.Obj
 	}
@@ -191,11 +191,11 @@ func (g *graphPopulator) deletePV(obj interface{}, rpId string) {
 	g.graph.DeletePV(pv.Name)
 }
 
-func (g *graphPopulator) addVolumeAttachment(obj interface{}, rpId string) {
-	g.updateVolumeAttachment(nil, obj, rpId)
+func (g *graphPopulator) addVolumeAttachment(obj interface{}) {
+	g.updateVolumeAttachment(nil, obj)
 }
 
-func (g *graphPopulator) updateVolumeAttachment(oldObj, obj interface{}, rpId string) {
+func (g *graphPopulator) updateVolumeAttachment(oldObj, obj interface{}) {
 	attachment := obj.(*storagev1.VolumeAttachment)
 	if oldObj != nil {
 		// skip add if node name is identical
@@ -207,7 +207,7 @@ func (g *graphPopulator) updateVolumeAttachment(oldObj, obj interface{}, rpId st
 	g.graph.AddVolumeAttachment(attachment.Name, attachment.Spec.NodeName)
 }
 
-func (g *graphPopulator) deleteVolumeAttachment(obj interface{}, rpId string) {
+func (g *graphPopulator) deleteVolumeAttachment(obj interface{}) {
 	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		obj = tombstone.Obj
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
@@ -265,13 +265,13 @@ func (c *DiscoveryController) enqueue(obj *apiextensions.CustomResourceDefinitio
 	}
 }
 
-func (c *DiscoveryController) addCustomResourceDefinition(obj interface{}, rpId string) {
+func (c *DiscoveryController) addCustomResourceDefinition(obj interface{}) {
 	castObj := obj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Adding customresourcedefinition %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *DiscoveryController) updateCustomResourceDefinition(oldObj, newObj interface{}, rpId string) {
+func (c *DiscoveryController) updateCustomResourceDefinition(oldObj, newObj interface{}) {
 	castNewObj := newObj.(*apiextensions.CustomResourceDefinition)
 	castOldObj := oldObj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Updating customresourcedefinition %s", castOldObj.Name)
@@ -281,7 +281,7 @@ func (c *DiscoveryController) updateCustomResourceDefinition(oldObj, newObj inte
 	c.enqueue(castOldObj)
 }
 
-func (c *DiscoveryController) deleteCustomResourceDefinition(obj interface{}, rpId string) {
+func (c *DiscoveryController) deleteCustomResourceDefinition(obj interface{}) {
 	castObj, ok := obj.(*apiextensions.CustomResourceDefinition)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -177,7 +177,7 @@ func NewCustomResourceDefinitionHandler(
 	}
 	crdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: ret.updateCustomResourceDefinition,
-		DeleteFunc: func(obj interface{}, rpId string) {
+		DeleteFunc: func(obj interface{}) {
 			ret.removeDeadStorage()
 		},
 	})
@@ -368,7 +368,7 @@ func (r *crdHandler) serveScale(w http.ResponseWriter, req *http.Request, reques
 	}
 }
 
-func (r *crdHandler) updateCustomResourceDefinition(oldObj, newObj interface{}, rpId string) {
+func (r *crdHandler) updateCustomResourceDefinition(oldObj, newObj interface{}) {
 	oldCRD := oldObj.(*apiextensions.CustomResourceDefinition)
 	newCRD := newObj.(*apiextensions.CustomResourceDefinition)
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -317,7 +317,7 @@ func (c *CRDFinalizer) enqueue(obj *apiextensions.CustomResourceDefinition) {
 	c.queue.Add(key)
 }
 
-func (c *CRDFinalizer) addCustomResourceDefinition(obj interface{}, rpId string) {
+func (c *CRDFinalizer) addCustomResourceDefinition(obj interface{}) {
 	castObj := obj.(*apiextensions.CustomResourceDefinition)
 	// only queue deleted things
 	if !castObj.DeletionTimestamp.IsZero() && apiextensions.CRDHasFinalizer(castObj, apiextensions.CustomResourceCleanupFinalizer) {
@@ -325,7 +325,7 @@ func (c *CRDFinalizer) addCustomResourceDefinition(obj interface{}, rpId string)
 	}
 }
 
-func (c *CRDFinalizer) updateCustomResourceDefinition(oldObj, newObj interface{}, rpId string) {
+func (c *CRDFinalizer) updateCustomResourceDefinition(oldObj, newObj interface{}) {
 	oldCRD := oldObj.(*apiextensions.CustomResourceDefinition)
 	newCRD := newObj.(*apiextensions.CustomResourceDefinition)
 	// only queue deleted things that haven't been finalized by us

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
@@ -243,19 +243,19 @@ func (c *ConditionController) enqueue(obj *apiextensions.CustomResourceDefinitio
 	c.queue.Add(key)
 }
 
-func (c *ConditionController) addCustomResourceDefinition(obj interface{}, rpId string) {
+func (c *ConditionController) addCustomResourceDefinition(obj interface{}) {
 	castObj := obj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Adding %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *ConditionController) updateCustomResourceDefinition(obj, _ interface{}, rpId string) {
+func (c *ConditionController) updateCustomResourceDefinition(obj, _ interface{}) {
 	castObj := obj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Updating %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *ConditionController) deleteCustomResourceDefinition(obj interface{}, rpId string) {
+func (c *ConditionController) deleteCustomResourceDefinition(obj interface{}) {
 	castObj, ok := obj.(*apiextensions.CustomResourceDefinition)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
@@ -220,19 +220,19 @@ func (c *Controller) updateSpecLocked() error {
 	return c.openAPIService.UpdateSpec(mergeSpecs(c.staticSpec, crdSpecs...))
 }
 
-func (c *Controller) addCustomResourceDefinition(obj interface{}, rpId string) {
+func (c *Controller) addCustomResourceDefinition(obj interface{}) {
 	castObj := obj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Adding customresourcedefinition %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *Controller) updateCustomResourceDefinition(oldObj, newObj interface{}, rpId string) {
+func (c *Controller) updateCustomResourceDefinition(oldObj, newObj interface{}) {
 	castNewObj := newObj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Updating customresourcedefinition %s", castNewObj.Name)
 	c.enqueue(castNewObj)
 }
 
-func (c *Controller) deleteCustomResourceDefinition(obj interface{}, rpId string) {
+func (c *Controller) deleteCustomResourceDefinition(obj interface{}) {
 	castObj, ok := obj.(*apiextensions.CustomResourceDefinition)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -336,19 +336,19 @@ func (c *NamingConditionController) enqueue(obj *apiextensions.CustomResourceDef
 	c.queue.Add(key)
 }
 
-func (c *NamingConditionController) addCustomResourceDefinition(obj interface{}, rpId string) {
+func (c *NamingConditionController) addCustomResourceDefinition(obj interface{}) {
 	castObj := obj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Adding %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *NamingConditionController) updateCustomResourceDefinition(obj, _ interface{}, rpId string) {
+func (c *NamingConditionController) updateCustomResourceDefinition(obj, _ interface{}) {
 	castObj := obj.(*apiextensions.CustomResourceDefinition)
 	klog.V(4).Infof("Updating %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *NamingConditionController) deleteCustomResourceDefinition(obj interface{}, rpId string) {
+func (c *NamingConditionController) deleteCustomResourceDefinition(obj interface{}) {
 	castObj, ok := obj.(*apiextensions.CustomResourceDefinition)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
@@ -54,9 +54,9 @@ func NewMutatingWebhookConfigurationManager(f informers.SharedInformerFactory) g
 
 	// On any change, rebuild the config
 	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(_ interface{}, rpId string) { manager.updateConfiguration() },
-		UpdateFunc: func(_, _ interface{}, rpId string) { manager.updateConfiguration() },
-		DeleteFunc: func(_ interface{}, rpId string) { manager.updateConfiguration() },
+		AddFunc:    func(_ interface{}) { manager.updateConfiguration() },
+		UpdateFunc: func(_, _ interface{}) { manager.updateConfiguration() },
+		DeleteFunc: func(_ interface{}) { manager.updateConfiguration() },
 	})
 
 	return manager

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
@@ -54,9 +54,9 @@ func NewValidatingWebhookConfigurationManager(f informers.SharedInformerFactory)
 
 	// On any change, rebuild the config
 	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(_ interface{}, rpId string) { manager.updateConfiguration() },
-		UpdateFunc: func(_, _ interface{}, rpId string) { manager.updateConfiguration() },
-		DeleteFunc: func(_ interface{}, rpId string) { manager.updateConfiguration() },
+		AddFunc:    func(_ interface{}) { manager.updateConfiguration() },
+		UpdateFunc: func(_, _ interface{}) { manager.updateConfiguration() },
+		DeleteFunc: func(_ interface{}) { manager.updateConfiguration() },
 	})
 
 	return manager

--- a/staging/src/k8s.io/apiserver/pkg/storage/datapartition/datapartitionmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/datapartition/datapartitionmanager.go
@@ -126,7 +126,7 @@ func (m *DataPartitionConfigManager) syncDataPartition() error {
 	return nil
 }
 
-func (m *DataPartitionConfigManager) addDataPartition(obj interface{}, rpId string) {
+func (m *DataPartitionConfigManager) addDataPartition(obj interface{}) {
 	dp := obj.(*v1.DataPartitionConfig)
 	if dp.DeletionTimestamp != nil {
 		return
@@ -161,7 +161,7 @@ func (m *DataPartitionConfigManager) addDataPartition(obj interface{}, rpId stri
 	}
 }
 
-func (m *DataPartitionConfigManager) updateDataPartition(old, cur interface{}, rpId string) {
+func (m *DataPartitionConfigManager) updateDataPartition(old, cur interface{}) {
 	curDp := cur.(*v1.DataPartitionConfig)
 	oldDp := old.(*v1.DataPartitionConfig)
 
@@ -199,7 +199,7 @@ func (m *DataPartitionConfigManager) updateDataPartition(old, cur interface{}, r
 	}
 }
 
-func (m *DataPartitionConfigManager) deleteDataPartition(obj interface{}, rpId string) {
+func (m *DataPartitionConfigManager) deleteDataPartition(obj interface{}) {
 	dp, ok := obj.(*v1.DataPartitionConfig)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagecluster/storageclustermanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagecluster/storageclustermanager.go
@@ -130,7 +130,7 @@ func (s *StorageClusterManager) syncClusters() error {
 	return utilerrors.NewAggregate(aggErr)
 }
 
-func (s *StorageClusterManager) addCluster(obj interface{}, rpId string) {
+func (s *StorageClusterManager) addCluster(obj interface{}) {
 	c := obj.(*v1.StorageCluster)
 	if c.DeletionTimestamp != nil {
 		return
@@ -169,7 +169,7 @@ func (s *StorageClusterManager) addCluster(obj interface{}, rpId string) {
 	klog.V(4).Infof("mux released addCluster.")
 }
 
-func (s *StorageClusterManager) updateCluster(old, cur interface{}, rpId string) {
+func (s *StorageClusterManager) updateCluster(old, cur interface{}) {
 	curCluster := cur.(*v1.StorageCluster)
 	oldCluster := old.(*v1.StorageCluster)
 
@@ -217,7 +217,7 @@ func (s *StorageClusterManager) updateCluster(old, cur interface{}, rpId string)
 	}
 }
 
-func (s *StorageClusterManager) deleteCluster(obj interface{}, rpId string) {
+func (s *StorageClusterManager) deleteCluster(obj interface{}) {
 	cluster, ok := obj.(*v1.StorageCluster)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagecluster/tenantstoragemapmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagecluster/tenantstoragemapmanager.go
@@ -130,7 +130,7 @@ func (ts *TenantStorageMapManager) syncTenants() error {
 	return utilerrors.NewAggregate(aggErr)
 }
 
-func (ts *TenantStorageMapManager) addTenant(obj interface{}, rpId string) {
+func (ts *TenantStorageMapManager) addTenant(obj interface{}) {
 	tenant := obj.(*v1.Tenant)
 	if tenant.DeletionTimestamp != nil {
 		return
@@ -172,7 +172,7 @@ func (ts *TenantStorageMapManager) addTenant(obj interface{}, rpId string) {
 	klog.V(4).Infof("mux released addTenant.")
 }
 
-func (ts *TenantStorageMapManager) updateTenant(old, cur interface{}, rpId string) {
+func (ts *TenantStorageMapManager) updateTenant(old, cur interface{}) {
 	curTenant := cur.(*v1.Tenant)
 	oldTenant := old.(*v1.Tenant)
 
@@ -222,7 +222,7 @@ func (ts *TenantStorageMapManager) updateTenant(old, cur interface{}, rpId strin
 	}
 }
 
-func (ts *TenantStorageMapManager) deleteTenant(obj interface{}, rpId string) {
+func (ts *TenantStorageMapManager) deleteTenant(obj interface{}) {
 	tenant, ok := obj.(*v1.Tenant)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/dynamic/dynamic.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/dynamic/dynamic.go
@@ -129,13 +129,13 @@ func NewBackend(c *Config) (audit.Backend, error) {
 	manager.delegates.Store(syncedDelegates{})
 
 	c.Informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			manager.addSink(obj.(*auditregv1alpha1.AuditSink))
 		},
-		UpdateFunc: func(oldObj, newObj interface{}, rpId string) {
+		UpdateFunc: func(oldObj, newObj interface{}) {
 			manager.updateSink(oldObj.(*auditregv1alpha1.AuditSink), newObj.(*auditregv1alpha1.AuditSink))
 		},
-		DeleteFunc: func(obj interface{}, rpId string) {
+		DeleteFunc: func(obj interface{}) {
 			sink, ok := obj.(*auditregv1alpha1.AuditSink)
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/client-go/datapartition/apiserverconfigmanager.go
+++ b/staging/src/k8s.io/client-go/datapartition/apiserverconfigmanager.go
@@ -194,7 +194,7 @@ func syncApiServerConfig(a *APIServerConfigManager) error {
 	return nil
 }
 
-func (a *APIServerConfigManager) updateApiServer(old, cur interface{}, rpId string) {
+func (a *APIServerConfigManager) updateApiServer(old, cur interface{}) {
 	curEp := cur.(*v1.Endpoints)
 	oldEp := old.(*v1.Endpoints)
 	if !isApiServerEndpoint(curEp) || !isApiServerEndpoint(oldEp) {
@@ -226,7 +226,7 @@ func (a *APIServerConfigManager) updateApiServer(old, cur interface{}, rpId stri
 }
 
 // It's ok not to test here since Kubernetes endpoints should never be deleted
-func (a *APIServerConfigManager) deleteApiServer(obj interface{}, rpId string) {
+func (a *APIServerConfigManager) deleteApiServer(obj interface{}) {
 	ep, ok := obj.(*v1.Endpoints)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer_test.go
@@ -57,7 +57,7 @@ func TestDynamicSharedInformerFactory(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *unstructured.Unstructured) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					AddFunc: func(obj interface{}, rpId string) {
+					AddFunc: func(obj interface{}) {
 						rcvCh <- obj.(*unstructured.Unstructured)
 					},
 				}
@@ -80,7 +80,7 @@ func TestDynamicSharedInformerFactory(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *unstructured.Unstructured) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					UpdateFunc: func(old, updated interface{}, rpId string) {
+					UpdateFunc: func(old, updated interface{}) {
 						rcvCh <- updated.(*unstructured.Unstructured)
 					},
 				}
@@ -102,7 +102,7 @@ func TestDynamicSharedInformerFactory(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *unstructured.Unstructured) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					DeleteFunc: func(obj interface{}, rpId string) {
+					DeleteFunc: func(obj interface{}) {
 						rcvCh <- obj.(*unstructured.Unstructured)
 					},
 				}

--- a/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
+++ b/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
@@ -43,7 +43,7 @@ func TestFakeClient(t *testing.T) {
 	informers := informers.NewSharedInformerFactory(client, 0)
 	podInformer := informers.Core().V1().Pods().Informer()
 	podInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			pod := obj.(*v1.Pod)
 			t.Logf("pod added: %s/%s", pod.Namespace, pod.Name)
 			pods <- pod

--- a/staging/src/k8s.io/client-go/examples/workqueue/main.go
+++ b/staging/src/k8s.io/client-go/examples/workqueue/main.go
@@ -173,19 +173,19 @@ func main() {
 	// Note that when we finally process the item from the workqueue, we might see a newer version
 	// of the Pod than the version which was responsible for triggering the update.
 	indexer, informer := cache.NewIndexerInformer(podListWatcher, &v1.Pod{}, 0, cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(obj)
 			if err == nil {
 				queue.Add(key)
 			}
 		},
-		UpdateFunc: func(old interface{}, new interface{}, rpId string) {
+		UpdateFunc: func(old interface{}, new interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(new)
 			if err == nil {
 				queue.Add(key)
 			}
 		},
-		DeleteFunc: func(obj interface{}, rpId string) {
+		DeleteFunc: func(obj interface{}) {
 			// IndexerInformer uses a delta queue, therefore for deletes we have to use this
 			// key function.
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_multitenancy_test.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_multitenancy_test.go
@@ -56,7 +56,7 @@ func TestMetadataSharedInformerFactoryWithMultiTenancy(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *metav1.PartialObjectMetadata) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					AddFunc: func(obj interface{}, rpId string) {
+					AddFunc: func(obj interface{}) {
 						rcvCh <- obj.(*metav1.PartialObjectMetadata)
 					},
 				}
@@ -83,7 +83,7 @@ func TestMetadataSharedInformerFactoryWithMultiTenancy(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *metav1.PartialObjectMetadata) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					UpdateFunc: func(old, updated interface{}, rpId string) {
+					UpdateFunc: func(old, updated interface{}) {
 						rcvCh <- updated.(*metav1.PartialObjectMetadata)
 					},
 				}
@@ -106,7 +106,7 @@ func TestMetadataSharedInformerFactoryWithMultiTenancy(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *metav1.PartialObjectMetadata) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					DeleteFunc: func(obj interface{}, rpId string) {
+					DeleteFunc: func(obj interface{}) {
 						rcvCh <- obj.(*metav1.PartialObjectMetadata)
 					},
 				}

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_test.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_test.go
@@ -64,7 +64,7 @@ func TestMetadataSharedInformerFactory(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *metav1.PartialObjectMetadata) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					AddFunc: func(obj interface{}, rpId string) {
+					AddFunc: func(obj interface{}) {
 						rcvCh <- obj.(*metav1.PartialObjectMetadata)
 					},
 				}
@@ -90,7 +90,7 @@ func TestMetadataSharedInformerFactory(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *metav1.PartialObjectMetadata) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					UpdateFunc: func(old, updated interface{}, rpId string) {
+					UpdateFunc: func(old, updated interface{}) {
 						rcvCh <- updated.(*metav1.PartialObjectMetadata)
 					},
 				}
@@ -112,7 +112,7 @@ func TestMetadataSharedInformerFactory(t *testing.T) {
 			},
 			handler: func(rcvCh chan<- *metav1.PartialObjectMetadata) *cache.ResourceEventHandlerFuncs {
 				return &cache.ResourceEventHandlerFuncs{
-					DeleteFunc: func(obj interface{}, rpId string) {
+					DeleteFunc: func(obj interface{}) {
 						rcvCh <- obj.(*metav1.PartialObjectMetadata)
 					},
 				}

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -208,30 +208,29 @@ type ResourceEventHandler interface {
 // as few of the notification functions as you want while still implementing
 // ResourceEventHandler.
 type ResourceEventHandlerFuncs struct {
-	AddFunc            func(obj interface{}, rpId string)
-	UpdateFunc         func(oldObj, newObj interface{}, rpId string)
-	DeleteFunc         func(obj interface{}, rpId string)
-	ResourceProviderId string
+	AddFunc            func(obj interface{})
+	UpdateFunc         func(oldObj, newObj interface{})
+	DeleteFunc         func(obj interface{})
 }
 
 // OnAdd calls AddFunc if it's not nil.
 func (r ResourceEventHandlerFuncs) OnAdd(obj interface{}) {
 	if r.AddFunc != nil {
-		r.AddFunc(obj, r.ResourceProviderId)
+		r.AddFunc(obj)
 	}
 }
 
 // OnUpdate calls UpdateFunc if it's not nil.
 func (r ResourceEventHandlerFuncs) OnUpdate(oldObj, newObj interface{}) {
 	if r.UpdateFunc != nil {
-		r.UpdateFunc(oldObj, newObj, r.ResourceProviderId)
+		r.UpdateFunc(oldObj, newObj)
 	}
 }
 
 // OnDelete calls DeleteFunc if it's not nil.
 func (r ResourceEventHandlerFuncs) OnDelete(obj interface{}) {
 	if r.DeleteFunc != nil {
-		r.DeleteFunc(obj, r.ResourceProviderId)
+		r.DeleteFunc(obj)
 	}
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -135,10 +135,10 @@ func ExampleNewInformer() {
 		&v1.Pod{},
 		time.Millisecond*100,
 		ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}, rpId string) {
+			AddFunc: func(obj interface{}) {
 				source.Delete(obj.(runtime.Object))
 			},
-			DeleteFunc: func(obj interface{}, rpId string) {
+			DeleteFunc: func(obj interface{}) {
 				key, err := DeletionHandlingMetaNamespaceKeyFunc(obj)
 				if err != nil {
 					key = "oops something went wrong with the key"
@@ -148,7 +148,6 @@ func ExampleNewInformer() {
 				deletionCounter <- key
 			},
 		},
-		"resourceProviderId",
 	)
 
 	// Run the controller and run it until we close stop.
@@ -212,11 +211,10 @@ func TestHammerController(t *testing.T) {
 		&v1.Pod{},
 		time.Millisecond*100,
 		ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}, rpId string) { recordFunc("add", obj) },
-			UpdateFunc: func(oldObj, newObj interface{}, rpId string) { recordFunc("update", newObj) },
-			DeleteFunc: func(obj interface{}, rpId string) { recordFunc("delete", obj) },
+			AddFunc:    func(obj interface{}) { recordFunc("add", obj) },
+			UpdateFunc: func(oldObj, newObj interface{}) { recordFunc("update", newObj) },
+			DeleteFunc: func(obj interface{}) { recordFunc("delete", obj) },
 		},
-		"resourceProviderId",
 	)
 
 	if controller.HasSynced() {
@@ -368,7 +366,7 @@ func TestUpdate(t *testing.T) {
 		&v1.Pod{},
 		0,
 		ResourceEventHandlerFuncs{
-			UpdateFunc: func(oldObj, newObj interface{}, rpId string) {
+			UpdateFunc: func(oldObj, newObj interface{}) {
 				o, n := oldObj.(*v1.Pod), newObj.(*v1.Pod)
 				from, to := o.Labels["check"], n.Labels["check"]
 				if !allowedTransitions[pair{from, to}] {
@@ -378,11 +376,10 @@ func TestUpdate(t *testing.T) {
 					source.Delete(n)
 				}
 			},
-			DeleteFunc: func(obj interface{}, rpId string) {
+			DeleteFunc: func(obj interface{}) {
 				testDoneWG.Done()
 			},
 		},
-		"resourceProviderId",
 	)
 
 	// Run the controller and run it until we close stop.

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
@@ -62,7 +62,7 @@ func TestMutationDetector(t *testing.T) {
 	}
 	informer.AddEventHandler(
 		ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}, rpId string) {
+			AddFunc: func(obj interface{}) {
 				addReceived <- true
 			},
 		},

--- a/staging/src/k8s.io/client-go/tools/cache/processor_listener_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/processor_listener_test.go
@@ -37,7 +37,7 @@ func BenchmarkListener(b *testing.B) {
 	b.SetParallelism(concurrencyLevel)
 	// Preallocate enough space so that benchmark does not run out of it
 	pl := newProcessListener(&ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			swg.Done()
 		},
 	}, 0, 0, time.Now(), 1024*1024)

--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
@@ -110,19 +110,19 @@ func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (
 	e := newEventProcessor(ch)
 
 	indexer, informer := cache.NewIndexerInformer(lw, objType, 0, cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			e.push(watch.Event{
 				Type:   watch.Added,
 				Object: obj.(runtime.Object),
 			})
 		},
-		UpdateFunc: func(old, new interface{}, rpId string) {
+		UpdateFunc: func(old, new interface{}) {
 			e.push(watch.Event{
 				Type:   watch.Modified,
 				Object: new.(runtime.Object),
 			})
 		},
-		DeleteFunc: func(obj interface{}, rpId string) {
+		DeleteFunc: func(obj interface{}) {
 			staleObj, stale := obj.(cache.DeletedFinalStateUnknown)
 			if stale {
 				// We have no means of passing the additional information down using

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go
@@ -146,19 +146,19 @@ func (c *APIServiceRegistrationController) enqueue(obj *apiregistration.APIServi
 	c.queue.Add(key)
 }
 
-func (c *APIServiceRegistrationController) addAPIService(obj interface{}, rpId string) {
+func (c *APIServiceRegistrationController) addAPIService(obj interface{}) {
 	castObj := obj.(*apiregistration.APIService)
 	klog.V(4).Infof("Adding %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *APIServiceRegistrationController) updateAPIService(obj, _ interface{}, rpId string) {
+func (c *APIServiceRegistrationController) updateAPIService(obj, _ interface{}) {
 	castObj := obj.(*apiregistration.APIService)
 	klog.V(4).Infof("Updating %s", castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *APIServiceRegistrationController) deleteAPIService(obj interface{}, rpId string) {
+func (c *APIServiceRegistrationController) deleteAPIService(obj interface{}) {
 	castObj, ok := obj.(*apiregistration.APIService)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller.go
@@ -103,15 +103,15 @@ func NewAutoRegisterController(apiServiceInformer informers.APIServiceInformer, 
 	c.syncHandler = c.checkAPIService
 
 	apiServiceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			cast := obj.(*apiregistration.APIService)
 			c.queue.Add(NameWithMultiTenancy(cast))
 		},
-		UpdateFunc: func(_, obj interface{}, rpId string) {
+		UpdateFunc: func(_, obj interface{}) {
 			cast := obj.(*apiregistration.APIService)
 			c.queue.Add(NameWithMultiTenancy(cast))
 		},
-		DeleteFunc: func(obj interface{}, rpId string) {
+		DeleteFunc: func(obj interface{}) {
 			cast, ok := obj.(*apiregistration.APIService)
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -427,19 +427,19 @@ func (c *AvailableConditionController) enqueue(obj *apiregistration.APIService) 
 	c.queue.Add(key)
 }
 
-func (c *AvailableConditionController) addAPIService(obj interface{}, rpId string) {
+func (c *AvailableConditionController) addAPIService(obj interface{}) {
 	castObj := obj.(*apiregistration.APIService)
 	klog.V(4).Infof("Adding %s/%s", castObj.Tenant, castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *AvailableConditionController) updateAPIService(obj, _ interface{}, rpId string) {
+func (c *AvailableConditionController) updateAPIService(obj, _ interface{}) {
 	castObj := obj.(*apiregistration.APIService)
 	klog.V(4).Infof("Updating %s/%s", castObj.Tenant, castObj.Name)
 	c.enqueue(castObj)
 }
 
-func (c *AvailableConditionController) deleteAPIService(obj interface{}, rpId string) {
+func (c *AvailableConditionController) deleteAPIService(obj interface{}) {
 	castObj, ok := obj.(*apiregistration.APIService)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -481,19 +481,19 @@ func (c *AvailableConditionController) getAPIServicesFor(obj runtime.Object) []*
 
 // TODO, think of a way to avoid checking on every service manipulation
 
-func (c *AvailableConditionController) addService(obj interface{}, rpId string) {
+func (c *AvailableConditionController) addService(obj interface{}) {
 	for _, apiService := range c.getAPIServicesFor(obj.(*v1.Service)) {
 		c.enqueue(apiService)
 	}
 }
 
-func (c *AvailableConditionController) updateService(obj, _ interface{}, rpId string) {
+func (c *AvailableConditionController) updateService(obj, _ interface{}) {
 	for _, apiService := range c.getAPIServicesFor(obj.(*v1.Service)) {
 		c.enqueue(apiService)
 	}
 }
 
-func (c *AvailableConditionController) deleteService(obj interface{}, rpId string) {
+func (c *AvailableConditionController) deleteService(obj interface{}) {
 	castObj, ok := obj.(*v1.Service)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -512,19 +512,19 @@ func (c *AvailableConditionController) deleteService(obj interface{}, rpId strin
 	}
 }
 
-func (c *AvailableConditionController) addEndpoints(obj interface{}, rpId string) {
+func (c *AvailableConditionController) addEndpoints(obj interface{}) {
 	for _, apiService := range c.getAPIServicesFor(obj.(*v1.Endpoints)) {
 		c.enqueue(apiService)
 	}
 }
 
-func (c *AvailableConditionController) updateEndpoints(obj, _ interface{}, rpId string) {
+func (c *AvailableConditionController) updateEndpoints(obj, _ interface{}) {
 	for _, apiService := range c.getAPIServicesFor(obj.(*v1.Endpoints)) {
 		c.enqueue(apiService)
 	}
 }
 
-func (c *AvailableConditionController) deleteEndpoints(obj interface{}, rpId string) {
+func (c *AvailableConditionController) deleteEndpoints(obj interface{}) {
 	castObj, ok := obj.(*v1.Endpoints)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -585,11 +585,11 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 	klog.Infof("Setting up informers for Azure cloud provider")
 	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
 	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			node := obj.(*v1.Node)
 			az.updateNodeCaches(nil, node)
 		},
-		UpdateFunc: func(prev, obj interface{}, rpId string) {
+		UpdateFunc: func(prev, obj interface{}) {
 			prevNode := prev.(*v1.Node)
 			newNode := obj.(*v1.Node)
 			if newNode.Labels[v1.LabelZoneFailureDomain] ==
@@ -598,7 +598,7 @@ func (az *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 			}
 			az.updateNodeCaches(prevNode, newNode)
 		},
-		DeleteFunc: func(obj interface{}, rpId string) {
+		DeleteFunc: func(obj interface{}) {
 			node, isNode := obj.(*v1.Node)
 			// We can get DeletedFinalStateUnknown instead of *v1.Node here
 			// and we need to handle that correctly.

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go
@@ -688,11 +688,11 @@ func (g *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 	klog.Infof("Setting up informers for Cloud")
 	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
 	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			node := obj.(*v1.Node)
 			g.updateNodeZones(nil, node)
 		},
-		UpdateFunc: func(prev, obj interface{}, rpId string) {
+		UpdateFunc: func(prev, obj interface{}) {
 			prevNode := prev.(*v1.Node)
 			newNode := obj.(*v1.Node)
 			if newNode.Labels[v1.LabelZoneFailureDomain] ==
@@ -701,7 +701,7 @@ func (g *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 			}
 			g.updateNodeZones(prevNode, newNode)
 		},
-		DeleteFunc: func(obj interface{}, rpId string) {
+		DeleteFunc: func(obj interface{}) {
 			node, isNode := obj.(*v1.Node)
 			// We can get DeletedFinalStateUnknown instead of *v1.Node here
 			// and we need to handle that correctly.

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_clusterid.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_clusterid.go
@@ -75,7 +75,7 @@ func (g *Cloud) watchClusterID(stop <-chan struct{}) {
 	}
 
 	mapEventHandler := cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}, rpId string) {
+		AddFunc: func(obj interface{}) {
 			m, ok := obj.(*v1.ConfigMap)
 			if !ok || m == nil {
 				klog.Errorf("Expected v1.ConfigMap, item=%+v, typeIsOk=%v", obj, ok)
@@ -89,7 +89,7 @@ func (g *Cloud) watchClusterID(stop <-chan struct{}) {
 			klog.V(4).Infof("Observed new configmap for clusteriD: %v, %v; setting local values", m.Name, m.Data)
 			g.ClusterID.update(m)
 		},
-		UpdateFunc: func(old, cur interface{}, rpId string) {
+		UpdateFunc: func(old, cur interface{}) {
 			m, ok := cur.(*v1.ConfigMap)
 			if !ok || m == nil {
 				klog.Errorf("Expected v1.ConfigMap, item=%+v, typeIsOk=%v", cur, ok)

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -1407,7 +1407,7 @@ func (vs *VSphere) HasClusterID() bool {
 }
 
 // Notification handler when node is added into k8s cluster.
-func (vs *VSphere) NodeAdded(obj interface{}, rpId string) {
+func (vs *VSphere) NodeAdded(obj interface{}) {
 	node, ok := obj.(*v1.Node)
 	if node == nil || !ok {
 		klog.Warningf("NodeAdded: unrecognized object %+v", obj)
@@ -1421,7 +1421,7 @@ func (vs *VSphere) NodeAdded(obj interface{}, rpId string) {
 }
 
 // Notification handler when node is removed from k8s cluster.
-func (vs *VSphere) NodeDeleted(obj interface{}, rpId string) {
+func (vs *VSphere) NodeDeleted(obj interface{}) {
 	node, ok := obj.(*v1.Node)
 	if node == nil || !ok {
 		klog.Warningf("NodeDeleted: unrecognized object %+v", obj)

--- a/staging/src/k8s.io/sample-controller/controller.go
+++ b/staging/src/k8s.io/sample-controller/controller.go
@@ -116,7 +116,7 @@ func NewController(
 	// Set up an event handler for when Foo resources change
 	fooInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.enqueueFoo,
-		UpdateFunc: func(old, new interface{}, rpId string) {
+		UpdateFunc: func(old, new interface{}) {
 			controller.enqueueFoo(new)
 		},
 	})
@@ -128,7 +128,7 @@ func NewController(
 	// https://github.com/kubernetes/community/blob/8cafef897a22026d42f5e5bb3f104febe7e29830/contributors/devel/controllers.md
 	deploymentInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.handleObject,
-		UpdateFunc: func(old, new interface{}, rpId string) {
+		UpdateFunc: func(old, new interface{}) {
 			newDepl := new.(*appsv1.Deployment)
 			oldDepl := old.(*appsv1.Deployment)
 			if newDepl.ResourceVersion == oldDepl.ResourceVersion {
@@ -136,7 +136,7 @@ func NewController(
 				// Two different versions of the same Deployment will always have different RVs.
 				return
 			}
-			controller.handleObject(new, rpId)
+			controller.handleObject(new)
 		},
 		DeleteFunc: controller.handleObject,
 	})
@@ -335,7 +335,7 @@ func (c *Controller) updateFooStatus(foo *samplev1alpha1.Foo, deployment *appsv1
 // enqueueFoo takes a Foo resource and converts it into a namespace/name
 // string which is then put onto the work queue. This method should *not* be
 // passed resources of any type other than Foo.
-func (c *Controller) enqueueFoo(obj interface{}, rpId string) {
+func (c *Controller) enqueueFoo(obj interface{}) {
 	var key string
 	var err error
 	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
@@ -350,7 +350,7 @@ func (c *Controller) enqueueFoo(obj interface{}, rpId string) {
 // objects metadata.ownerReferences field for an appropriate OwnerReference.
 // It then enqueues that Foo resource to be processed. If the object does not
 // have an appropriate OwnerReference, it will simply be skipped.
-func (c *Controller) handleObject(obj interface{}, rpId string) {
+func (c *Controller) handleObject(obj interface{}) {
 	var object metav1.Object
 	var ok bool
 	if object, ok = obj.(metav1.Object); !ok {


### PR DESCRIPTION
As we discussed, making event handler signature changes to get resource provider id is not idea. This change has two major changes:
1. Remove rpId from event handler
2. Change array of node informers/listers to map

Test done:
1TP/2RP, able to scheduler to both RPs. But pods for system tenant keeps getting restarted. It is out of scope for this PR.

```
ubuntu@ip-172-30-0-148:~$ kubectl get pods -A -T
TENANT   NAMESPACE     NAME                                  HASHKEY               READY   STATUS              RESTARTS   AGE
aaa      namespace-a   nginx-deployment-a-676f445fdf-jr8w8   8198298326532790695   1/1     Running             0          28m
system   default       nginx-deployment-676f445fdf-q8xmt     2990775166439868131   1/1     Running             0          17s
system   kube-system   kube-dns-6fdcc959b4-qsdpc             7036721288620706801   0/3     ContainerCreating   0          17s
```
