### PR TITLE
bug fix 1048: api server tsl handshake error with proxy server

### DIFF
--- a/cmd/haproxy-cfg-generator/cfg_generator.go
+++ b/cmd/haproxy-cfg-generator/cfg_generator.go
@@ -212,8 +212,9 @@ func get_backends(config *Config) string {
 	}
 
 	if config.tlsMode == BRIDGING {
-		tp_backend = "backend tenant_api_%v\n    server tp_%v %v:%v maxconn %v ssl check ca-file /etc/haproxy/ca.crt\n\n"
-		rp_backend = "backend resource_api\n    server rp %v:%v maxconn %v ssl check ca-file /etc/haproxy/ca.crt\n\n"
+		// perform a TCP check for backend health
+		tp_backend = "backend tenant_api_%v\n    option tcp-check\n    tcp-check connect\n    server tp_%v %v:%v maxconn %v ssl check ca-file /etc/haproxy/ca.crt\n\n"
+		rp_backend = "backend resource_api\n    option tcp-check\n    tcp-check connect\n    server rp %v:%v maxconn %v ssl check ca-file /etc/haproxy/ca.crt\n\n"
 	} else {
 		tp_backend = "backend tenant_api_%v\n    server tp_%v %v:%v maxconn %v\n\n"
 		rp_backend = "backend resource_api\n    server rp %v:%v maxconn %v\n\n"

--- a/cmd/haproxy-cfg-generator/data/sample_four_tp_haproxy.cfg
+++ b/cmd/haproxy-cfg-generator/data/sample_four_tp_haproxy.cfg
@@ -102,16 +102,26 @@ frontend scale-out-proxy
     default_backend tenant_api_1
 
 backend tenant_api_1
+    option tcp-check
+    tcp-check connect
     server tp_1 1.1.1.1:443 maxconn 500000 ssl check ca-file /etc/haproxy/ca.crt
 
 backend tenant_api_2
+    option tcp-check
+    tcp-check connect
     server tp_2 2.2.2.2:443 maxconn 500000 ssl check ca-file /etc/haproxy/ca.crt
 
 backend tenant_api_3
+    option tcp-check
+    tcp-check connect
     server tp_3 3.3.3.3:443 maxconn 500000 ssl check ca-file /etc/haproxy/ca.crt
 
 backend tenant_api_4
+    option tcp-check
+    tcp-check connect
     server tp_4 4.4.4.4:443 maxconn 500000 ssl check ca-file /etc/haproxy/ca.crt
 
 backend resource_api
+    option tcp-check
+    tcp-check connect
     server rp 9.9.9.9:443 maxconn 500000 ssl check ca-file /etc/haproxy/ca.crt

--- a/cmd/haproxy-cfg-generator/data/sample_one_tp_haproxy.cfg
+++ b/cmd/haproxy-cfg-generator/data/sample_one_tp_haproxy.cfg
@@ -84,7 +84,11 @@ frontend scale-out-proxy
     default_backend tenant_api_1
 
 backend tenant_api_1
+    option tcp-check
+    tcp-check connect
     server tp_1 1.1.1.1:443 maxconn 500000 ssl check ca-file /etc/haproxy/ca.crt
 
 backend resource_api
+    option tcp-check
+    tcp-check connect
     server rp 9.9.9.9:443 maxconn 500000 ssl check ca-file /etc/haproxy/ca.crt

--- a/cmd/haproxy-cfg-generator/data/sample_three_tp_haproxy.cfg
+++ b/cmd/haproxy-cfg-generator/data/sample_three_tp_haproxy.cfg
@@ -96,13 +96,21 @@ frontend scale-out-proxy
     default_backend tenant_api_1
 
 backend tenant_api_1
+    option tcp-check
+    tcp-check connect
     server tp_1 1.1.1.1:443 maxconn 500000 ssl check ca-file /etc/haproxy/ca.crt
 
 backend tenant_api_2
+    option tcp-check
+    tcp-check connect
     server tp_2 2.2.2.2:443 maxconn 500000 ssl check ca-file /etc/haproxy/ca.crt
 
 backend tenant_api_3
+    option tcp-check
+    tcp-check connect
     server tp_3 3.3.3.3:443 maxconn 500000 ssl check ca-file /etc/haproxy/ca.crt
 
 backend resource_api
+    option tcp-check
+    tcp-check connect
     server rp 9.9.9.9:443 maxconn 500000 ssl check ca-file /etc/haproxy/ca.crt

--- a/cmd/haproxy-cfg-generator/data/sample_two_tp_haproxy.cfg
+++ b/cmd/haproxy-cfg-generator/data/sample_two_tp_haproxy.cfg
@@ -90,10 +90,16 @@ frontend scale-out-proxy
     default_backend tenant_api_1
 
 backend tenant_api_1
+    option tcp-check
+    tcp-check connect
     server tp_1 1.1.1.1:443 maxconn 500000 ssl check ca-file /etc/haproxy/ca.crt
 
 backend tenant_api_2
+    option tcp-check
+    tcp-check connect
     server tp_2 2.2.2.2:443 maxconn 500000 ssl check ca-file /etc/haproxy/ca.crt
 
 backend resource_api
+    option tcp-check
+    tcp-check connect
     server rp 9.9.9.9:443 maxconn 500000 ssl check ca-file /etc/haproxy/ca.crt


### PR DESCRIPTION

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
the haproxy service periodically performs health check with the backend API servers. the current configuration for this backend health check is check-ssl, which enforces full TSL traffic for the check. this causes a lot log entries in the api server due to the source where the health check originated is not the 443 port of the haporxy.

currently one can either specify the "source <proxy server Ip>:443" or just perform TCP checks to backend servers. this PR takes the later one to not occupy the 443 port too much just in case to affect testing throughputs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1048 

**Special notes for your reviewer**:
Tested with 100 node under  POC 430 branch.
