### PR TITLE
Decouple proxy operations from kube-up and create-master functions and optimize proxy creation routines

### DIFF
--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -1430,9 +1430,6 @@ scrape_configs:
   - job_name: prometheus-metrics
     static_configs:
     - targets: ['127.0.0.1:2382','127.0.0.1:8080','127.0.0.1:10251','127.0.0.1:10252']
-  - job_name: 'haproxy'
-    static_configs:
-    - targets: ['scale_out_proxy_ip:8404']
 EOF
   sed -i -e "s/scale_out_proxy_ip/$PROXY_RESERVED_IP/g" /tmp/prometheus-metrics.yaml
   nohup ./prometheus --config.file="/tmp/prometheus-metrics.yaml" --web.listen-address=":9090" --web.enable-admin-api > prometheus.log 2>&1 &

--- a/cluster/proxy-down.sh
+++ b/cluster/proxy-down.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Authors of Arktos - file modified.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Delete proxy in Arktos clusters
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+if [ -f "${KUBE_ROOT}/cluster/env.sh" ]; then
+    source "${KUBE_ROOT}/cluster/env.sh"
+fi
+
+source "${KUBE_ROOT}/cluster/kube-util.sh"
+
+detect-project
+detect-subnetworks
+
+if [ -z "${ZONE-}" ]; then
+  echo "... Using provider: ${KUBERNETES_PROVIDER}" >&2
+else
+  echo "... In ${ZONE} using provider ${KUBERNETES_PROVIDER}" >&2
+fi
+
+if gcloud compute instances describe "${SCALEOUT_PROXY_NAME}" --zone "${ZONE}" --project "${PROJECT}" &>/dev/null; then
+  gcloud compute instances delete \
+    --project "${PROJECT}" \
+    --quiet \
+    --delete-disks all \
+    --zone "${ZONE}" \
+    "${SCALEOUT_PROXY_NAME}"
+fi
+# Delete firewall rule for the proxy.
+delete-firewall-rules "${SCALEOUT_PROXY_NAME}-https"
+echo "Deleting proxy's reserved IP"
+if gcloud compute addresses describe "${SCALEOUT_PROXY_NAME}-ip" --region "${REGION}" --project "${PROJECT}" &>/dev/null; then
+  gcloud compute addresses delete \
+    --project "${PROJECT}" \
+    --region "${REGION}" \
+    --quiet \
+    "${PROXY_NAME}-ip"
+fi
+if gcloud compute addresses describe "${SCALEOUT_PROXY_NAME}-internalip" --region "${REGION}" --project "${PROJECT}" &>/dev/null; then
+  gcloud compute addresses delete \
+    --project "${PROJECT}" \
+    --region "${REGION}" \
+    --quiet \
+    "${SCALEOUT_PROXY_NAME}-internalip"
+fi
+
+echo "Done. deleted arktos-proxy"
+
+exit 0

--- a/cluster/proxy-up.sh
+++ b/cluster/proxy-up.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Authors of Arktos - file modified.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Setup proxy for Arktos clusters
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+if [ -f "${KUBE_ROOT}/cluster/env.sh" ]; then
+    source "${KUBE_ROOT}/cluster/env.sh"
+fi
+
+source "${KUBE_ROOT}/cluster/kube-util.sh"
+
+if [ -z "${ZONE-}" ]; then
+  echo "... Creating proxy using provider: ${KUBERNETES_PROVIDER}" >&2
+else
+  echo "... Creating proxy in ${ZONE} using provider ${KUBERNETES_PROVIDER}" >&2
+fi
+
+echo "... calling verify-prereqs" >&2
+verify-prereqs
+
+echo "...calling proxy-up" >&2
+proxy-up
+
+exit 0

--- a/cluster/skeleton/util.sh
+++ b/cluster/skeleton/util.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright 2016 The Kubernetes Authors.
+# Copyright 2020 Authors of Arktos - file modified.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,6 +64,10 @@ function test-build-release {
 # Execute prior to running tests to initialize required structure
 function test-setup {
 	echo "Skeleton Provider: test-setup not implemented" 1>&2
+}
+
+function proxy-setup {
+	echo "Skeleton Provider: proxy-setup not implemented" 1>&2
 }
 
 # Execute after running tests to perform any required clean-up

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -72,16 +72,10 @@ fi
 ### files to explicitly save the kubeconfig to different cluster or proxy
 ### those are used for targeted operations such as tenant creation etc on
 ### desired cluster directly
-###
-PROXY_KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-proxy"
-
-export KUBERNETES_SCALEOUT_PROXY_APP=${KUBERNETES_SCALEOUT_PROXY_APP:-haproxy}
-export PROXY_CONFIG_FILE=${PROXY_CONFIG_FILE:-"haproxy.cfg"}
 export SCALEOUT_CLUSTER=${SCALEOUT_CLUSTER:-false}
 export KUBE_APISERVER_EXTRA_ARGS=${KUBE_APISERVER_EXTRA_ARGS:-}
 export KUBE_CONTROLLER_EXTRA_ARGS=${KUBE_CONTROLLER_EXTRA_ARGS:-}
 export KUBE_SCHEDULER_EXTRA_ARGS=${KUBE_SCHEDULER_EXTRA_ARGS:-}
-export PROXY_CONFIG_FILE_TMP="${RESOURCE_DIRECTORY}/${PROXY_CONFIG_FILE}.tmp"
 
 # Generate a random 6-digit alphanumeric tag for the kubemark image.
 # Used to uniquify image builds across different invocations of this script.
@@ -426,6 +420,32 @@ function start_hollow_nodes_scaleout {
   done
 }
 
+# setup_proxy setups the proxy service for the scale-out deployment
+# and creates kubeconfig with the proxy service IP and port
+function setup_proxy {
+  local -r tp1_ip=$(grep server "${TP_KUBECONFIG}-1" | awk -F "/" '{print $3}')
+  export TPIP="${tp1_ip}"
+  for (( tp_num=2; tp_num<=${SCALEOUT_TP_COUNT}; tp_num++ ))
+  do
+    tp_ip=$(grep server "${TP_KUBECONFIG}-${tp_num}" | awk -F "/" '{print $3}')
+    export TPIP=${TPIP},"${tp_ip}"
+  done
+
+  # currently proxy only supports 1 RP
+  rp1_ip=$(grep server "${RP_KUBECONFIG}-1" | awk -F "/" '{print $3}')
+  export RPIP="${rp1_ip}"
+
+  export KUBERNETES_SCALEOUT_PROXY=true
+  export KUBE_BEARER_TOKEN=${SHARED_APISERVER_TOKEN}
+  export SCALEOUT_PROXY_NAME="${KUBE_GCE_INSTANCE_PREFIX}-proxy"
+  export PROXY_KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark-proxy"
+  export KUBERNETES_SCALEOUT_PROXY_APP=${KUBERNETES_SCALEOUT_PROXY_APP:-haproxy}
+  export PROXY_CONFIG_FILE=${PROXY_CONFIG_FILE:-"haproxy.cfg"}
+  export PROXY_CONFIG_FILE_TMP="${RESOURCE_DIRECTORY}/${PROXY_CONFIG_FILE}.tmp"
+  create-arktos-proxy
+  export KUBERNETES_SCALEOUT_PROXY=false
+}
+
 detect-project &> /dev/null
 
 rm /tmp/saved_tenant_ips.txt >/dev/null 2>&1 || true
@@ -442,7 +462,7 @@ if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
   export USE_INSECURE_SCALEOUT_CLUSTER_MODE="${USE_INSECURE_SCALEOUT_CLUSTER_MODE:-false}"
   export KUBE_ENABLE_APISERVER_INSECURE_PORT="${KUBE_ENABLE_APISERVER_INSECURE_PORT:-false}"
   export KUBERNETES_TENANT_PARTITION=true
-  export KUBERNETES_SCALEOUT_PROXY=true
+  export KUBERNETES_RESOURCE_PARTITION=false
   export PROXY_KUBECONFIG
 
   for (( tp_num=1; tp_num<=${SCALEOUT_TP_COUNT}; tp_num++ ))
@@ -450,9 +470,6 @@ if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
     export TENANT_PARTITION_SEQUENCE=${tp_num}
     export KUBEMARK_CLUSTER_KUBECONFIG="${TP_KUBECONFIG}-${tp_num}"
     create-kubemark-master
-
-    export PROXY_RESERVED_IP=$(cat ${KUBE_TEMP}/proxy-reserved-ip.txt)
-    echo "DBG: PROXY_RESERVED_IP=$PROXY_RESERVED_IP"
     
     export TP_${tp_num}_RESERVED_IP=$(cat ${KUBE_TEMP}/master_reserved_ip.txt)
 
@@ -476,9 +493,6 @@ if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
       export SHARED_APISERVER_TOKEN=${tp1_token}
       echo "shares token: ${SHARED_APISERVER_TOKEN}"
     fi
-
-    ## reset the scaleout proxy flag
-    export KUBERNETES_SCALEOUT_PROXY=false
   done
 
   echo "DBG: Starting resource partition ..."
@@ -499,6 +513,7 @@ if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
 
   restart_tp_scheduler_and_controller
   start_hollow_nodes_scaleout
+  setup_proxy
 else
   # scale-up, just create the master servers
   export KUBEMARK_CLUSTER_KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark"
@@ -516,21 +531,8 @@ else
   echo "Master IP: ${MASTER_IP}"
 fi
 
-# all kubectl OPs go via the proxy for scale-out env
-if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
-  KUBEMARK_KUBECONFIG="${PROXY_KUBECONFIG}"
-else
-  KUBEMARK_KUBECONFIG="${KUBEMARK_CLUSTER_KUBECONFIG}"
-fi
-
 sleep 5
 echo -e "\nListing kubeamrk cluster details:" >&2
-echo -e "Getting total nodes number:" >&2
-"${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get node | wc -l
-echo
-echo -e "Getting total hollow-nodes number:" >&2
-"${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get node | grep "hollow-node" | wc -l
-echo
 
 if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
   for (( rp_num=1; rp_num<=${SCALEOUT_RP_COUNT}; rp_num++ ))
@@ -541,18 +543,41 @@ if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
     "${KUBECTL}" --kubeconfig="${rp_kubeconfig}" get node | grep "hollow-node" | wc -l
     echo
   done
+
+  for (( tp_num=1; tp_num<=${SCALEOUT_TP_COUNT}; tp_num++ ))
+  do
+    tp_kubeconfig="${TP_KUBECONFIG}-${tp_num}"
+    echo
+    echo -e "Getting endpoints status for TP-${tp_num}:" >&2
+    "${KUBECTL}" --kubeconfig="${tp_kubeconfig}" get endpoints -A
+    echo
+    echo -e "Getting workload controller co status for TP-${tp_num}:" >&2
+    "${KUBECTL}" --kubeconfig="${tp_kubeconfig}" get co
+    echo
+    echo -e "Getting apiserver data partition status for TP-${tp_num}:" >&2
+    "${KUBECTL}" --kubeconfig="${tp_kubeconfig}" get datapartition
+    echo
+    echo -e "Getting ETCD data partition status for TP-${tp_num}:" >&2
+    "${KUBECTL}" --kubeconfig="${tp_kubeconfig}" get etcd
+    echo
+  done
+else
+  KUBEMARK_KUBECONFIG="${KUBEMARK_CLUSTER_KUBECONFIG}"
+  "${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get node | wc -l
+  echo
+  echo -e "Getting total hollow-nodes number:" >&2
+  "${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get node | grep "hollow-node" | wc -l
+  echo
+  echo -e "Getting endpoints status:" >&2
+  "${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get endpoints -A
+  echo
+  echo -e "Getting workload controller co status:" >&2
+  "${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get co
+  echo
+  echo -e "Getting apiserver data partition status:" >&2
+  "${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get datapartition
+  echo
+  echo -e "Getting ETCD data partition status:" >&2
+  "${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get etcd
+echo
 fi
-
-echo -e "Getting endpoints status:" >&2
-"${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get endpoints -A
-echo
-echo -e "Getting workload controller co status:" >&2
-"${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get co
-echo
-echo -e "Getting apiserver data partition status:" >&2
-"${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get datapartition
-echo
-echo -e "Getting ETCD data partition status:" >&2
-"${KUBECTL}" --kubeconfig="${KUBEMARK_KUBECONFIG}" get etcd
-echo
-

--- a/test/kubemark/stop-kubemark.sh
+++ b/test/kubemark/stop-kubemark.sh
@@ -70,6 +70,9 @@ if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
     delete-kubemark-master
   done
 
+  export SCALEOUT_PROXY_NAME="${KUBE_GCE_INSTANCE_PREFIX}-proxy"
+  delete-proxy
+
   rm -rf ${RESOURCE_DIRECTORY}/kubeconfig.kubemark-proxy
   rm -rf "${RESOURCE_DIRECTORY}/haproxy.cfg.tmp"
   rm -rf ${RESOURCE_DIRECTORY}/kubeconfig.kubemark.tmp


### PR DESCRIPTION

**What type of PR is this?**
> /kind feature


**What this PR does / why we need it**:
Currently in Arktos scalability test setup, the proxy were created and then updated per RP or TP cluster creation, which is not efficient in setup the test env.

This PR decouples the proxy creation routines from the cluster master setup functions and only create the proxy once all RP/TPs were setup to optimize the proxy creation time for multiple RP/TP env.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None
