### PR TITLE
kube-sched: perf-related: adapt PR 84293, and replace map with slice for referring nodes

### DIFF
--- a/pkg/scheduler/algorithm/predicates/metadata.go
+++ b/pkg/scheduler/algorithm/predicates/metadata.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/scheduler/algorithm/predicates/metadata.go
+++ b/pkg/scheduler/algorithm/predicates/metadata.go
@@ -430,7 +430,9 @@ func getTPMapMatchingExistingAntiAffinity(pod *v1.Pod, nodeInfoMap map[string]*s
 				cancel()
 				return
 			}
-			appendResult(existingPodTopologyMaps)
+			if existingPodTopologyMaps!=nil {
+				appendTopologyPairsMaps(existingPodTopologyMaps)
+			}
 		}
 	}
 

--- a/pkg/scheduler/algorithm/predicates/metadata.go
+++ b/pkg/scheduler/algorithm/predicates/metadata.go
@@ -463,8 +463,10 @@ func getTPMapMatchingIncomingAffinityAntiAffinity(pod *v1.Pod, nodeInfoMap map[s
 		return nil, nil, err
 	}
 	antiAffinityTerms := GetPodAntiAffinityTerms(affinity.PodAntiAffinity)
-
-	ctx, cancel := context.WithCancel(context.Background())
+	antiAffinityProperties, err := getAffinityTermProperties(pod, antiAffinityTerms)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	processNode := func(i int) {
 		nodeInfo := nodeInfoMap[allNodeNames[i]]
@@ -486,15 +488,9 @@ func getTPMapMatchingIncomingAffinityAntiAffinity(pod *v1.Pod, nodeInfoMap map[s
 				}
 			}
 			// Check anti-affinity properties.
-			for _, term := range antiAffinityTerms {
-				namespaces := priorityutil.GetNamespacesFromPodAffinityTerm(pod, &term)
-				selector, err := metav1.LabelSelectorAsSelector(term.LabelSelector)
-				if err != nil {
-					catchError(err)
-					cancel()
-					return
-				}
-				if priorityutil.PodMatchesTermsNamespaceAndSelector(existingPod, namespaces, selector) {
+			for i, term := range antiAffinityTerms {
+				p := antiAffinityProperties[i]
+				if priorityutil.PodMatchesTermsNamespaceAndSelector(existingPod, p.namespaces, p.selector) {
 					if topologyValue, ok := node.Labels[term.TopologyKey]; ok {
 						pair := topologyPair{key: term.TopologyKey, value: topologyValue}
 						nodeTopologyPairsAntiAffinityPodsMaps.addTopologyPair(pair, existingPod)
@@ -510,7 +506,8 @@ func getTPMapMatchingIncomingAffinityAntiAffinity(pod *v1.Pod, nodeInfoMap map[s
 	klog.V(6).Infof("DEBUG: should not see this log in our current perf runs. Number of nodes: %v", len(allNodeNames))
 	// TODO: make this configurable so we can test perf impact when increasing or decreasing concurrency
 	//       on a 96 core machine, it can be much more than 16 concurrent threads to run the processNode function
-	workqueue.ParallelizeUntil(ctx, 16, len(allNodeNames), processNode)
+	workqueue.ParallelizeUntil(context.Background(), 16, len(allNodeNames), processNode)
+
 	return topologyPairsAffinityPodsMaps, topologyPairsAntiAffinityPodsMaps, firstError
 }
 

--- a/pkg/scheduler/algorithm/predicates/metadata.go
+++ b/pkg/scheduler/algorithm/predicates/metadata.go
@@ -430,9 +430,7 @@ func getTPMapMatchingExistingAntiAffinity(pod *v1.Pod, nodeInfoMap map[string]*s
 				cancel()
 				return
 			}
-			if existingPodTopologyMaps!=nil {
-				appendTopologyPairsMaps(existingPodTopologyMaps)
-			}
+			appendResult(existingPodTopologyMaps)
 		}
 	}
 

--- a/pkg/scheduler/algorithm/predicates/metadata.go
+++ b/pkg/scheduler/algorithm/predicates/metadata.go
@@ -422,6 +422,8 @@ func getTPMapMatchingExistingAntiAffinity(pod *v1.Pod, nodeInfoMap map[string]*s
 		existingPods := nodeInfo.PodsWithAffinity()
 		klog.V(6).Infof("Node %v, Pods with Affinity: %v", nodeInfo.Node().Name, len(existingPods))
 		for _, existingPod := range existingPods {
+			// in current arktos perf runs, this should not be reached
+			klog.V(2).Infof("DEBUG: this should not be reached. print out the pod: %v-%v", existingPod.Namespace, existingPod.Name)
 			existingPodTopologyMaps, err := getMatchingAntiAffinityTopologyPairsOfPod(pod, existingPod, node)
 			if err != nil {
 				catchError(err)

--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -1301,13 +1301,13 @@ func GetPodAntiAffinityTerms(podAntiAffinity *v1.PodAntiAffinity) (terms []v1.Po
 // getMatchingAntiAffinityTopologyPairs calculates the following for "existingPod" on given node:
 // (1) Whether it has PodAntiAffinity
 // (2) Whether ANY AffinityTerm matches the incoming pod
-func getMatchingAntiAffinityTopologyPairsOfPod(newPod *v1.Pod, existingPod *v1.Pod, node *v1.Node) (*topologyPairsMaps, error) {
+func getMatchingAntiAffinityTopologyPairsOfPod(newPod *v1.Pod, existingPod *v1.Pod, node *v1.Node) (topologyToMatchedTermCount, error) {
 	affinity := existingPod.Spec.Affinity
 	if affinity == nil || affinity.PodAntiAffinity == nil {
 		return nil, nil
 	}
 
-	topologyMaps := newTopologyPairsMaps()
+	topologyMaps := make(topologyToMatchedTermCount)
 	for _, term := range GetPodAntiAffinityTerms(affinity.PodAntiAffinity) {
 		selector, err := metav1.LabelSelectorAsSelector(term.LabelSelector)
 		if err != nil {
@@ -1317,15 +1317,15 @@ func getMatchingAntiAffinityTopologyPairsOfPod(newPod *v1.Pod, existingPod *v1.P
 		if priorityutil.PodMatchesTermsNamespaceAndSelector(newPod, namespaces, selector) {
 			if topologyValue, ok := node.Labels[term.TopologyKey]; ok {
 				pair := topologyPair{key: term.TopologyKey, value: topologyValue}
-				topologyMaps.addTopologyPair(pair, existingPod)
+				topologyMaps[pair]++
 			}
 		}
 	}
 	return topologyMaps, nil
 }
 
-func (c *PodAffinityChecker) getMatchingAntiAffinityTopologyPairsOfPods(pod *v1.Pod, existingPods []*v1.Pod) (*topologyPairsMaps, error) {
-	topologyMaps := newTopologyPairsMaps()
+func (c *PodAffinityChecker) getMatchingAntiAffinityTopologyPairsOfPods(pod *v1.Pod, existingPods []*v1.Pod) (topologyToMatchedTermCount, error) {
+	topologyMaps := make(topologyToMatchedTermCount)
 
 	for _, existingPod := range existingPods {
 		existingPodNode, _, err := c.info.GetNodeInfo(existingPod.Spec.NodeName)
@@ -1353,9 +1353,9 @@ func (c *PodAffinityChecker) satisfiesExistingPodsAntiAffinity(pod *v1.Pod, meta
 	if node == nil {
 		return ErrExistingPodsAntiAffinityRulesNotMatch, fmt.Errorf("Node is nil")
 	}
-	var topologyMaps *topologyPairsMaps
+	var topologyMaps topologyToMatchedTermCount
 	if predicateMeta, ok := meta.(*predicateMetadata); ok {
-		topologyMaps = predicateMeta.topologyPairsAntiAffinityPodsMap
+		topologyMaps = predicateMeta.podAffinityMetadata.topologyToMatchedExistingAntiAffinityTerms
 	} else {
 		// Filter out pods whose nodeName is equal to nodeInfo.node.Name, but are not
 		// present in nodeInfo. Pods on other nodes pass the filter.
@@ -1375,7 +1375,7 @@ func (c *PodAffinityChecker) satisfiesExistingPodsAntiAffinity(pod *v1.Pod, meta
 	// Iterate over topology pairs to get any of the pods being affected by
 	// the scheduled pod anti-affinity terms
 	for topologyKey, topologyValue := range node.Labels {
-		if topologyMaps.topologyPairToPods[topologyPair{key: topologyKey, value: topologyValue}] != nil {
+		if topologyMaps[topologyPair{key: topologyKey, value: topologyValue}] > 0 {
 			klog.V(10).Infof("Cannot schedule pod %+v onto node %v", podName(pod), node.Name)
 			return ErrExistingPodsAntiAffinityRulesNotMatch, nil
 		}
@@ -1391,12 +1391,12 @@ func (c *PodAffinityChecker) satisfiesExistingPodsAntiAffinity(pod *v1.Pod, meta
 
 //  nodeMatchesAllTopologyTerms checks whether "nodeInfo" matches
 //  topology of all the "terms" for the given "pod".
-func (c *PodAffinityChecker) nodeMatchesAllTopologyTerms(pod *v1.Pod, topologyPairs *topologyPairsMaps, nodeInfo *schedulernodeinfo.NodeInfo, terms []v1.PodAffinityTerm) bool {
+func (c *PodAffinityChecker) nodeMatchesAllTopologyTerms(pod *v1.Pod, topologyPairs topologyToMatchedTermCount, nodeInfo *schedulernodeinfo.NodeInfo, terms []v1.PodAffinityTerm) bool {
 	node := nodeInfo.Node()
 	for _, term := range terms {
 		if topologyValue, ok := node.Labels[term.TopologyKey]; ok {
 			pair := topologyPair{key: term.TopologyKey, value: topologyValue}
-			if _, ok := topologyPairs.topologyPairToPods[pair]; !ok {
+			if topologyPairs[pair] <= 0 {
 				return false
 			}
 		} else {
@@ -1408,12 +1408,12 @@ func (c *PodAffinityChecker) nodeMatchesAllTopologyTerms(pod *v1.Pod, topologyPa
 
 //  nodeMatchesAnyTopologyTerm checks whether "nodeInfo" matches
 //  topology of any "term" for the given "pod".
-func (c *PodAffinityChecker) nodeMatchesAnyTopologyTerm(pod *v1.Pod, topologyPairs *topologyPairsMaps, nodeInfo *schedulernodeinfo.NodeInfo, terms []v1.PodAffinityTerm) bool {
+func (c *PodAffinityChecker) nodeMatchesAnyTopologyTerm(pod *v1.Pod, topologyPairs topologyToMatchedTermCount, nodeInfo *schedulernodeinfo.NodeInfo, terms []v1.PodAffinityTerm) bool {
 	node := nodeInfo.Node()
 	for _, term := range terms {
 		if topologyValue, ok := node.Labels[term.TopologyKey]; ok {
 			pair := topologyPair{key: term.TopologyKey, value: topologyValue}
-			if _, ok := topologyPairs.topologyPairToPods[pair]; ok {
+			if topologyPairs[pair] > 0 {
 				return true
 			}
 		}
@@ -1431,15 +1431,15 @@ func (c *PodAffinityChecker) satisfiesPodsAffinityAntiAffinity(pod *v1.Pod,
 	}
 	if predicateMeta, ok := meta.(*predicateMetadata); ok {
 		// Check all affinity terms.
-		topologyPairsPotentialAffinityPods := predicateMeta.topologyPairsPotentialAffinityPods
+		topologyToMatchedAffinityTerms := predicateMeta.podAffinityMetadata.topologyToMatchedAffinityTerms
 		if affinityTerms := GetPodAffinityTerms(affinity.PodAffinity); len(affinityTerms) > 0 {
-			matchExists := c.nodeMatchesAllTopologyTerms(pod, topologyPairsPotentialAffinityPods, nodeInfo, affinityTerms)
+			matchExists := c.nodeMatchesAllTopologyTerms(pod, topologyToMatchedAffinityTerms, nodeInfo, affinityTerms)
 			if !matchExists {
 				// This pod may the first pod in a series that have affinity to themselves. In order
 				// to not leave such pods in pending state forever, we check that if no other pod
 				// in the cluster matches the namespace and selector of this pod and the pod matches
 				// its own terms, then we allow the pod to pass the affinity check.
-				if !(len(topologyPairsPotentialAffinityPods.topologyPairToPods) == 0 && targetPodMatchesAffinityOfPod(pod, pod)) {
+				if !(len(topologyToMatchedAffinityTerms) == 0 && targetPodMatchesAffinityOfPod(pod, pod)) {
 					klog.V(10).Infof("Cannot schedule pod %+v onto node %v, because of PodAffinity",
 						podName(pod), node.Name)
 					return ErrPodAffinityRulesNotMatch, nil
@@ -1448,7 +1448,7 @@ func (c *PodAffinityChecker) satisfiesPodsAffinityAntiAffinity(pod *v1.Pod,
 		}
 
 		// Check all anti-affinity terms.
-		topologyPairsPotentialAntiAffinityPods := predicateMeta.topologyPairsPotentialAntiAffinityPods
+		topologyPairsPotentialAntiAffinityPods := predicateMeta.podAffinityMetadata.topologyToMatchedAntiAffinityTerms
 		if antiAffinityTerms := GetPodAntiAffinityTerms(affinity.PodAntiAffinity); len(antiAffinityTerms) > 0 {
 			matchExists := c.nodeMatchesAnyTopologyTerm(pod, topologyPairsPotentialAntiAffinityPods, nodeInfo, antiAffinityTerms)
 			if matchExists {

--- a/pkg/scheduler/algorithm/predicates/testing_helper.go
+++ b/pkg/scheduler/algorithm/predicates/testing_helper.go
@@ -50,13 +50,13 @@ func (n FakeNodeInfo) GetNodeInfo(nodeName string) (*v1.Node, error) {
 type FakeNodeListInfo []v1.Node
 
 // GetNodeInfo returns a fake node object in the fake nodes.
-func (nodes FakeNodeListInfo) GetNodeInfo(nodeName string) (*v1.Node, error) {
+func (nodes FakeNodeListInfo) GetNodeInfo(nodeName string) (*v1.Node, string, error) {
 	for _, node := range nodes {
 		if node.Name == nodeName {
-			return &node, nil
+			return &node, nodeName, nil
 		}
 	}
-	return nil, fmt.Errorf("Unable to find node: %s", nodeName)
+	return nil, "", fmt.Errorf("Unable to find node: %s", nodeName)
 }
 
 // FakePersistentVolumeInfo declares a []v1.PersistentVolume type for testing.

--- a/pkg/scheduler/algorithm/priorities/interpod_affinity.go
+++ b/pkg/scheduler/algorithm/priorities/interpod_affinity.go
@@ -114,7 +114,7 @@ func (p *podAffinityPriorityMap) processTerms(terms []v1.WeightedPodAffinityTerm
 // that node; the node(s) with the highest sum are the most preferred.
 // Symmetry need to be considered for preferredDuringSchedulingIgnoredDuringExecution from podAffinity & podAntiAffinity,
 // symmetry need to be considered for hard requirements from podAffinity
-func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, nodeNameToInfo map[string]*schedulernodeinfo.NodeInfo, nodes []*v1.Node) (schedulerapi.HostPriorityList, error) {
+func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, nodeNameToInfo map[string]*schedulernodeinfo.NodeInfo, nis []*schedulernodeinfo.NodeInfo, nodes []*v1.Node) (schedulerapi.HostPriorityList, error) {
 	affinity := pod.Spec.Affinity
 	hasAffinityConstraints := affinity != nil && affinity.PodAffinity != nil
 	hasAntiAffinityConstraints := affinity != nil && affinity.PodAntiAffinity != nil
@@ -199,7 +199,7 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, node
 		return nil
 	}
 	processNode := func(i int) {
-		nodeInfo := nodeNameToInfo[allNodeNames[i]]
+		nodeInfo := nis[i]
 		if nodeInfo.Node() != nil {
 			if hasAffinityConstraints || hasAntiAffinityConstraints {
 				// We need to process all the pods.

--- a/pkg/scheduler/algorithm/priorities/test_util.go
+++ b/pkg/scheduler/algorithm/priorities/test_util.go
@@ -41,10 +41,10 @@ func makeNode(node string, milliCPU, memory int64) *v1.Node {
 }
 
 func priorityFunction(mapFn PriorityMapFunction, reduceFn PriorityReduceFunction, metaData interface{}) PriorityFunction {
-	return func(pod *v1.Pod, nodeNameToInfo map[string]*schedulernodeinfo.NodeInfo, nodes []*v1.Node) (schedulerapi.HostPriorityList, error) {
+	return func(pod *v1.Pod, nodeNameToInfo map[string]*schedulernodeinfo.NodeInfo, nis []*schedulernodeinfo.NodeInfo, nodes []*v1.Node) (schedulerapi.HostPriorityList, error) {
 		result := make(schedulerapi.HostPriorityList, 0, len(nodes))
 		for i := range nodes {
-			hostResult, err := mapFn(pod, metaData, nodeNameToInfo[nodes[i].Name])
+			hostResult, err := mapFn(pod, metaData, nis[i])
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/scheduler/algorithm/priorities/types.go
+++ b/pkg/scheduler/algorithm/priorities/types.go
@@ -40,7 +40,7 @@ type PriorityMetadataProducer func(pod *v1.Pod, nodeNameToInfo map[string]*sched
 // PriorityFunction is a function that computes scores for all nodes.
 // DEPRECATED
 // Use Map-Reduce pattern for priority functions.
-type PriorityFunction func(pod *v1.Pod, nodeNameToInfo map[string]*schedulernodeinfo.NodeInfo, nodes []*v1.Node) (schedulerapi.HostPriorityList, error)
+type PriorityFunction func(pod *v1.Pod, nodeNameToInfo map[string]*schedulernodeinfo.NodeInfo, nis []*schedulernodeinfo.NodeInfo, nodes []*v1.Node) (schedulerapi.HostPriorityList, error)
 
 // PriorityConfig is a config used for a priority function.
 type PriorityConfig struct {

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -37,7 +38,8 @@ const (
 	MaxWeight = MaxInt / MaxPriority
 	// DefaultPercentageOfNodesToScore defines the percentage of nodes of all nodes
 	// that once found feasible, the scheduler stops looking for more nodes.
-	DefaultPercentageOfNodesToScore = 50
+	// A value of 0 means adaptive, meaning the scheduler figures out a proper default.
+	DefaultPercentageOfNodesToScore = 0
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand"
 	"sort"
 	"strings"
 	"sync"
@@ -161,7 +162,6 @@ type genericScheduler struct {
 	prioritizers             []priorities.PriorityConfig
 	framework                framework.Framework
 	extenders                []algorithm.SchedulerExtender
-	lastNodeIndex            uint64
 	alwaysCheckAllPredicates bool
 	nodeInfoSnapshot         *internalcache.NodeInfoSnapshot
 	volumeBinder             *volumebinder.VolumeBinder
@@ -272,34 +272,29 @@ func (g *genericScheduler) Predicates() map[string]predicates.FitPredicate {
 	return g.predicates
 }
 
-// findMaxScores returns the indexes of nodes in the "priorityList" that has the highest "Score".
-func findMaxScores(priorityList schedulerapi.HostPriorityList) []int {
-	maxScoreIndexes := make([]int, 0, len(priorityList)/2)
-	maxScore := priorityList[0].Score
-	for i, hp := range priorityList {
-		if hp.Score > maxScore {
-			maxScore = hp.Score
-			maxScoreIndexes = maxScoreIndexes[:0]
-			maxScoreIndexes = append(maxScoreIndexes, i)
-		} else if hp.Score == maxScore {
-			maxScoreIndexes = append(maxScoreIndexes, i)
-		}
-	}
-	return maxScoreIndexes
-}
-
 // selectHost takes a prioritized list of nodes and then picks one
-// in a round-robin manner from the nodes that had the highest score.
+// in a reservoir sampling manner from the nodes that had the highest score.
 func (g *genericScheduler) selectHost(priorityList schedulerapi.HostPriorityList) (string, error) {
 	if len(priorityList) == 0 {
 		return "", fmt.Errorf("empty priorityList")
 	}
-
-	maxScores := findMaxScores(priorityList)
-	ix := int(g.lastNodeIndex % uint64(len(maxScores)))
-	g.lastNodeIndex++
-
-	return priorityList[maxScores[ix]].Host, nil
+	maxScore := priorityList[0].Score
+	selected := priorityList[0].Host
+	cntOfMaxScore := 1
+	for _, hp := range priorityList[1:] {
+		if hp.Score > maxScore {
+			maxScore = hp.Score
+			selected = hp.Host
+			cntOfMaxScore = 1
+		} else if hp.Score == maxScore {
+			cntOfMaxScore++
+			if rand.Intn(cntOfMaxScore) == 0 {
+				// Replace the candidate with probability of 1/cntOfMaxScore
+				selected = hp.Host
+			}
+		}
+	}
+	return selected, nil
 }
 
 // preempt finds nodes with pods that can be preempted to make room for "pod" to

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -445,7 +445,8 @@ func (g *genericScheduler) numFeasibleNodesToFind(numAllNodes int32) (numNodes i
 
 	adaptivePercentage := g.percentageOfNodesToScore
 	if adaptivePercentage <= 0 {
-		adaptivePercentage = schedulerapi.DefaultPercentageOfNodesToScore - numAllNodes/125
+		basePercentageOfNodesToScore := int32(50)
+		adaptivePercentage = basePercentageOfNodesToScore - numAllNodes/125
 		if adaptivePercentage < minFeasibleNodesPercentageToFind {
 			adaptivePercentage = minFeasibleNodesPercentageToFind
 		}

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -247,7 +247,7 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 	}
 
 	metaPrioritiesInterface := g.priorityMetaProducer(pod, g.nodeInfoSnapshot.NodeInfoMap)
-	priorityList, err := PrioritizeNodes(pod, g.nodeInfoSnapshot.NodeInfoMap, metaPrioritiesInterface, g.prioritizers, filteredNodes, g.extenders)
+	priorityList, err := PrioritizeNodes(pod, g.nodeInfoSnapshot.NodeInfoMap, g.nodeInfoSnapshot.List(), metaPrioritiesInterface, g.prioritizers, filteredNodes, g.extenders)
 	if err != nil {
 		return result, err
 	}
@@ -701,6 +701,7 @@ func podFitsOnNode(
 func PrioritizeNodes(
 	pod *v1.Pod,
 	nodeNameToInfo map[string]*schedulernodeinfo.NodeInfo,
+	nis []*schedulernodeinfo.NodeInfo,
 	meta interface{},
 	priorityConfigs []priorities.PriorityConfig,
 	nodes []*v1.Node,
@@ -741,7 +742,7 @@ func PrioritizeNodes(
 			go func(index int) {
 				defer wg.Done()
 				var err error
-				results[index], err = priorityConfigs[index].Function(pod, nodeNameToInfo, nodes)
+				results[index], err = priorityConfigs[index].Function(pod, nodeNameToInfo, nis, nodes)
 				if err != nil {
 					appendError(err)
 				}

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -1088,10 +1088,10 @@ func selectVictimsOnNode(
 	potentialVictims := util.SortableList{CompFunc: util.MoreImportantPod}
 	nodeInfoCopy := nodeInfo.Clone()
 
-	removePod := func(rp *v1.Pod) {
+	removePod := func(rp *v1.Pod, node *v1.Node) {
 		nodeInfoCopy.RemovePod(rp)
 		if meta != nil {
-			meta.RemovePod(rp)
+			meta.RemovePod(rp, node)
 		}
 	}
 	addPod := func(ap *v1.Pod) {
@@ -1106,7 +1106,7 @@ func selectVictimsOnNode(
 	for _, p := range nodeInfoCopy.Pods() {
 		if util.GetPodPriority(p) < podPriority {
 			potentialVictims.Items = append(potentialVictims.Items, p)
-			removePod(p)
+			removePod(p, nodeInfo.Node())
 		}
 	}
 	// If the new pod does not fit after removing all the lower priority pods,
@@ -1132,7 +1132,7 @@ func selectVictimsOnNode(
 		addPod(p)
 		fits, _, _ := podFitsOnNode(pod, meta, nodeInfoCopy, fitPredicates, queue, false)
 		if !fits {
-			removePod(p)
+			removePod(p, nodeInfo.Node())
 			victims = append(victims, p)
 			klog.V(5).Infof("Pod %v/%v is a potential preemption victim on node %v.", p.Namespace, p.Name, nodeInfo.Node().Name)
 		}

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -576,7 +576,7 @@ func (g *genericScheduler) findNodesThatFit(pluginContext *framework.PluginConte
 
 // addNominatedPods adds pods with equal or greater priority which are nominated
 // to run on the node given in nodeInfo to meta and nodeInfo. It returns 1) whether
-// any pod was found, 2) augmented meta data, 3) augmented nodeInfo.
+// any pod was added, 2) augmented meta data, 3) augmented nodeInfo.
 func addNominatedPods(pod *v1.Pod, meta predicates.PredicateMetadata,
 	nodeInfo *schedulernodeinfo.NodeInfo, queue internalqueue.SchedulingQueue) (bool, predicates.PredicateMetadata,
 	*schedulernodeinfo.NodeInfo) {
@@ -593,15 +593,17 @@ func addNominatedPods(pod *v1.Pod, meta predicates.PredicateMetadata,
 		metaOut = meta.ShallowCopy()
 	}
 	nodeInfoOut := nodeInfo.Clone()
+	podsAdded := false
 	for _, p := range nominatedPods {
 		if util.GetPodPriority(p) >= util.GetPodPriority(pod) && p.UID != pod.UID {
 			nodeInfoOut.AddPod(p)
 			if metaOut != nil {
 				metaOut.AddPod(p, nodeInfoOut)
 			}
+			podsAdded = true
 		}
 	}
-	return true, metaOut, nodeInfoOut
+	return podsAdded, metaOut, nodeInfoOut
 }
 
 // podFitsOnNode checks whether a node given by NodeInfo satisfies the given predicate functions.

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -196,11 +196,8 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 		return result, prefilterStatus.AsError()
 	}
 
-	nodes, err := nodeLister.List()
-	if err != nil {
-		return result, err
-	}
-	if len(nodes) == 0 {
+	numNodes := g.cache.NodeTree().NumNodes()
+	if numNodes == 0 {
 		return result, ErrNoNodesAvailable
 	}
 
@@ -211,7 +208,7 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 	klog.V(2).Infof("DEBUG: Compute predicates pod: %v/%v/%v", pod.Tenant, pod.Namespace, pod.Name)
 	trace.Step("Computing predicates")
 	startPredicateEvalTime := time.Now()
-	filteredNodes, failedPredicateMap, err := g.findNodesThatFit(pod, nodes)
+	filteredNodes, failedPredicateMap, err := g.findNodesThatFit(pluginContext, pod, nodeLister)
 	if err != nil {
 		return result, err
 	}
@@ -219,7 +216,7 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, nodeLister algorithm.NodeLister
 	if len(filteredNodes) == 0 {
 		return result, &FitError{
 			Pod:              pod,
-			NumAllNodes:      len(nodes),
+			NumAllNodes:      numNodes,
 			FailedPredicates: failedPredicateMap,
 		}
 	}
@@ -469,12 +466,15 @@ func (g *genericScheduler) numFeasibleNodesToFind(numAllNodes int32) (numNodes i
 
 // Filters the nodes to find the ones that fit based on the given predicate functions
 // Each node is passed through the predicate functions to determine if it is a fit
-func (g *genericScheduler) findNodesThatFit(pod *v1.Pod, nodes []*v1.Node) ([]*v1.Node, FailedPredicateMap, error) {
+func (g *genericScheduler) findNodesThatFit(pluginContext *framework.PluginContext, pod *v1.Pod, nodeLister algorithm.NodeLister) ([]*v1.Node, FailedPredicateMap, error) {
 	var filtered []*v1.Node
 	failedPredicateMap := FailedPredicateMap{}
 
 	if len(g.predicates) == 0 {
-		filtered = nodes
+		var err error
+		if filtered, err = nodeLister.List(); err != nil {
+			return nil, failedPredicateMap, err
+		}
 	} else {
 		allNodes := int32(g.cache.NodeTree().NumNodes())
 		numNodesToFind := g.numFeasibleNodesToFind(allNodes)

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -738,7 +738,7 @@ func PrioritizeNodes(
 		}
 	}
 
-	klog.V(2).Infof("Number of nodes: %v", len(nodes))
+	klog.V(6).Infof("Number of nodes: %v", len(nodes))
 	// TODO: make this configurable so we can test perf impact when increasing or decreasing concurrency
 	//       on a 96 core machine, it can be much more than 16 concurrent threads to run the processNode function
 	workqueue.ParallelizeUntil(context.TODO(), 16, len(nodes), func(index int) {

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -563,6 +563,72 @@ func TestFindFitSomeError(t *testing.T) {
 	}
 }
 
+type predicateCallCounter struct {
+	count int
+}
+
+func (c *predicateCallCounter) truePredicate() algorithmpredicates.FitPredicate {
+	return func(pod *v1.Pod, meta algorithmpredicates.PredicateMetadata, nodeInfo *schedulernodeinfo.NodeInfo) (bool, []algorithmpredicates.PredicateFailureReason, error) {
+		c.count++
+		return truePredicate(pod, meta, nodeInfo)
+	}
+}
+
+func TestFindFitPredicateCallCounts(t *testing.T) {
+	defer algorithmpredicates.SetPredicatesOrderingDuringTest(order)()
+
+	tests := []struct {
+		name          string
+		pod           *v1.Pod
+		expectedCount int
+	}{
+		{
+			name:          "nominated pods have lower priority, predicate is called once",
+			pod:           &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "1", UID: types.UID("1")}, Spec: v1.PodSpec{Priority: &highPriority}},
+			expectedCount: 1,
+		},
+		{
+			name:          "nominated pods have higher priority, predicate is called twice",
+			pod:           &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "1", UID: types.UID("1")}, Spec: v1.PodSpec{Priority: &lowPriority}},
+			expectedCount: 2,
+		},
+	}
+
+	for _, test := range tests {
+		pc := predicateCallCounter{}
+		predicates := map[string]algorithmpredicates.FitPredicate{"true": pc.truePredicate()}
+		nodes := makeNodeList([]string{"1"})
+
+		cache := internalcache.New(time.Duration(0), wait.NeverStop)
+		for _, n := range nodes {
+			cache.AddNode(n)
+		}
+		prioritizers := []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}}
+		queue := internalqueue.NewSchedulingQueue(nil, nil)
+		scheduler := NewGenericScheduler(
+			cache,
+			queue,
+			predicates,
+			algorithmpredicates.EmptyPredicateMetadataProducer,
+			prioritizers,
+			priorities.EmptyPriorityMetadataProducer,
+			emptyFramework,
+			nil, nil, nil, nil, false, false,
+			schedulerapi.DefaultPercentageOfNodesToScore, false).(*genericScheduler)
+		cache.UpdateNodeInfoSnapshot(scheduler.nodeInfoSnapshot)
+		queue.UpdateNominatedPodForNode(&v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: types.UID("nominated")}, Spec: v1.PodSpec{Priority: &midPriority}}, "1")
+
+		_, _, _, err := scheduler.findNodesThatFit(nil, test.pod)
+
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if test.expectedCount != pc.count {
+			t.Errorf("predicate was called %d times, expected is %d", pc.count, test.expectedCount)
+		}
+	}
+}
+
 func makeNode(node string, milliCPU, memory int64) *v1.Node {
 	return &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: node},

--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -357,7 +357,7 @@ func (cache *schedulerCache) ForgetPod(pod *v1.Pod) error {
 func (cache *schedulerCache) addPod(pod *v1.Pod) {
 	n, ok := cache.nodes[pod.Spec.NodeName]
 	if !ok {
-		// TODO - check whether RP id should be availalble now
+		// TODO - check whether RP id should be available now
 		n = newNodeInfoListItem(schedulernodeinfo.NewNodeInfo())
 		cache.nodes[pod.Spec.NodeName] = n
 	}

--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -357,7 +357,7 @@ func (cache *schedulerCache) ForgetPod(pod *v1.Pod) error {
 func (cache *schedulerCache) addPod(pod *v1.Pod) {
 	n, ok := cache.nodes[pod.Spec.NodeName]
 	if !ok {
-		// TODO - check whether RP id should be available now
+		// TODO - check whether RP id should be availalble now
 		n = newNodeInfoListItem(schedulernodeinfo.NewNodeInfo())
 		cache.nodes[pod.Spec.NodeName] = n
 	}

--- a/pkg/scheduler/internal/cache/interface.go
+++ b/pkg/scheduler/internal/cache/interface.go
@@ -128,4 +128,19 @@ type Snapshot struct {
 type NodeInfoSnapshot struct {
 	NodeInfoMap map[string]*schedulernodeinfo.NodeInfo
 	Generation  int64
+
+	NodeInfoList []*schedulernodeinfo.NodeInfo
+}
+
+func (n *NodeInfoSnapshot) GenList() {
+	n.NodeInfoList = make([]*schedulernodeinfo.NodeInfo, len(n.NodeInfoMap))
+	i := 0
+	for _, v := range n.NodeInfoMap {
+		n.NodeInfoList[i] = v
+		i++
+	}
+}
+
+func (n *NodeInfoSnapshot) List() []*schedulernodeinfo.NodeInfo {
+	return n.NodeInfoList
 }

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -423,7 +423,7 @@ func (p *PriorityQueue) Pop() (*v1.Pod, error) {
 	p.schedulingCycle++
 
 	end := time.Now()
-	klog.V(2).Infof("Pod pod %v-$v, duration %v ms", pInfo.Pod.Namespace, pInfo.Pod.Name, end.Sub(start).Milliseconds())
+	klog.V(2).Infof("Pop pod %v-%v, duration %v ms", pInfo.Pod.Namespace, pInfo.Pod.Name, end.Sub(start).Milliseconds())
 	return pInfo.Pod, err
 }
 

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -42,6 +42,7 @@ import (
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/util"
+	utiltrace "k8s.io/utils/trace"
 )
 
 var (
@@ -205,10 +206,13 @@ func (p *PriorityQueue) run() {
 // Add adds a pod to the active queue. It should be called only when a new pod
 // is added so there is no chance the pod is already in active/unschedulable/backoff queues
 func (p *PriorityQueue) Add(pod *v1.Pod) error {
+	trace := utiltrace.New(fmt.Sprintf("Adding Pod %s-%s to queue", pod.Namespace, pod.Name))
+	defer trace.LogIfLong(5 * time.Millisecond)
+
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	klog.V(2).Infof("adding pod %v/%v/%v to the scheduling queue.", pod.Tenant, pod.Namespace, pod.Name)
-
+	trace.Step("Adding pod")
 	pInfo := p.newPodInfo(pod)
 	if err := p.activeQ.Add(pInfo); err != nil {
 		klog.Errorf("Error adding pod %v/%v/%v to the scheduling queue: %v", pod.Tenant, pod.Namespace, pod.Name, err)
@@ -223,6 +227,8 @@ func (p *PriorityQueue) Add(pod *v1.Pod) error {
 		klog.Errorf("Error: pod %v/%v/%v is already in the podBackoff queue.", pod.Tenant, pod.Namespace, pod.Name)
 	}
 	p.nominatedPods.add(pod, "")
+
+	trace.Step("Boradcasting pod")
 	p.cond.Broadcast()
 
 	return nil
@@ -391,11 +397,13 @@ func (p *PriorityQueue) flushUnschedulableQLeftover() {
 // activeQ is empty and waits until a new item is added to the queue. It
 // increments scheduling cycle when a pod is popped.
 func (p *PriorityQueue) Pop() (*v1.Pod, error) {
-	start := time.Now()
+	trace := utiltrace.New(fmt.Sprintf("Poping Pod from queue"))
+	defer trace.LogIfLong(3 * time.Millisecond)
 
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
+	trace.Step("Wait active queue")
 	for p.activeQ.Len() == 0 {
 		// When the queue is empty, invocation of Pop() is blocked until new item is enqueued.
 		// When Close() is called, the p.closed is set and the condition is broadcast,
@@ -405,6 +413,8 @@ func (p *PriorityQueue) Pop() (*v1.Pod, error) {
 		}
 		p.cond.Wait()
 	}
+
+	trace.Step("Pod pod")
 	obj, err := p.activeQ.Pop()
 	if err != nil {
 		return nil, err

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -391,8 +391,11 @@ func (p *PriorityQueue) flushUnschedulableQLeftover() {
 // activeQ is empty and waits until a new item is added to the queue. It
 // increments scheduling cycle when a pod is popped.
 func (p *PriorityQueue) Pop() (*v1.Pod, error) {
+	start := time.Now()
+
 	p.lock.Lock()
 	defer p.lock.Unlock()
+
 	for p.activeQ.Len() == 0 {
 		// When the queue is empty, invocation of Pop() is blocked until new item is enqueued.
 		// When Close() is called, the p.closed is set and the condition is broadcast,
@@ -408,6 +411,9 @@ func (p *PriorityQueue) Pop() (*v1.Pod, error) {
 	}
 	pInfo := obj.(*framework.PodInfo)
 	p.schedulingCycle++
+
+	end := time.Now()
+	klog.V(2).Infof("Pod pod %v-$v, duration %v ms", pInfo.Pod.Namespace, pInfo.Pod.Name, end.Sub(start).Milliseconds())
 	return pInfo.Pod, err
 }
 

--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -42,7 +42,6 @@ import (
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/util"
-	utiltrace "k8s.io/utils/trace"
 )
 
 var (
@@ -206,13 +205,10 @@ func (p *PriorityQueue) run() {
 // Add adds a pod to the active queue. It should be called only when a new pod
 // is added so there is no chance the pod is already in active/unschedulable/backoff queues
 func (p *PriorityQueue) Add(pod *v1.Pod) error {
-	trace := utiltrace.New(fmt.Sprintf("Adding Pod %s-%s to queue", pod.Namespace, pod.Name))
-	defer trace.LogIfLong(5 * time.Millisecond)
-
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	klog.V(2).Infof("adding pod %v/%v/%v to the scheduling queue.", pod.Tenant, pod.Namespace, pod.Name)
-	trace.Step("Adding pod")
+
 	pInfo := p.newPodInfo(pod)
 	if err := p.activeQ.Add(pInfo); err != nil {
 		klog.Errorf("Error adding pod %v/%v/%v to the scheduling queue: %v", pod.Tenant, pod.Namespace, pod.Name, err)
@@ -227,8 +223,6 @@ func (p *PriorityQueue) Add(pod *v1.Pod) error {
 		klog.Errorf("Error: pod %v/%v/%v is already in the podBackoff queue.", pod.Tenant, pod.Namespace, pod.Name)
 	}
 	p.nominatedPods.add(pod, "")
-
-	trace.Step("Boradcasting pod")
 	p.cond.Broadcast()
 
 	return nil
@@ -397,13 +391,11 @@ func (p *PriorityQueue) flushUnschedulableQLeftover() {
 // activeQ is empty and waits until a new item is added to the queue. It
 // increments scheduling cycle when a pod is popped.
 func (p *PriorityQueue) Pop() (*v1.Pod, error) {
-	trace := utiltrace.New(fmt.Sprintf("Poping Pod from queue"))
-	defer trace.LogIfLong(3 * time.Millisecond)
+	start := time.Now()
 
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	trace.Step("Wait active queue")
 	for p.activeQ.Len() == 0 {
 		// When the queue is empty, invocation of Pop() is blocked until new item is enqueued.
 		// When Close() is called, the p.closed is set and the condition is broadcast,
@@ -413,8 +405,6 @@ func (p *PriorityQueue) Pop() (*v1.Pod, error) {
 		}
 		p.cond.Wait()
 	}
-
-	trace.Step("Pod pod")
 	obj, err := p.activeQ.Pop()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
__targeting 430 POC for now__

**What type of PR is this?**
/kind feature (partially adapted on upstream k8s PR)

**What this PR does / why we need it**:
* adapted part of [PR#84293](https://github.com/kubernetes/kubernetes/pull/84293) use nodes snapshot instead of cache;
* in getTPMapMatchingExistingAntiAffinity and CalculateInterPodAffinityPriority methods, not to use map but adopt slice of node info objects;

**Special notes for your reviewer**:
commits up to cfe9abc have already tested in various scale tests, which proved limited (even little) perf gains for large system. Please ignore commits before/at cfe9abc.

this is the one of series PRs kube-scheduler related performance related improvements (up to k8s 1.18.5). It will be put out of POC branch until it is perf tested with others in the series. While it is marked as WIP, peer comments are welcome; just not to merge yet.

The adapted code ( commit 6ddf1d7 ) was inspired by upstream PR; only small chunk of code in the original PR was extracted out manually.
Other parts (commits 7cbab08 & b92c3a9) are attempts to optimization based on live system perf analysis; these need to be verified against large scale test to understand their impacts.

**Does this PR introduce a user-facing change?**:
NONE
