### PR TITLE
fix issue 1038. kubeconfig for kcm on TP to use the proxy till the KCM supports direct talk to RPs

### DIFF
--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -2261,11 +2261,17 @@ function apply-encryption-config() {
 #   DOCKER_REGISTRY
 function start-kube-controller-manager {
   echo "Start kubernetes controller-manager"
-  if [[ "${USE_INSECURE_SCALEOUT_CLUSTER_MODE:-false}" == "true" ]]; then
-    create-kubeconfig "kube-controller-manager" ${KUBE_CONTROLLER_MANAGER_TOKEN} "localhost" "8080" "http"
-  else
-    create-kubeconfig "kube-controller-manager" ${KUBE_CONTROLLER_MANAGER_TOKEN}
-  fi
+  if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
+    if [[ -n "${SHARED_APISERVER_TOKEN:-}" ]]; then
+      create-kubeconfig "kube-controller-manager" ${SHARED_APISERVER_TOKEN} "${PROXY_RESERVED_IP}" "443" "https"
+    else
+      create-kubeconfig "kube-controller-manager" ${KUBE_BEARER_TOKEN} "${PROXY_RESERVED_IP}" "443" "https"
+    fi
+  elif [[ "${USE_INSECURE_SCALEOUT_CLUSTER_MODE:-false}" == "true" ]]; then
+      create-kubeconfig "kube-controller-manager" ${KUBE_CONTROLLER_MANAGER_TOKEN} "localhost" "8080" "http"
+    else
+      create-kubeconfig "kube-controller-manager" ${KUBE_CONTROLLER_MANAGER_TOKEN}
+   fi
   prepare-log-file /var/log/kube-controller-manager.log
   # Calculate variables and assemble the command line.
   local params="${CONTROLLER_MANAGER_TEST_LOG_LEVEL:-"--v=4"} ${CONTROLLER_MANAGER_TEST_ARGS:-} ${CLOUD_CONFIG_OPT}"
@@ -2273,14 +2279,8 @@ function start-kube-controller-manager {
     params+=" --use-service-account-credentials"
   #fi
   params+=" --cloud-provider=gce"
-  ## hack, to workaround a RBAC issue with the controller token, it failed syncing replicasets so pods cannot be created from the deployments
-  ## TODO: investigate and fix it later
-  #
-  if [[ "${USE_INSECURE_SCALEOUT_CLUSTER_MODE:-false}" == "false" ]]; then
-    params+=" --kubeconfig=/etc/srv/kubernetes/kube-bootstrap/kubeconfig"
-  else
-   params+=" --kubeconfig=/etc/srv/kubernetes/kube-controller-manager/kubeconfig"
-  fi
+
+  params+=" --kubeconfig=/etc/srv/kubernetes/kube-controller-manager/kubeconfig"
 
   ##switch to enable/disable kube-controller-manager leader-elect: --leader-elect=true/false
   if [[ "${ENABLE_KCM_LEADER_ELECT:-true}" == "false" ]]; then

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -857,10 +857,10 @@ rules:
         resources: ["configmaps"]
   - level: None
     users: ["system:kubelet"] # legacy kubelet identity
-    verbs: ["get"]
+    verbs: ["get", "create"]
     resources:
       - group: "" # core
-        resources: ["nodes", "nodes/status"]
+        resources: ["nodes", "nodes/status", "events"]
   - level: None
     userGroups: ["system:nodes"]
     verbs: ["get"]
@@ -2269,9 +2269,9 @@ function start-kube-controller-manager {
   prepare-log-file /var/log/kube-controller-manager.log
   # Calculate variables and assemble the command line.
   local params="${CONTROLLER_MANAGER_TEST_LOG_LEVEL:-"--v=4"} ${CONTROLLER_MANAGER_TEST_ARGS:-} ${CLOUD_CONFIG_OPT}"
-  if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "false" ]] && [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "false" ]]; then
+  #if [[ "${KUBERNETES_RESOURCE_PARTITION:-false}" == "false" ]] && [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "false" ]]; then
     params+=" --use-service-account-credentials"
-  fi
+  #fi
   params+=" --cloud-provider=gce"
   ## hack, to workaround a RBAC issue with the controller token, it failed syncing replicasets so pods cannot be created from the deployments
   ## TODO: investigate and fix it later

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2905,11 +2905,6 @@ function create-proxy-vm() {
       echo "${result}" >&2
       export PROXY_RESERVED_IP
       export PROXY_RESERVED_INTERNAL_IP
-
-      # pass back the proxy reserved IP
-      echo ${PROXY_RESERVED_IP} > ${KUBE_TEMP}/proxy-reserved-ip.txt
-      cat ${KUBE_TEMP}/proxy-reserved-ip.txt
-
       return 0
     else
       echo "${result}" >&2
@@ -3100,8 +3095,6 @@ function create-master() {
   create-static-internalip "${MASTER_NAME}-internalip" "${REGION}" "${SUBNETWORK}"
   MASTER_RESERVED_IP=$(gcloud compute addresses describe "${MASTER_NAME}-ip" \
     --project "${PROJECT}" --region "${REGION}" -q --format='value(address)')
-
-  echo ${MASTER_RESERVED_IP} > ${KUBE_TEMP}/master_reserved_ip.txt
 
   MASTER_RESERVED_INTERNAL_IP=$(gcloud compute addresses describe "${MASTER_NAME}-internalip" \
     --project "${PROJECT}" --region "${REGION}" -q --format='value(address)')

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -421,6 +421,12 @@ func ClusterRoles() []rbacv1.ClusterRole {
 				rbacv1helpers.NewRule("delete").Groups(legacyGroup).Resources("secrets").RuleOrDie(),
 				rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("endpoints", "namespaces", "secrets", "serviceaccounts", "configmaps").RuleOrDie(),
 				rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("endpoints", "secrets", "serviceaccounts").RuleOrDie(),
+				rbacv1helpers.NewRule(ReadWrite...).Groups(appsGroup).Resources(
+					"statefulsets", "statefulsets/scale",
+					"daemonsets",
+					"deployments", "deployments/scale", "deployments/rollback", "deployments/status",
+					"replicasets", "replicasets/scale", "replicasets/status",
+					"controllerrevisions").RuleOrDie(),
 				// Needed to check API access.  These creates are non-mutating
 				rbacv1helpers.NewRule("create").Groups(authenticationGroup).Resources("tokenreviews").RuleOrDie(),
 				rbacv1helpers.NewRule("create").Groups(authorizationGroup).Resources("subjectaccessreviews").RuleOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -643,6 +643,29 @@ items:
     verbs:
     - update
   - apiGroups:
+    - apps
+    resources:
+    - controllerrevisions
+    - daemonsets
+    - deployments
+    - deployments/rollback
+    - deployments/scale
+    - deployments/status
+    - replicasets
+    - replicasets/scale
+    - replicasets/status
+    - statefulsets
+    - statefulsets/scale
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
     - authentication.k8s.io
     resources:
     - tokenreviews

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -347,11 +347,9 @@ if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
     export KUBEMARK_CLUSTER_KUBECONFIG="${TP_KUBECONFIG}-${tp_num}"
     create-kubemark-master
 
-    export PROXY_RESERVED_IP=$(cat ${KUBE_TEMP}/proxy-reserved-ip.txt)
+    export PROXY_RESERVED_IP=$(grep server "${PROXY_KUBECONFIG}" | awk -F "//" '{print $2}'  | awk -F ":" '{print $1}')
     echo "DBG: PROXY_RESERVED_IP=$PROXY_RESERVED_IP"
     
-    export TP_${tp_num}_RESERVED_IP=$(cat ${KUBE_TEMP}/master_reserved_ip.txt)
-
     # TODO: fix the hardcoded path
     # the path is what the controller used in master init script on the master machines
     if [[ ${tp_num} == 1 ]]; then


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
fix bug in KCM on TP cluster to talk to the proxy instead of pointing to the local cluster --- the RP directly connect from KCM on TP is not yet supported in main -- it is currently tested in 430 branch

**Which issue(s) this PR fixes**:

Fixes #1038 

**Special notes for your reviewer**:
unblock perf testing in master branch. essential changes is 
```
if [[ "${KUBERNETES_TENANT_PARTITION:-false}" == "true" ]]; then
    create-kubeconfig "kube-controller-manager" ${KUBE_CONTROLLER_MANAGER_TOKEN} "${PROXY_RESERVED_IP}" "443" "https"
```

**Does this PR introduce a user-facing change?**:
none 

**Testing:
1. 1 TP, 1 RP scaleout
2. scaleup test

verified bug fix:
```
ybai2016@yb01-multiple-rp-kubemark-tp-1-master /var/log $ grep -i "Found orphaned Pod" kube-controller-manager.log
ybai2016@yb01-multiple-rp-kubemark-tp-1-master /var/log $
```
