### PR TITLE
fix rp server failed to collect pprof error

### DIFF
--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -1464,81 +1464,22 @@ function start-collect-pprof {
     mkdir "${CURRENTTIME}"
     cd "${CURRENTTIME}"
 
-    COMPONENTS_PORTS="8080"
-    COMPONENTS_NAME="kube-apiserver"
     echo "Collecting kube-apiserver pprof at ${CURRENTTIME}"
-    collecting-pprof ${COMPONENTS_PORTS} ${COMPONENTS_NAME} 
+    ps -C kube-apiserver >/dev/null && collecting-pprof "8080" "kube-apiserver" || echo "kube-apiserver is not running on this machine"
 
-    COMPONENTS_PORTS="2382"
-    COMPONENTS_NAME="etcd"
     echo "Collecting etcd pprof at ${CURRENTTIME}"
-    collecting-pprof ${COMPONENTS_PORTS} ${COMPONENTS_NAME} 
+    ps -C etcd >/dev/null && collecting-pprof "2382" "etcd" || echo "etcd is not running on this machine" 
 
-    COMPONENTS_PORTS="10251"
-    COMPONENTS_NAME="kube-scheduler"
     echo "Collecting kube-scheduler pprof at ${CURRENTTIME}"
-    collecting-pprof ${COMPONENTS_PORTS} ${COMPONENTS_NAME} 
+    ps -C kube-scheduler >/dev/null && collecting-pprof "10251" "kube-scheduler" || echo "kube-scheduler is not running on this machine"  
     
-    COMPONENTS_PORTS="10252"
-    COMPONENTS_NAME="kube-controller-manager"
     echo "Collecting kube-controller-manager pprof"
-    collecting-pprof ${COMPONENTS_PORTS} ${COMPONENTS_NAME} 
-
-    COMPONENTS_PORTS="10250"
-    COMPONENTS_NAME="kubelet"
-    echo "Collecting kubelet pprof"
-    collecting-pprof ${COMPONENTS_PORTS} ${COMPONENTS_NAME} 
+    ps -C kube-controller >/dev/null && collecting-pprof "10252" "kube-controller-manager" || echo "kube-controller-manager is not running on this machine"   
+ 
     sleep 1800
   done &
 }
 
-
-# Starts collecting profiling files.
-function start-collect-partitionserver-pprof {
-  echo "Start to collect profiling files"
-  mkdir -p /var/log/pprof
-  while true; do
-    cd /var/log/pprof
-    CURRENTTIME=`date +"%Y-%m-%d-%T"`
-    mkdir "${CURRENTTIME}"
-    cd "${CURRENTTIME}"
-
-    COMPONENTS_PORTS="10250"
-    COMPONENTS_NAME="kubelet"
-    echo "Collecting kubelet pprof"
-    collecting-pprof ${COMPONENTS_PORTS} ${COMPONENTS_NAME} 
-
-    if [[ "${ENABLE_APISERVER}" == "true" ]]; then
-      COMPONENTS_PORTS="8080"
-      COMPONENTS_NAME="kube-apiserver"
-      echo "Collecting kube-apiserver pprof at ${CURRENTTIME}"
-      collecting-pprof ${COMPONENTS_PORTS} ${COMPONENTS_NAME} 
-    fi
-
-    if [[ "${ENABLE_ETCD}" == "true" ]]; then
-      COMPONENTS_PORTS="2382"
-      COMPONENTS_NAME="etcd"
-      echo "Collecting etcd pprof at ${CURRENTTIME}"
-      collecting-pprof ${COMPONENTS_PORTS} ${COMPONENTS_NAME} 
-    fi
-
-    if [[ "${ENABLE_KUBESCHEDULER}" == "true" ]]; then
-      COMPONENTS_PORTS="10251"
-      COMPONENTS_NAME="kube-scheduler"
-      echo "Collecting kube-scheduler pprof at ${CURRENTTIME}"
-      collecting-pprof ${COMPONENTS_PORTS} ${COMPONENTS_NAME} 
-    fi
-    
-    if [[ "${ENABLE_KUBECONTROLLER}" == "true" ]]; then
-      COMPONENTS_PORTS="10252"
-      COMPONENTS_NAME="kube-controller-manager"
-      echo "Collecting kube-controller-manager pprof"
-      collecting-pprof ${COMPONENTS_PORTS} ${COMPONENTS_NAME} 
-    fi
-
-    sleep 1800
-  done &
-}
 
 # Replaces the variables in the etcd manifest file with the real values, and then
 # copy the file to the manifest dir

--- a/cluster/gce/gci/partitionserver-configure-helper.sh
+++ b/cluster/gce/gci/partitionserver-configure-helper.sh
@@ -137,7 +137,7 @@ function main() {
   prepare-mounter-rootfs
   modprobe configs
   if [[ "${ENABLE_PPROF_DEBUG:-false}" == "true" ]]; then
-    start-collect-partitionserver-pprof &  #### start collect profiling files
+    start-collect-pprof &  #### start collect profiling files
   fi
   if [[ "${ENABLE_PROMETHEUS_DEBUG:-false}" == "true" ]]; then
     start-prometheus &  #####start prometheus


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:
rp server failed to collect pprof becuase there is no kube-scheduler running. Add component running judgment, only collecting pprof for running component.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/CentaurusInfra/arktos/issues/1057

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
