### PR TITLE
debug logging for scheduler perf analysis

### DIFF
--- a/pkg/scheduler/algorithm/predicates/metadata.go
+++ b/pkg/scheduler/algorithm/predicates/metadata.go
@@ -398,7 +398,9 @@ func getTPMapMatchingExistingAntiAffinity(pod *v1.Pod, nodeInfoMap map[string]*s
 			catchError(fmt.Errorf("node not found"))
 			return
 		}
-		for _, existingPod := range nodeInfo.PodsWithAffinity() {
+		existingPods := nodeInfo.PodsWithAffinity()
+		// klog.V(2).Infof("Node %v, Pods with Affinity: %v", nodeInfo.Node().Name, len(existingPods))
+		for _, existingPod := range existingPods {
 			existingPodTopologyMaps, err := getMatchingAntiAffinityTopologyPairsOfPod(pod, existingPod, node)
 			if err != nil {
 				catchError(err)
@@ -408,6 +410,10 @@ func getTPMapMatchingExistingAntiAffinity(pod *v1.Pod, nodeInfoMap map[string]*s
 			appendTopologyPairsMaps(existingPodTopologyMaps)
 		}
 	}
+
+	klog.V(2).Infof("Number of nodes: %v", len(allNodeNames))
+	// TODO: make this configurable so we can test perf impact when increasing or decreasing concurrency
+	//       on a 96 core machine, it can be much more than 16 concurrent threads to run the processNode function
 	workqueue.ParallelizeUntil(ctx, 16, len(allNodeNames), processNode)
 	return topologyMaps, firstError
 }
@@ -499,6 +505,10 @@ func getTPMapMatchingIncomingAffinityAntiAffinity(pod *v1.Pod, nodeInfoMap map[s
 			appendResult(node.Name, nodeTopologyPairsAffinityPodsMaps, nodeTopologyPairsAntiAffinityPodsMaps)
 		}
 	}
+
+	klog.V(2).Infof("DEBUG: should not see this log in our current perf runs. Number of nodes: %v", len(allNodeNames))
+	// TODO: make this configurable so we can test perf impact when increasing or decreasing concurrency
+	//       on a 96 core machine, it can be much more than 16 concurrent threads to run the processNode function
 	workqueue.ParallelizeUntil(ctx, 16, len(allNodeNames), processNode)
 	return topologyPairsAffinityPodsMaps, topologyPairsAntiAffinityPodsMaps, firstError
 }

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -161,6 +161,7 @@ func (sched *Scheduler) deleteNodeFromCache(obj interface{}) {
 	}
 }
 func (sched *Scheduler) addPodToSchedulingQueue(obj interface{}) {
+	klog.V(2).Infof("Getting pod %v from API server", obj.(*v1.Pod).Name )
 	if err := sched.config.SchedulingQueue.Add(obj.(*v1.Pod)); err != nil {
 		utilruntime.HandleError(fmt.Errorf("unable to queue %T: %v", obj, err))
 	}
@@ -207,7 +208,7 @@ func (sched *Scheduler) addPodToCache(obj interface{}) {
 		klog.Errorf("cannot convert to *v1.Pod: %v", obj)
 		return
 	}
-	klog.V(4).Infof("Got ADD pod event. pod name %s, rv %v, status %#v", pod.Name, pod.ResourceVersion, pod.Status)
+	klog.V(2).Infof("Got ADD pod event. pod name %s, rv %v, status %#v", pod.Name, pod.ResourceVersion, pod.Status)
 
 	if err := sched.config.SchedulerCache.AddPod(pod); err != nil {
 		klog.Errorf("scheduler cache AddPod failed: %v", err)

--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -274,6 +274,8 @@ func (cache *schedulerCache) FilteredList(podFilter algorithm.PodFilter, selecto
 			}
 		}
 	}
+
+	klog.V(2).Infof("returning %v pods out of %v nodes", len(pods), len(cache.nodes))
 	return pods, nil
 }
 
@@ -419,6 +421,8 @@ func (cache *schedulerCache) AddPod(pod *v1.Pod) error {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
+	//klog.V(2).Infof("DEBUG: ADD_DEL: Add pod from cache: %v/%v/%v", pod.Tenant, pod.Namespace, pod.Name)
+
 	currState, ok := cache.podStates[key]
 	switch {
 	case ok && cache.assumedPods[key]:
@@ -482,6 +486,8 @@ func (cache *schedulerCache) RemovePod(pod *v1.Pod) error {
 
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
+
+	//klog.V(2).Infof("DEBUG: ADD_DEL: Remove pod from cache: %v/%v/%v", pod.Tenant, pod.Namespace, pod.Name)
 
 	currState, ok := cache.podStates[key]
 	switch {

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -207,6 +207,8 @@ func (p *PriorityQueue) run() {
 func (p *PriorityQueue) Add(pod *v1.Pod) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
+	klog.V(2).Infof("adding pod %v/%v/%v to the scheduling queue.", pod.Tenant, pod.Namespace, pod.Name)
+
 	pInfo := p.newPodInfo(pod)
 	if err := p.activeQ.Add(pInfo); err != nil {
 		klog.Errorf("Error adding pod %v/%v/%v to the scheduling queue: %v", pod.Tenant, pod.Namespace, pod.Name, err)
@@ -814,7 +816,7 @@ func MakeNextPodFunc(queue SchedulingQueue) func() *v1.Pod {
 	return func() *v1.Pod {
 		pod, err := queue.Pop()
 		if err == nil {
-			klog.V(4).Infof("About to try and schedule pod %v/%v/%v", pod.Tenant, pod.Namespace, pod.Name)
+			klog.V(2).Infof("About to try and schedule pod %v/%v/%v", pod.Tenant, pod.Namespace, pod.Name)
 			return pod
 		}
 		klog.Errorf("Error while retrieving next pod from scheduling queue: %v", err)


### PR DESCRIPTION

**What this PR does / why we need it**:
Add some debug logs for perf analysis

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

```
I0408 17:40:19.912410       1 eventhandlers.go:164] Getting pod latency-deployment-306-8566f7d674-4dftj from API server
I0408 17:40:19.912478       1 scheduling_queue.go:210] adding pod arktos/y0g937-testns/latency-deployment-306-8566f7d674-4dftj to the scheduling queue.
I0408 17:40:19.912514       1 scheduling_queue.go:819] About to try and schedule pod arktos/y0g937-testns/latency-deployment-306-8566f7d674-4dftj
I0408 17:40:19.912525       1 scheduler.go:458] Attempting to schedule pod: arktos/y0g937-testns/latency-deployment-306-8566f7d674-4dftj
I0408 17:40:19.912585       1 generic_scheduler.go:211] DEBUG: Compute predicates pod: arktos/y0g937-testns/latency-deployment-306-8566f7d674-4dftj
I0408 17:40:19.912598       1 generic_scheduler.go:477] Total nodes: 101, calculated numberNodesToFind: 100
I0408 17:40:19.912630       1 metadata.go:414] Number of nodes: 101
I0408 17:40:19.912769       1 generic_scheduler.go:527] Number of nodes: 101
I0408 17:40:19.913973       1 generic_scheduler.go:231] DEBUG: Prioritizing pod: arktos/y0g937-testns/latency-deployment-306-8566f7d674-4dftj
I0408 17:40:19.917515       1 generic_scheduler.go:738] Number of nodes: 100
I0408 17:40:19.918937       1 interpod_affinity.go:122]  pod y0g937-testns-latency-deployment-306-8566f7d674-4dftj, affinity: nil, hasAffinityConstraints: false, hasAntiAffinityConstraints: false
I0408 17:40:19.919008       1 interpod_affinity.go:225] Number of nodes: 101
I0408 17:40:19.919128       1 generic_scheduler.go:255] DEBUG: Selecting host pod: arktos/y0g937-testns/latency-deployment-306-8566f7d674-4dftj
I0408 17:40:19.919223       1 scheduler.go:417] Attempting to bind pod: arktos/y0g937-testns/latency-deployment-306-8566f7d674-4dftj
I0408 17:40:19.923083       1 scheduler.go:596] pod arktos/y0g937-testns/latency-deployment-306-8566f7d674-4dftj is bound successfully on node hollow-node-1-xpj4t, 101 nodes evaluated, 100 nodes were found feasible
I0408 17:40:19.924021       1 eventhandlers.go:211] Got ADD pod event. pod name latency-deployment-306-8566f7d674-4dftj, rv 15916, status v1.PodStatus{Phase:"Pending", Conditions:[]v1.PodCondition{v1.PodCondition{Type:"PodScheduled", Status:"True", LastProbeTime:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*
time.Location)(nil)}}, LastTransitionTime:v1.Time{Time:time.Time{wall:0x0, ext:63753500419, loc:(*time.Location)(0x2c456c0)}}, Reason:"", Message:""}}, Message:"", Reason:"", NominatedNodeName:"", HostIP:"", PodIP:"", StartTime:(*v1.Time)(nil), InitContainerStatuses:[]v1.ContainerStatus(nil), ContainerStatus
es:[]v1.ContainerStatus(nil), QOSClass:"Burstable", VirtualMachineStatus:(*v1.VirtualMachineStatus)(nil), NICStatuses:[]v1.NICStatus(nil)}

```
