### PR TITLE
kube-sched: perf-related back-ports: Merge pull request #78009 from hainesc/develop

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand"
 	"sort"
 	"strings"
 	"sync"
@@ -161,7 +162,6 @@ type genericScheduler struct {
 	prioritizers             []priorities.PriorityConfig
 	framework                framework.Framework
 	extenders                []algorithm.SchedulerExtender
-	lastNodeIndex            uint64
 	alwaysCheckAllPredicates bool
 	nodeInfoSnapshot         *internalcache.NodeInfoSnapshot
 	volumeBinder             *volumebinder.VolumeBinder
@@ -272,34 +272,29 @@ func (g *genericScheduler) Predicates() map[string]predicates.FitPredicate {
 	return g.predicates
 }
 
-// findMaxScores returns the indexes of nodes in the "priorityList" that has the highest "Score".
-func findMaxScores(priorityList schedulerapi.HostPriorityList) []int {
-	maxScoreIndexes := make([]int, 0, len(priorityList)/2)
-	maxScore := priorityList[0].Score
-	for i, hp := range priorityList {
-		if hp.Score > maxScore {
-			maxScore = hp.Score
-			maxScoreIndexes = maxScoreIndexes[:0]
-			maxScoreIndexes = append(maxScoreIndexes, i)
-		} else if hp.Score == maxScore {
-			maxScoreIndexes = append(maxScoreIndexes, i)
-		}
-	}
-	return maxScoreIndexes
-}
-
 // selectHost takes a prioritized list of nodes and then picks one
-// in a round-robin manner from the nodes that had the highest score.
+// in a reservoir sampling manner from the nodes that had the highest score.
 func (g *genericScheduler) selectHost(priorityList schedulerapi.HostPriorityList) (string, error) {
 	if len(priorityList) == 0 {
 		return "", fmt.Errorf("empty priorityList")
 	}
-
-	maxScores := findMaxScores(priorityList)
-	ix := int(g.lastNodeIndex % uint64(len(maxScores)))
-	g.lastNodeIndex++
-
-	return priorityList[maxScores[ix]].Host, nil
+	maxScore := priorityList[0].Score
+	selected := priorityList[0].Host
+	cntOfMaxScore := 1
+	for _, hp := range priorityList[1:] {
+		if hp.Score > maxScore {
+			maxScore = hp.Score
+			selected = hp.Host
+			cntOfMaxScore = 1
+		} else if hp.Score == maxScore {
+			cntOfMaxScore++
+			if rand.Intn(cntOfMaxScore) == 0 {
+				// Replace the candidate with probability of 1/cntOfMaxScore
+				selected = hp.Host
+			}
+		}
+	}
+	return selected, nil
 }
 
 // preempt finds nodes with pods that can be preempted to make room for "pod" to


### PR DESCRIPTION
__target to 30 POC branch right now__

**What type of PR is this?**
/kind feature (back-port from upstream k8s)

**What this PR does / why we need it**:
This PR was back-ported from upstream kubernetes [PR 78009](https://github.com/kubernetes/kubernetes/pull/78009)
Use reservoir sampling to select one host from priority list

**Special notes for your reviewer**:
this is the first one of series PRs kube-scheduler related performance related improvements (up to k8s 1.18.5). Since this specific PR was before the scheduling framework was introduced, the cherry-picked PR is quite clean cut. However, expecting other PRs to have quite conflicts to resolve; so these PR series will be intentionally split into small chunks i a hope to smooth the review process.

Tested locally; kube-scheduler is verified functioning properly.