### PR TITLE
Add log for percentageOfNodesToScore vs. evaluated node

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -456,6 +456,8 @@ func (g *genericScheduler) numFeasibleNodesToFind(numAllNodes int32) (numNodes i
 		return minFeasibleNodesToFind
 	}
 
+	klog.V(2).Infof("Get # of evaluated node. Total nodes %v, percentageOfNodesToScore %v, adaptivePercentage %v, node to evaluate %v",
+		numAllNodes, g.percentageOfNodesToScore, adaptivePercentage, numNodes)
 	return numNodes
 }
 


### PR DESCRIPTION
K8s document said percentageOfNodesToScore can be set as lower than 5%. But the code seems only accept 5% as lowest threshold. Adding log to confirm.