### PR TITLE
bug fix: static pods are constantly recycled

### DIFF
--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -68,7 +68,9 @@ func NewPodGC(kubeClient clientset.Interface, rpClients map[string]clientset.Int
 		},
 	}
 
-	gcc.kubeClientForNodes = map[string]clientset.Interface{"tpself": kubeClient}
+	// key "0" is special case for TP client itself
+	// todo: avoid using magic literal "0"
+	gcc.kubeClientForNodes = map[string]clientset.Interface{"0": kubeClient}
 	for key, value := range rpClients {
 		gcc.kubeClientForNodes[key] = value
 	}

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -154,7 +154,7 @@ func (gcc *PodGCController) gcOrphaned(pods []*v1.Pod) {
 	// We want to get list of Nodes from the etcd, to make sure that it's as fresh as possible.
 
 	// get nodes from resource provider clients
-	allRpNodes, errs := getFreshNodes(gcc.nodeListers)
+	allRpNodes, errs := getLatestNodes(gcc.nodeListers)
 
 	// check errors and aggregate nodes
 	if len(errs) == len(gcc.nodeListers) {
@@ -186,7 +186,7 @@ func (gcc *PodGCController) gcOrphaned(pods []*v1.Pod) {
 	}
 }
 
-func getFreshNodes(nodeListers map[string]clientset.Interface) (map[string]*v1.NodeList, map[string]error) {
+func getLatestNodes(nodeListers map[string]clientset.Interface) (map[string]*v1.NodeList, map[string]error) {
 	allRpNodes := make(map[string]*v1.NodeList, len(nodeListers))
 	errs := make(map[string]error, len(nodeListers))
 	var wg sync.WaitGroup

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -188,13 +188,13 @@ func (gcc *PodGCController) gcOrphaned(pods []*v1.Pod) {
 	}
 }
 
-func getLatestNodes(nodeListers map[string]clientset.Interface) (map[string]*v1.NodeList, map[string]error) {
-	allRpNodes := make(map[string]*v1.NodeList, len(nodeListers))
-	errs := make(map[string]error, len(nodeListers))
+func getLatestNodes(kubeClients map[string]clientset.Interface) (map[string]*v1.NodeList, map[string]error) {
+	allRpNodes := make(map[string]*v1.NodeList, len(kubeClients))
+	errs := make(map[string]error, len(kubeClients))
 	var wg sync.WaitGroup
-	wg.Add(len(nodeListers))
+	wg.Add(len(kubeClients))
 	var lock sync.Mutex
-	for rpId, client := range nodeListers {
+	for rpId, client := range kubeClients {
 		go func(resourceProviderId string, rpClient clientset.Interface, nodeLists map[string]*v1.NodeList, errs map[string]error, writeLock *sync.Mutex) {
 			defer wg.Done()
 			nodes, err := rpClient.CoreV1().Nodes().List(metav1.ListOptions{})

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -44,7 +44,9 @@ const (
 
 type PodGCController struct {
 	kubeClient              clientset.Interface
-	resourceProviderClients map[string]clientset.Interface
+
+	// all clients to list nodes it cares about, particularly including the current TP client
+	nodeListers map[string]clientset.Interface
 
 	podLister       corelisters.PodLister
 	podListerSynced cache.InformerSynced
@@ -59,12 +61,16 @@ func NewPodGC(kubeClient clientset.Interface, rpClients map[string]clientset.Int
 	}
 	gcc := &PodGCController{
 		kubeClient:              kubeClient,
-		resourceProviderClients: rpClients,
 		terminatedPodThreshold:  terminatedPodThreshold,
 		deletePod: func(tenant, namespace, name string) error {
 			klog.Infof("PodGC is force deleting Pod: %v/%v/%v", tenant, namespace, name)
 			return kubeClient.CoreV1().PodsWithMultiTenancy(namespace, tenant).Delete(name, metav1.NewDeleteOptions(0))
 		},
+	}
+
+	gcc.nodeListers = map[string]clientset.Interface{"tpself": kubeClient}
+	for key, value := range rpClients {
+		gcc.nodeListers[key] = value
 	}
 
 	gcc.podLister = podInformer.Lister()
@@ -148,31 +154,10 @@ func (gcc *PodGCController) gcOrphaned(pods []*v1.Pod) {
 	// We want to get list of Nodes from the etcd, to make sure that it's as fresh as possible.
 
 	// get nodes from resource provider clients
-	allRpNodes := make(map[string]*v1.NodeList, len(gcc.resourceProviderClients))
-	errs := make(map[string]error, len(gcc.resourceProviderClients))
-	var wg sync.WaitGroup
-	wg.Add(len(gcc.resourceProviderClients))
-	var lock sync.Mutex
-	for rpId, client := range gcc.resourceProviderClients {
-		go func(resourceProviderId string, rpClient clientset.Interface, nodeLists map[string]*v1.NodeList, errs map[string]error, writeLock *sync.Mutex) {
-			defer wg.Done()
-			nodes, err := rpClient.CoreV1().Nodes().List(metav1.ListOptions{})
-			if err != nil {
-				writeLock.Lock()
-				errs[resourceProviderId] = err
-				klog.Errorf("Error listing nodes. err: %v", errs)
-				writeLock.Unlock()
-				return
-			}
-			writeLock.Lock()
-			nodeLists[resourceProviderId] = nodes
-			writeLock.Unlock()
-		}(rpId, client, allRpNodes, errs, &lock)
-	}
-	wg.Wait()
+	allRpNodes, errs := getFreshNodes(gcc.nodeListers)
 
 	// check errors and aggregate nodes
-	if len(errs) == len(gcc.resourceProviderClients) {
+	if len(errs) == len(gcc.nodeListers) {
 		// avoid garbage collection when
 		klog.Errorf("Error listing nodes from all resource partition. err: %v", errs)
 		return
@@ -199,6 +184,32 @@ func (gcc *PodGCController) gcOrphaned(pods []*v1.Pod) {
 			klog.V(0).Infof("Forced deletion of orphaned Pod %v/%v/%v succeeded", pod.Tenant, pod.Namespace, pod.Name)
 		}
 	}
+}
+
+func getFreshNodes(nodeListers map[string]clientset.Interface) (map[string]*v1.NodeList, map[string]error) {
+	allRpNodes := make(map[string]*v1.NodeList, len(nodeListers))
+	errs := make(map[string]error, len(nodeListers))
+	var wg sync.WaitGroup
+	wg.Add(len(nodeListers))
+	var lock sync.Mutex
+	for rpId, client := range nodeListers {
+		go func(resourceProviderId string, rpClient clientset.Interface, nodeLists map[string]*v1.NodeList, errs map[string]error, writeLock *sync.Mutex) {
+			defer wg.Done()
+			nodes, err := rpClient.CoreV1().Nodes().List(metav1.ListOptions{})
+			if err != nil {
+				writeLock.Lock()
+				errs[resourceProviderId] = err
+				klog.Errorf("Error listing nodes. err: %v", errs)
+				writeLock.Unlock()
+				return
+			}
+			writeLock.Lock()
+			nodeLists[resourceProviderId] = nodes
+			writeLock.Unlock()
+		}(rpId, client, allRpNodes, errs, &lock)
+	}
+	wg.Wait()
+	return allRpNodes, errs
 }
 
 // gcUnscheduledTerminating deletes pods that are terminating and haven't been scheduled to a particular node.


### PR DESCRIPTION
__This PR goes to POC 430 branch only.__

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
GC controller, as part of kube-controller-manager, list nodes, and delete pods if their nodes are gone. In scale-out env, GCC currently list nodes from RPs only; for static pods run from TP itself, it considers them as garbage and recycles them.

This PR changes GCC to include its own TP as one of the node sources.

**Which issue(s) this PR fixes**:
Fixes #1042

**Does this PR introduce a user-facing change?**:
NONE