### PR TITLE
Use kubeconfig to replace TP api server endpoints in kubelet

### DIFF
--- a/cmd/kubelet/app/BUILD
+++ b/cmd/kubelet/app/BUILD
@@ -39,6 +39,7 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/cmd/kubelet/app",
     deps = [
+        "//cmd/genutils:go_default_library",
         "//cmd/kubelet/app/options:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
@@ -136,6 +137,7 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//staging/src/k8s.io/client-go/util/certificate:go_default_library",
+        "//staging/src/k8s.io/client-go/util/clientutil:go_default_library",
         "//staging/src/k8s.io/client-go/util/connrotation:go_default_library",
         "//staging/src/k8s.io/client-go/util/keyutil:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",

--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -55,7 +55,7 @@ const defaultRootDir = "/var/lib/kubelet"
 // In general, please try to avoid adding flags or configuration fields,
 // we already have a confusingly large amount of them.
 type KubeletFlags struct {
-	TenantPartitionApiservers []string
+	TenantPartitionKubeConfig string
 	KubeConfig                string
 	BootstrapKubeconfig       string
 
@@ -362,7 +362,7 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 
 	//TODO: post POC, move this to a separated kubeconfig file dedicated for tenant servers
 	//
-	fs.StringSliceVar(&f.TenantPartitionApiservers, "tenant-servers", f.TenantPartitionApiservers, "Comma separated string representing tenant api-server URLs.")
+	fs.StringVar(&f.TenantPartitionKubeConfig, "tenant-server-kubeconfig", f.TenantPartitionKubeConfig, "Comma separated string representing kubeconfig files point to tenant api servers.")
 	fs.StringVar(&f.KubeletConfigFile, "config", f.KubeletConfigFile, "The Kubelet will load its initial configuration from this file. The path may be absolute or relative; relative paths start at the Kubelet's current working directory. Omit this flag to use the built-in default configuration values. Command-line flags override configuration from this file.")
 	fs.StringVar(&f.KubeConfig, "kubeconfig", f.KubeConfig, "Path to kubeconfig files, specifying how to connect to  API servers. Providing --kubeconfig enables API server mode, omitting --kubeconfig enables standalone mode.")
 

--- a/docs/setup-guide/scale-out-local-dev-setup.md
+++ b/docs/setup-guide/scale-out-local-dev-setup.md
@@ -4,13 +4,13 @@
 
 1. Two Tenant Partitions
 
-1. Two Resource Partitions (3/2/2021)
+1. Two Resource Partitions
 
-1. HA proxy
+1. HA proxy (not required if not using cloud KCM)
 
 ## Prerequsite
 
-1. 3 dev box (tested on ubuntu 16.04), 1 for RP, 2 for TPs. Record ip as TP1_IP, TP2_IP, RP_IP
+1. 4 dev box (tested on ubuntu 16.04), 2 for RP, 2 for TPs. Record ip as TP1_IP, TP2_IP, RP1_IP, RP2_IP
 
 1. One dev box for HA proxy, can share with dev boxes used for TP or RP. Record ip as PROXY_IP
 
@@ -19,11 +19,11 @@
 ### Setting up HA proxy
 1. Install HA proxy 2.3.0
 
-1. Set up environment variables
+1. Set up environment variables (no changes have been made for RP2 nor tested)
 
 ```
-export TENANT_PARTITION_IP=[TP1_IP],[TP2_IP]`
-export RESOURCE_PARTITION_IP=[RP_IP]
+export TENANT_PARTITION_IP=[TP1_IP],[TP2_IP]
+export RESOURCE_PARTITION_IP=[RP1_IP]
 ```
 
 1. Run ./hack/scalability/setup_haproxy.sh (depends on your HA proxy version and environment setup, you might need to comment out some code in the script)
@@ -34,8 +34,11 @@ export RESOURCE_PARTITION_IP=[RP_IP]
 1. Set up environment variables
 
 ```
+# optional, used for cloud KCM only but not tested
 export SCALE_OUT_PROXY_IP=[PROXY_IP]
 export SCALE_OUT_PROXY_PORT=8888
+
+# required
 export IS_RESOURCE_PARTITION=false
 export RESOURCE_SERVER=[RP1_IP]<,[RP2_IP]>
 ```
@@ -48,17 +51,14 @@ Note:
 
 1. As certificates generating and sharing is confusing and time consuming in local test environment. We will use insecure mode for local test for now. Secured mode can be added back later when main goal is acchieved.
 
-### Setting up RP
+### Setting up RPs
 1. Make sure hack/arktos-up.sh can be run at the box
 
 1. Set up environment variables
 
 ```
-export SCALE_OUT_PROXY_IP=[PROXY_IP]
-export SCALE_OUT_PROXY_PORT=8888
 export IS_RESOURCE_PARTITION=true
 export TENANT_SERVER=[TP1_IP]<,[TP2_IP]>
-export TENANT_SERVERS_KUBELET=http://[TP1_IP]:8080,<http://[TP2_IP]:8080>  # this is a temp solution before kubelet is ready to use TENANT_SERVER 
 ```
 
 1. Run ./hack/arktos-up-scale-out-poc.sh

--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -16,6 +16,9 @@
 
 # set up variables
 IS_RESOURCE_PARTITION=${IS_RESOURCE_PARTITION:-"false"}
+
+# proxy is still used to start cloud KCM. Also useful for system tenant requests.
+# However, don't use proxy to query node list as there is no aggregator for multiple RPs
 SCALE_OUT_PROXY_IP=${SCALE_OUT_PROXY_IP:-}
 SCALE_OUT_PROXY_PORT=${SCALE_OUT_PROXY_PORT:-"8888"}
 TENANT_SERVER=${TENANT_SERVER:-}
@@ -53,18 +56,6 @@ else
 fi
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-
-
-TENANT_SERVERS_KUBELET=${TENANT_SERVERS_KUBELET:-}
-if [[ -z "${TENANT_SERVERS_KUBELET}" ]]; then
-  if [ "${IS_RESOURCE_PARTITION}" == "true" ]; then
-    # for POC, the kubelet_flags is used for the new temporary kubelet commandline args
-    echo ERROR: Please set TENANT_SERVERS_KUBELET in resource parition for TP. For example: TENANT_SERVERS_KUBELET=http://192.168.0.2:8080,http://192.168.0.5:8080
-    exit 1
-  fi
-else
-  KUBELET_FLAGS="--tenant-servers=${TENANT_SERVERS_KUBELET}"
-fi
 
 source "${KUBE_ROOT}/hack/lib/common-var-init.sh"
 

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -217,9 +217,9 @@ func NewAttachDetachController(
 
 	for _, nodeInformer := range nodeInformers {
 		nodeInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
-			AddFunc:            adc.nodeAdd,
-			UpdateFunc:         adc.nodeUpdate,
-			DeleteFunc:         adc.nodeDelete,
+			AddFunc:    adc.nodeAdd,
+			UpdateFunc: adc.nodeUpdate,
+			DeleteFunc: adc.nodeDelete,
 		})
 	}
 

--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//pkg/scheduler/internal/queue:go_default_library",
         "//pkg/scheduler/metrics:go_default_library",
         "//pkg/scheduler/util:go_default_library",
+        "//pkg/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/storage/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -419,9 +419,9 @@ func AddAllEventHandlers(
 	for i := range nodeInformers {
 		nodeInformers[i].Informer().AddEventHandler(
 			cache.ResourceEventHandlerFuncs{
-				AddFunc:            sched.addNodeToCache,
-				UpdateFunc:         sched.updateNodeInCache,
-				DeleteFunc:         sched.deleteNodeFromCache,
+				AddFunc:    sched.addNodeToCache,
+				UpdateFunc: sched.updateNodeInCache,
+				DeleteFunc: sched.deleteNodeFromCache,
 			},
 		)
 		klog.V(3).Infof("Add event handler to node informer %d %p", i, nodeInformers[i].Informer())

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -510,7 +510,7 @@ func (c *configFactory) CreateFromKeys(predicateKeys, priorityKeys sets.String, 
 
 	algorithmNodeLister := convertToAlgorithmNodeListers(c.nodeListers)
 	return &Config{
-		SchedulerCache: c.schedulerCache,
+		SchedulerCache:              c.schedulerCache,
 		ResourceProviderNodeListers: c.nodeListers,
 		// The scheduler only needs to consider schedulable nodes.
 		NodeListers:         algorithmNodeLister,

--- a/pkg/scheduler/internal/cache/BUILD
+++ b/pkg/scheduler/internal/cache/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/scheduler/internal/cache/debugger/BUILD
+++ b/pkg/scheduler/internal/cache/debugger/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//pkg/scheduler/internal/cache:go_default_library",
         "//pkg/scheduler/internal/queue:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
+        "//pkg/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",

--- a/pkg/util/node/BUILD
+++ b/pkg/util/node/BUILD
@@ -15,6 +15,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/util/node",
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -208,9 +208,9 @@ type ResourceEventHandler interface {
 // as few of the notification functions as you want while still implementing
 // ResourceEventHandler.
 type ResourceEventHandlerFuncs struct {
-	AddFunc            func(obj interface{})
-	UpdateFunc         func(oldObj, newObj interface{})
-	DeleteFunc         func(obj interface{})
+	AddFunc    func(obj interface{})
+	UpdateFunc func(oldObj, newObj interface{})
+	DeleteFunc func(obj interface{})
 }
 
 // OnAdd calls AddFunc if it's not nil.


### PR DESCRIPTION
> 1. Changed Kubelet TP config from ip:port pairs to kubeconfig files

Previous kubelet starts as 

root      1179  4.5  0.3 1261568 105304 pts/9  Sl+  00:48   0:00 /home/ubuntu/go/src/arktos/_output/bin/hyperkube kubelet --v=3 --vmodule= --chaos-chance=0.0 --container-runtime=remote --hostname-override=ip-172-30-0-122 --cloud-provider= --cloud-config= --address=0.0.0.0 --kubeconfig /var/run/kubernetes/kubelet.kubeconfig --feature-gates=AllAlpha=false,WorkloadInfoDefaulting=true --cpu-cfs-quota=true --enable-controller-attach-detach=true --cgroups-per-qos=true --cgroup-driver= --cgroup-root= --eviction-hard=memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5% --eviction-soft= --eviction-pressure-transition-period=1m --pod-manifest-path=/var/run/kubernetes/static-pods --fail-swap-on=false --authorization-mode=Webhook --authentication-token-webhook --client-ca-file=/var/run/kubernetes/client-ca.crt --cluster-dns=10.0.0.10 --cluster-domain=cluster.local --container-runtime-endpoint=containerRuntime,container,/run/containerd/containerd.sock;vmRuntime,vm,/run/virtlet.sock --runtime-request-timeout=2m --port=10250 **--tenant-servers=http://172.30.0.148:8080,http://172.30.0.24:8080**

Now kubelet starts as

root     29605  4.5  0.3 1392476 120020 pts/8  Sl+  03:18   0:04 /home/ubuntu/go/src/arktos/_output/local/bin/linux/amd64/hyperkube kubelet --v=3 --vmodule= --chaos-chance=0.0 --container-runtime=remote --hostname-override=ip-172-30-0-122 --cloud-provider= --cloud-config= --address=0.0.0.0 --kubeconfig /var/run/kubernetes/kubelet.kubeconfig --feature-gates=AllAlpha=false,WorkloadInfoDefaulting=true --cpu-cfs-quota=true --enable-controller-attach-detach=true --cgroups-per-qos=true --cgroup-driver= --cgroup-root= --eviction-hard=memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5% --eviction-soft= --eviction-pressure-transition-period=1m --pod-manifest-path=/var/run/kubernetes/static-pods --fail-swap-on=false --authorization-mode=Webhook --authentication-token-webhook --client-ca-file=/var/run/kubernetes/client-ca.crt --cluster-dns=10.0.0.10 --cluster-domain=cluster.local --container-runtime-endpoint=containerRuntime,container,/run/containerd/containerd.sock;vmRuntime,vm,/run/virtlet.sock --runtime-request-timeout=2m --port=10250 **--tenant-server-kubeconfig=/var/run/kubernetes/tenant-server-kubelet0.kubeconfig,/var/run/kubernetes/tenant-server-kubelet1.kubeconfig**


> 2. Tested in 1TP/2RP, 2TP/2RP. Tenant deployment created running pods successfully. System tenant pods keep restarting. This is existing syndrome.

> 3. All local generated kubeconfig files no longer points to HA proxy.
