### PR TITLE
Fix pod GC issue in scale out case

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -305,6 +305,7 @@ func startReplicationController(ctx ControllerContext) (http.Handler, bool, erro
 func startPodGCController(ctx ControllerContext) (http.Handler, bool, error) {
 	go podgc.NewPodGC(
 		ctx.ClientBuilder.ClientOrDie("pod-garbage-collector"),
+		ctx.ResourceProviderClients,
 		ctx.InformerFactory.Core().V1().Pods(),
 		int(ctx.ComponentConfig.PodGCController.TerminatedPodGCThreshold),
 	).Run(ctx.Stop)

--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -23,6 +23,10 @@ IS_RESOURCE_PARTITION=${IS_RESOURCE_PARTITION:-"false"}
 
 # proxy is still used to start cloud KCM. Also useful for system tenant requests.
 # However, don't use proxy to query node list as there is no aggregator for multiple RPs
+# As we are tring to remove HA proxy, SCALE_OUT_PROXY_IP and SCALE_OUT_PROXY_PORT are both no longer
+#  required in local cluster up. When they are not provided, they will be default to API server host
+#  ip and port. If you need proxy to be running, please set environment variable SCALE_OUT_PROXY_IP
+#  and SCALE_OUT_PROXY_PORT explicitly.
 SCALE_OUT_PROXY_IP=${SCALE_OUT_PROXY_IP:-}
 SCALE_OUT_PROXY_PORT=${SCALE_OUT_PROXY_PORT:-}
 TENANT_SERVER=${TENANT_SERVER:-}

--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -15,12 +15,16 @@
 # limitations under the License.
 
 # set up variables
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+echo KUBE_ROOT ${KUBE_ROOT}
+source "${KUBE_ROOT}/hack/lib/common-var-init.sh"
+
 IS_RESOURCE_PARTITION=${IS_RESOURCE_PARTITION:-"false"}
 
 # proxy is still used to start cloud KCM. Also useful for system tenant requests.
 # However, don't use proxy to query node list as there is no aggregator for multiple RPs
 SCALE_OUT_PROXY_IP=${SCALE_OUT_PROXY_IP:-}
-SCALE_OUT_PROXY_PORT=${SCALE_OUT_PROXY_PORT:-"8888"}
+SCALE_OUT_PROXY_PORT=${SCALE_OUT_PROXY_PORT:-}
 TENANT_SERVER=${TENANT_SERVER:-}
 RESOURCE_SERVER=${RESOURCE_SERVER:-}
 IS_SCALE_OUT=${IS_SCALE_OUT:-"true"}
@@ -31,8 +35,13 @@ echo "RESOURCE_SERVER: |${RESOURCE_SERVER}|"
 echo "IS_SCALE_OUT: |${IS_SCALE_OUT}|"
 
 if [[ -z "${SCALE_OUT_PROXY_IP}" ]]; then
-  echo ERROR: Please set SCALE_OUT_PROXY_IP.
-  exit 1
+  echo SCALE_OUT_PROXY_IP is missing. Default to local host ip ${API_HOST}
+  SCALE_OUT_PROXY_IP=${API_HOST}
+fi
+
+if [[ -z "${SCALE_OUT_PROXY_PORT}" ]]; then
+  echo SCALE_OUT_PROXY_PORT is missing. Default to local host non secure port ${API_PORT}
+  SCALE_OUT_PROXY_PORT=${API_PORT}
 fi
 
 SCALE_OUT_PROXY_ENDPOINT="https://${SCALE_OUT_PROXY_IP}:${SCALE_OUT_PROXY_PORT}/"
@@ -54,10 +63,6 @@ if [[ -z "${RESOURCE_SERVER}" ]]; then
 else
   RESOURCE_SERVERS=(${RESOURCE_SERVER//,/ })
 fi
-
-KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-
-source "${KUBE_ROOT}/hack/lib/common-var-init.sh"
 
 # sanity check for OpenStack provider
 if [ "${CLOUD_PROVIDER}" == "openstack" ]; then

--- a/hack/lib/common-var-init.sh
+++ b/hack/lib/common-var-init.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2020 Authors of Arktos.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -62,7 +62,7 @@ func NewPodGC(kubeClient clientset.Interface, rpClients map[string]clientset.Int
 		resourceProviderClients: rpClients,
 		terminatedPodThreshold:  terminatedPodThreshold,
 		deletePod: func(tenant, namespace, name string) error {
-			klog.Infof("PodGC is force deleting Pod: %v/%v", namespace, name)
+			klog.Infof("PodGC is force deleting Pod: %v/%v/%v", tenant, namespace, name)
 			return kubeClient.CoreV1().PodsWithMultiTenancy(namespace, tenant).Delete(name, metav1.NewDeleteOptions(0))
 		},
 	}


### PR DESCRIPTION
This change fix this issue: https://github.com/CentaurusInfra/arktos/issues/1020

Before code fix, GC list nodes every 20s and could not find node, hence recycle pods every 20s.
```
ubuntu@ip-172-30-0-148:~$ kubectl get pods -A
NAMESPACE     NAME                                HASHKEY               READY   STATUS    RESTARTS   AGE
default       nginx-deployment-676f445fdf-t2lnw   5880710705033174106   1/1     Running   0          55s
kube-system   kube-dns-6fdcc959b4-66ssw           1357571739321344899   2/3     Running   1          110s
```

After stopped node where pod t2lnw was created, it got recreated in a different host:
```
ubuntu@ip-172-30-0-148:~$ kubectl get pods -A
NAMESPACE     NAME                                HASHKEY               READY   STATUS    RESTARTS   AGE
default       nginx-deployment-676f445fdf-8h257   8574656549163554292   1/1     Running   0          8s
kube-system   kube-dns-6fdcc959b4-66ssw           1357571739321344899   2/3     Running   1          2m28s
```

Log:
I0313 00:59:24.509731    1412 gc_controller.go:199] Forced deletion of orphaned Pod system/default/nginx-deployment-676f445fdf-t2lnw succeeded
I0313 00:59:24.512072    1412 event.go:259] Event(v1.ObjectReference{Kind:"ReplicaSet", Namespace:"default", Name:"nginx-deployment-676f445fdf", UID:"03d8692b-2996-45b5-8606-96d6e6c7faf3", APIVersion:"apps/v1", ResourceVersion:"847038162319966209", FieldPath:"", Tenant:"system"}): type: 'Normal' reason: 'SuccessfulCreate' Created pod: nginx-deployment-676f445fdf-8h257

Also works for pod for non system tenant:
```
ubuntu@ip-172-30-0-148:~$ kubectl get pods -A -T
TENANT   NAMESPACE     NAME                                  HASHKEY               READY   STATUS             RESTARTS   AGE
aaa      namespace-a   nginx-deployment-a-676f445fdf-nk5ft   3243237195972317040   1/1     Running            0          61s
system   default       nginx-deployment-676f445fdf-8h257     8574656549163554292   1/1     Running            0          5m2s
system   kube-system   kube-dns-6fdcc959b4-66ssw             1357571739321344899   1/3     CrashLoopBackOff   9          7m22s
```

Manually stopped RP that hosts the pods, pods got recreated automatically in another RP:
```
ubuntu@ip-172-30-0-148:~$ kubectl get pods -A -T
TENANT   NAMESPACE     NAME                                  HASHKEY               READY   STATUS    RESTARTS   AGE
aaa      namespace-a   nginx-deployment-a-676f445fdf-szqx6   5738940787212938146   1/1     Running   0          60s
system   default       nginx-deployment-676f445fdf-tbw9f     9007118871540703210   1/1     Running   0          20s
system   kube-system   kube-dns-6fdcc959b4-gnf9t             6951555085537816387   2/3     Running   0          60s
```



