### PR TITLE
Fix issue 1023

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1474,7 +1474,9 @@ func (e *Store) CompleteWithOptions(options *generic.StoreOptions) error {
 
 // startObservingCount starts monitoring given prefix and periodically updating metrics. It returns a function to stop collection.
 func (e *Store) startObservingCount(period time.Duration) func() {
-	prefix := e.KeyRootFunc(genericapirequest.NewContext())
+	ctx := genericapirequest.NewContext()
+	ctx = genericapirequest.WithTenant(ctx, metav1.TenantAll)
+	prefix := e.KeyRootFunc(ctx)
 	resourceName := e.DefaultQualifiedResource.String()
 	klog.V(2).Infof("Monitoring %v count at <storage-prefix>/%v", resourceName, prefix)
 	stopCh := make(chan struct{})

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1476,6 +1476,7 @@ func (e *Store) CompleteWithOptions(options *generic.StoreOptions) error {
 func (e *Store) startObservingCount(period time.Duration) func() {
 	ctx := genericapirequest.NewContext()
 	ctx = genericapirequest.WithTenant(ctx, metav1.TenantAll)
+	ctx = genericapirequest.WithNamespace(ctx, metav1.NamespaceAll)
 	prefix := e.KeyRootFunc(ctx)
 	resourceName := e.DefaultQualifiedResource.String()
 	klog.V(2).Infof("Monitoring %v count at <storage-prefix>/%v", resourceName, prefix)


### PR DESCRIPTION
Fixing https://github.com/CentaurusInfra/arktos/issues

Verified with a successful 100-node scale-out 1TP-1RP density test run, where the maximal number of pods should be 3000+. Here is the Prometheus graph for metric etcd_object_count of pods, where the peak number reaches 3430. 

![image](https://user-images.githubusercontent.com/51831990/111020032-ec13ce80-8377-11eb-9217-560c8c83b966.png)

