### PR TITLE
perftest tool: bypass accessing RPs

### DIFF
--- a/perf-tests/clusterloader2/cmd/clusterloader.go
+++ b/perf-tests/clusterloader2/cmd/clusterloader.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -78,6 +79,7 @@ func initClusterFlags() {
 	flags.StringEnvVar(&clusterLoaderConfig.ClusterConfig.KubemarkRootKubeConfigPath, "kubemark-root-kubeconfig", "KUBEMARK_ROOT_KUBECONFIG", "",
 		"Path the to kubemark root kubeconfig file, i.e. kubeconfig of the cluster where kubemark cluster is run. Ignored if provider != kubemark")
 	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.APIServerPprofByClientEnabled, "apiserver-pprof-by-client-enabled", "APISERVER_PPROF_BY_CLIENT_ENABLED", true, "Whether apiserver pprof endpoint can be accessed by Kubernetes client.")
+	flags.BoolEnvVar(&clusterLoaderConfig.ClusterConfig.RPAccess, "rp-access", "RP_ACCESS", false, "Whether to access RP clusters")
 }
 
 func validateClusterFlags() *errors.ErrorList {
@@ -125,6 +127,10 @@ func validateFlags() *errors.ErrorList {
 }
 
 func completeConfig(m *framework.MultiClientSet) error {
+	if clusterLoaderConfig.ClusterConfig.Nodes == 0 && !clusterLoaderConfig.ClusterConfig.RPAccess {
+		return fmt.Errorf("nodes must be specified explicitly without access to RP")
+	}
+
 	if clusterLoaderConfig.ClusterConfig.Nodes == 0 {
 		nodes, err := util.GetSchedulableUntainedNodesNumber(m.GetClient())
 		if err != nil {
@@ -244,8 +250,11 @@ func main() {
 		klog.Exitf("Cannot create report directory: %v", err)
 	}
 
-	if err = util.LogClusterNodes(mclient.GetClient()); err != nil {
-		klog.Errorf("Nodes info logging error: %v", err)
+	if clusterLoaderConfig.ClusterConfig.RPAccess {
+		// todo: use direct access to RPs w/o proxy
+		if err = util.LogClusterNodes(mclient.GetClient()); err != nil {
+			klog.Errorf("Nodes info logging error: %v", err)
+		}
 	}
 
 	if err = verifyCluster(mclient.GetClient()); err != nil {

--- a/perf-tests/clusterloader2/pkg/config/cluster.go
+++ b/perf-tests/clusterloader2/pkg/config/cluster.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2018 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,6 +33,7 @@ type ClusterLoaderConfig struct {
 // ClusterConfig is a structure that represents cluster description.
 type ClusterConfig struct {
 	KubeConfigPath             string
+	RPAccess                   bool
 	Nodes                      int
 	Provider                   string
 	EtcdCertificatePath        string


### PR DESCRIPTION
this PR targets 430 POC.

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
It introduces to perf command tool (clusterloader) a new env var controlling whether to access RPs to list nodes, or not.

In default mode (no chaos monkey), clusterloader does not really care much about node details, other than the number of nodes. This PR makes option for it not to access RPs, so to access TP directly, w/o proxy.

**Special notes for your reviewer**:
When no to access RPs, chaos monkey must not be enabled (it is disabled by default). The change to support enabling chaos monkey will be considered later (as chaos monley is not being used in current stage of Arktos scalability test)

**Does this PR introduce a user-facing change?**:
Yes
```release-note
run-e2e.sh could use TP-only kubeconfig (--kubeconfig) parameter; 
run-e2e.sh must provide --nodes parameter with proper value (unless RP_ACCESS set to true and --kubeconfig points to proxy kubeconfig)
```
