### PR TITLE
Disable Daemonset from perf-test: load testing

### DIFF
--- a/perf-tests/clusterloader2/testing/experiments/enable_daemonset.yaml
+++ b/perf-tests/clusterloader2/testing/experiments/enable_daemonset.yaml
@@ -1,0 +1,1 @@
+ENABLE_DAEMONSET: true

--- a/perf-tests/clusterloader2/testing/load/config.yaml
+++ b/perf-tests/clusterloader2/testing/load/config.yaml
@@ -17,6 +17,7 @@
 {{$ENABLE_CHAOSMONKEY := DefaultParam .ENABLE_CHAOSMONKEY false}}
 {{$PROMETHEUS_SCRAPE_KUBE_PROXY := DefaultParam .PROMETHEUS_SCRAPE_KUBE_PROXY true}}
 {{$ENABLE_PROMETHEUS_API_RESPONSIVENESS := DefaultParam .ENABLE_PROMETHEUS_API_RESPONSIVENESS false}}
+{{$ENABLE_DAEMONSET := DefaultParam .ENABLE_DAEMONSET false}}
 {{$ENABLE_PVS := DefaultParam .CL2_ENABLE_PVS true}}
 {{$ENABLE_NETWORKPOLICIES := DefaultParam .CL2_ENABLE_NETWORKPOLICIES false}}
 {{$ENABLE_SYSTEM_POD_METRICS:= DefaultParam .ENABLE_SYSTEM_POD_METRICS true}}
@@ -135,6 +136,7 @@ steps:
     - basename: small-service
       objectTemplatePath: service.yaml
 
+{{if $ENABLE_DAEMONSET}}
 - name: Creating PriorityClass for DaemonSets
   phases:
   - replicasPerNamespace: 1
@@ -142,6 +144,7 @@ steps:
     objectBundle:
       - basename: daemonset-priorityclass
         objectTemplatePath: daemonset-priorityclass.yaml
+{{end}}
 
 - name: Starting measurement for waiting for pods
   measurements:
@@ -161,6 +164,7 @@ steps:
       kind: StatefulSet
       labelSelector: group = load
       operationTimeout: 15m
+  {{if $ENABLE_DAEMONSET}}
   - Identifier: WaitForRunningDaemonSets
     Method: WaitForControlledPodsRunning
     Params:
@@ -169,6 +173,7 @@ steps:
       kind: DaemonSet
       labelSelector: group = load
       operationTimeout: 15m
+  {{end}}
   - Identifier: WaitForRunningJobs
     Method: WaitForControlledPodsRunning
     Params:
@@ -180,6 +185,7 @@ steps:
 
 - name: Creating objects
   phases:
+  {{if $ENABLE_DAEMONSET}}
   - namespaceRange:
       min: 1
       max: 1
@@ -190,6 +196,7 @@ steps:
       objectTemplatePath: daemonset.yaml
       templateFillMap:
         Image: k8s.gcr.io/pause:3.0
+  {{end}}
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -320,10 +327,12 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
+  {{if $ENABLE_DAEMONSET}}
   - Identifier: WaitForRunningDaemonSets
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
+  {{end}}
   - Identifier: WaitForRunningJobs
     Method: WaitForControlledPodsRunning
     Params:
@@ -389,6 +398,7 @@ steps:
         templateFillMap:
           ReplicasMin: {{MultiplyInt $MEDIUM_GROUP_SIZE 0.5}}
           ReplicasMax: {{MultiplyInt $MEDIUM_GROUP_SIZE 1.5}}
+  {{if $ENABLE_DAEMONSET}}
   - namespaceRange:
       min: 1
       max: 1
@@ -399,6 +409,7 @@ steps:
         objectTemplatePath: daemonset.yaml
         templateFillMap:
           Image: k8s.gcr.io/pause:3.1
+  {{end}}
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -443,10 +454,12 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
+  {{if $ENABLE_DAEMONSET}}
   - Identifier: WaitForRunningDaemonSets
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
+  {{end}}
   - Identifier: WaitForRunningJobs
     Method: WaitForControlledPodsRunning
     Params:
@@ -522,6 +535,7 @@ steps:
         objectTemplatePath: statefulset.yaml
       - basename: medium-statefulset
         objectTemplatePath: statefulset_service.yaml
+  {{if $ENABLE_DAEMONSET}}
   - namespaceRange:
       min: 1
       max: 1
@@ -530,6 +544,7 @@ steps:
     objectBundle:
       - basename: daemonset
         objectTemplatePath: daemonset.yaml
+  {{end}}
   - namespaceRange:
       min: 1
       max: {{$namespaces}}
@@ -596,10 +611,12 @@ steps:
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
+  {{if $ENABLE_DAEMONSET}}
   - Identifier: WaitForRunningDaemonSets
     Method: WaitForControlledPodsRunning
     Params:
       action: gather
+  {{end}}
   - Identifier: WaitForRunningJobs
     Method: WaitForControlledPodsRunning
     Params:
@@ -613,6 +630,7 @@ steps:
       timeout: 15m
   {{end}}
 
+{{if $ENABLE_DAEMONSET}}
 - name: Deleting PriorityClass for DaemonSets
   phases:
     - replicasPerNamespace: 0
@@ -620,6 +638,7 @@ steps:
       objectBundle:
         - basename: daemonset-priorityclass
           objectTemplatePath: daemonset-priorityclass.yaml
+{{end}}
 
 - name: Deleting SVCs
   phases:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind cleanup


**What this PR does / why we need it**:
Add "ENABLE_DAEMONSET" to perf-test load testing and set default to false 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**
1tp-1rp for 100 nodes perf testing run successfully with the configuration below:

```
export KUBEMARK_NUM_NODES=100 NUM_NODES=2 SCALEOUT_TP_COUNT=1 RUN_PREFIX=disableds-032521-1x100
export MASTER_DISK_SIZE=200GB MASTER_ROOT_DISK_SIZE=200GB KUBE_GCE_ZONE=us-central1-b MASTER_SIZE=n1-highmem-32 NODE_SIZE=n1-highmem-16 NODE_DISK_SIZE=200GB GOPATH=$HOME/go KUBE_GCE_ENABLE_IP_ALIASES=true KUBE_GCE_PRIVATE_CLUSTER=true CREATE_CUSTOM_NETWORK=true KUBE_GCE_INSTANCE_PREFIX=${RUN_PREFIX} KUBE_GCE_NETWORK=${RUN_PREFIX} ENABLE_KCM_LEADER_ELECT=false ENABLE_SCHEDULER_LEADER_ELECT=false ETCD_QUOTA_BACKEND_BYTES=8589934592 SHARE_PARTITIONSERVER=false LOGROTATE_FILES_MAX_COUNT=200 LOGROTATE_MAX_SIZE=200M KUBE_ENABLE_APISERVER_INSECURE_PORT=true KUBE_ENABLE_PROMETHEUS_DEBUG=true KUBE_ENABLE_PPROF_DEBUG=true TEST_CLUSTER_LOG_LEVEL=--v=2 HOLLOW_KUBELET_TEST_LOG_LEVEL=--v=2 SCALEOUT_CLUSTER=true SCALEOUT_TP_COUNT=1 KUBE_FEATURE_GATES=ExperimentalCriticalPodAnnotation=true,QPSDoubleGCController=true
SCALEOUT_TEST_TENANT=arktos RUN_PREFIX=disableds-032521-1x100 PERF_LOG_DIR=/home/sonyali/logs/perf-test/gce-100/arktos/${RUN_PREFIX}/${SCALEOUT_TEST_TENANT} perf-tests/clusterloader2/run-e2e.sh --nodes=100 --provider=kubemark --kubeconfig=/home/sonyali/go/src/k8s.io/arktos/test/kubemark/resources/kubeconfig.kubemark-proxy --report-dir=${PERF_LOG_DIR} --testconfig=testing/density/config.yaml --testconfig=testing/load/config.yaml --testoverrides=./testing/experiments/disable_pvs.yaml > ${PERF_LOG_DIR}/perf-run.log  2>&1  &
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
