### PR TITLE
fix prometheus config to include haproxy metrics

### DIFF
--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -1430,7 +1430,11 @@ scrape_configs:
   - job_name: prometheus-metrics
     static_configs:
     - targets: ['127.0.0.1:2382','127.0.0.1:8080','127.0.0.1:10251','127.0.0.1:10252']
+  - job_name: 'haproxy'
+    static_configs:
+    - targets: ['scale_out_proxy_ip:8404']
 EOF
+  sed -i -e "s/scale_out_proxy_ip/$PROXY_RESERVED_IP/g" /tmp/prometheus-metrics.yaml
   nohup ./prometheus --config.file="/tmp/prometheus-metrics.yaml" --web.listen-address=":9090" --web.enable-admin-api > prometheus.log 2>&1 &
 
 }


### PR DESCRIPTION

**What type of PR is this?**
> /kind bug


**What this PR does / why we need it**:
> prometheus metric for the Arktos proxy is not picked up by the cluster api servers. this is a missing code in 330 code merged and fixed in 530 perf branch. Now merge the fix to master.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None
