### PR TITLE
kube-sched: perf-related back-ports: adopt PR 80533 85030 81346

### DIFF
--- a/pkg/scheduler/algorithm/predicates/metadata.go
+++ b/pkg/scheduler/algorithm/predicates/metadata.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -37,7 +38,8 @@ const (
 	MaxWeight = MaxInt / MaxPriority
 	// DefaultPercentageOfNodesToScore defines the percentage of nodes of all nodes
 	// that once found feasible, the scheduler stops looking for more nodes.
-	DefaultPercentageOfNodesToScore = 50
+	// A value of 0 means adaptive, meaning the scheduler figures out a proper default.
+	DefaultPercentageOfNodesToScore = 0
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -445,7 +445,8 @@ func (g *genericScheduler) numFeasibleNodesToFind(numAllNodes int32) (numNodes i
 
 	adaptivePercentage := g.percentageOfNodesToScore
 	if adaptivePercentage <= 0 {
-		adaptivePercentage = schedulerapi.DefaultPercentageOfNodesToScore - numAllNodes/125
+		basePercentageOfNodesToScore := int32(50)
+		adaptivePercentage = basePercentageOfNodesToScore - numAllNodes/125
 		if adaptivePercentage < minFeasibleNodesPercentageToFind {
 			adaptivePercentage = minFeasibleNodesPercentageToFind
 		}

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -576,7 +576,7 @@ func (g *genericScheduler) findNodesThatFit(pluginContext *framework.PluginConte
 
 // addNominatedPods adds pods with equal or greater priority which are nominated
 // to run on the node given in nodeInfo to meta and nodeInfo. It returns 1) whether
-// any pod was found, 2) augmented meta data, 3) augmented nodeInfo.
+// any pod was added, 2) augmented meta data, 3) augmented nodeInfo.
 func addNominatedPods(pod *v1.Pod, meta predicates.PredicateMetadata,
 	nodeInfo *schedulernodeinfo.NodeInfo, queue internalqueue.SchedulingQueue) (bool, predicates.PredicateMetadata,
 	*schedulernodeinfo.NodeInfo) {
@@ -593,15 +593,17 @@ func addNominatedPods(pod *v1.Pod, meta predicates.PredicateMetadata,
 		metaOut = meta.ShallowCopy()
 	}
 	nodeInfoOut := nodeInfo.Clone()
+	podsAdded := false
 	for _, p := range nominatedPods {
 		if util.GetPodPriority(p) >= util.GetPodPriority(pod) && p.UID != pod.UID {
 			nodeInfoOut.AddPod(p)
 			if metaOut != nil {
 				metaOut.AddPod(p, nodeInfoOut)
 			}
+			podsAdded = true
 		}
 	}
-	return true, metaOut, nodeInfoOut
+	return podsAdded, metaOut, nodeInfoOut
 }
 
 // podFitsOnNode checks whether a node given by NodeInfo satisfies the given predicate functions.

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -196,11 +196,8 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 		return result, prefilterStatus.AsError()
 	}
 
-	nodes, err := nodeLister.List()
-	if err != nil {
-		return result, err
-	}
-	if len(nodes) == 0 {
+	numNodes := g.cache.NodeTree().NumNodes()
+	if numNodes == 0 {
 		return result, ErrNoNodesAvailable
 	}
 
@@ -211,7 +208,7 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 	klog.V(2).Infof("DEBUG: Compute predicates pod: %v/%v/%v", pod.Tenant, pod.Namespace, pod.Name)
 	trace.Step("Computing predicates")
 	startPredicateEvalTime := time.Now()
-	filteredNodes, failedPredicateMap, err := g.findNodesThatFit(pod, nodes)
+	filteredNodes, failedPredicateMap, err := g.findNodesThatFit(pluginContext, pod, nodeLister)
 	if err != nil {
 		return result, err
 	}
@@ -219,7 +216,7 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 	if len(filteredNodes) == 0 {
 		return result, &FitError{
 			Pod:              pod,
-			NumAllNodes:      len(nodes),
+			NumAllNodes:      numNodes,
 			FailedPredicates: failedPredicateMap,
 		}
 	}
@@ -469,12 +466,15 @@ func (g *genericScheduler) numFeasibleNodesToFind(numAllNodes int32) (numNodes i
 
 // Filters the nodes to find the ones that fit based on the given predicate functions
 // Each node is passed through the predicate functions to determine if it is a fit
-func (g *genericScheduler) findNodesThatFit(pod *v1.Pod, nodes []*v1.Node) ([]*v1.Node, FailedPredicateMap, error) {
+func (g *genericScheduler) findNodesThatFit(pluginContext *framework.PluginContext, pod *v1.Pod, nodeLister algorithm.NodeLister) ([]*v1.Node, FailedPredicateMap, error) {
 	var filtered []*v1.Node
 	failedPredicateMap := FailedPredicateMap{}
 
 	if len(g.predicates) == 0 {
-		filtered = nodes
+		var err error
+		if filtered, err = nodeLister.List(); err != nil {
+			return nil, failedPredicateMap, err
+		}
 	} else {
 		allNodes := int32(g.cache.NodeTree().NumNodes())
 		numNodesToFind := g.numFeasibleNodesToFind(allNodes)

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -563,6 +563,72 @@ func TestFindFitSomeError(t *testing.T) {
 	}
 }
 
+type predicateCallCounter struct {
+	count int
+}
+
+func (c *predicateCallCounter) truePredicate() algorithmpredicates.FitPredicate {
+	return func(pod *v1.Pod, meta algorithmpredicates.PredicateMetadata, nodeInfo *schedulernodeinfo.NodeInfo) (bool, []algorithmpredicates.PredicateFailureReason, error) {
+		c.count++
+		return truePredicate(pod, meta, nodeInfo)
+	}
+}
+
+func TestFindFitPredicateCallCounts(t *testing.T) {
+	defer algorithmpredicates.SetPredicatesOrderingDuringTest(order)()
+
+	tests := []struct {
+		name          string
+		pod           *v1.Pod
+		expectedCount int
+	}{
+		{
+			name:          "nominated pods have lower priority, predicate is called once",
+			pod:           &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "1", UID: types.UID("1")}, Spec: v1.PodSpec{Priority: &highPriority}},
+			expectedCount: 1,
+		},
+		{
+			name:          "nominated pods have higher priority, predicate is called twice",
+			pod:           &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "1", UID: types.UID("1")}, Spec: v1.PodSpec{Priority: &lowPriority}},
+			expectedCount: 2,
+		},
+	}
+
+	for _, test := range tests {
+		pc := predicateCallCounter{}
+		predicates := map[string]algorithmpredicates.FitPredicate{"true": pc.truePredicate()}
+		nodes := makeNodeList([]string{"1"})
+
+		cache := internalcache.New(time.Duration(0), wait.NeverStop)
+		for _, n := range nodes {
+			cache.AddNode(n)
+		}
+		prioritizers := []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}}
+		queue := internalqueue.NewSchedulingQueue(nil, nil)
+		scheduler := NewGenericScheduler(
+			cache,
+			queue,
+			predicates,
+			algorithmpredicates.EmptyPredicateMetadataProducer,
+			prioritizers,
+			priorities.EmptyPriorityMetadataProducer,
+			emptyFramework,
+			nil, nil, nil, nil, false, false,
+			schedulerapi.DefaultPercentageOfNodesToScore, false).(*genericScheduler)
+		cache.UpdateNodeInfoSnapshot(scheduler.nodeInfoSnapshot)
+		queue.UpdateNominatedPodForNode(&v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: types.UID("nominated")}, Spec: v1.PodSpec{Priority: &midPriority}}, "1")
+
+		_, _, _, err := scheduler.findNodesThatFit(nil, test.pod)
+
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if test.expectedCount != pc.count {
+			t.Errorf("predicate was called %d times, expected is %d", pc.count, test.expectedCount)
+		}
+	}
+}
+
 func makeNode(node string, milliCPU, memory int64) *v1.Node {
 	return &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: node},


### PR DESCRIPTION
__targeting 430 POC for now__

**What type of PR is this?**
/kind feature (back-port from upstream k8s)

**What this PR does / why we need it**:
including 3 k8s PRs that are perf optimization related
1. [k8s PR80533 Query nodes in Schedule only when there are no predicates](https://github.com/kubernetes/kubernetes/pull/80533)
1. [k8s PR85030 Set default percentageOfNodesToScore in kube-scheduler back to "adaptive"](https://github.com/kubernetes/kubernetes/pull/85030)
1. [k8s PR81346 Add fast path to podFitsOnNode](https://github.com/kubernetes/kubernetes/pull/81346)

**Special notes for your reviewer**:
this is the one of series PRs kube-scheduler related performance related improvements (up to k8s 1.18.5). It will be put out of POC branch until it is perf tested with others in the series. While it is marked as WIP, peer comments are welcome; just not to merge yet.

The code was mostly manually modified based on upstream PR, not automatically cherry-picked, due to the conflicts it would have caused. Unit test code is not introduced in POC; however, when porting to main branch, unit test code should go under necessary revising.

**Does this PR introduce a user-facing change?**:
NONE