### PR TITLE
set user agent for hollow nodes and perf test clients

### DIFF
--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -186,7 +186,7 @@ func run(config *hollowNodeConfig) {
 			klog.Fatalf("Failed to create a client config: %v. Exiting.", err)
 		}
 
-		clientFromConfig, err := clientset.NewForConfig(cfg)
+		clientFromConfig, err := clientset.NewForConfig(restclient.AddUserAgent(cfg, "hollow-node"))
 		if err != nil {
 			klog.Fatalf("Failed to create a ClientSet: %v. Exiting.", err)
 		}
@@ -232,7 +232,7 @@ func run(config *hollowNodeConfig) {
 			cfg.ContentType = "application/json"
 			cfg.AcceptContentTypes = "application/json"
 		}
-		arktosExtClient, err := arktos.NewForConfig(&arktosExtClientConfig)
+		arktosExtClient, err := arktos.NewForConfig(restclient.AddUserAgent(&arktosExtClientConfig, "arktos-extension"))
 		if err != nil {
 			klog.Fatalf("Failed to create an arktos ClientSet: %v. Exiting.", err)
 		}

--- a/perf-tests/clusterloader2/pkg/framework/multiclient.go
+++ b/perf-tests/clusterloader2/pkg/framework/multiclient.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/perf-tests/clusterloader2/pkg/framework/config"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -50,7 +51,7 @@ func NewMultiClientSet(kubeconfigPath string, number int) (*MultiClientSet, erro
 		if number < 1 {
 			return nil, fmt.Errorf("incorrect clients number")
 		}
-		m.clients[i], err = clientset.NewForConfig(conf)
+		m.clients[i], err = clientset.NewForConfig(restclient.AddUserAgent(conf, "cluster-loader"))
 		if err != nil {
 			return nil, fmt.Errorf("creating clientset failed: %v", err)
 		}
@@ -86,7 +87,7 @@ func NewMultiDynamicClient(kubeconfigPath string, number int) (*MultiDynamicClie
 		if number < 1 {
 			return nil, fmt.Errorf("incorrect clients number")
 		}
-		m.clients[i], err = dynamic.NewForConfig(conf)
+		m.clients[i], err = dynamic.NewForConfig(restclient.AddUserAgent(conf, "cluster-loader"))
 		if err != nil {
 			return nil, fmt.Errorf("creating dynamic config failed: %v", err)
 		}
@@ -109,7 +110,7 @@ func NewRestMapper(kubeconfigPath string) (*restmapper.DeferredDiscoveryRESTMapp
 		return nil, fmt.Errorf("config prepare failed: %v", err)
 	}
 
-	discoveryClient, err := clientset.NewForConfig(conf)
+	discoveryClient, err := clientset.NewForConfig(restclient.AddUserAgent(conf, "cluster-loader-discovery"))
 	if err != nil {
 		return nil, fmt.Errorf("creating discovery client failed: %v", err)
 	}


### PR DESCRIPTION
Explicitly set user agent for the hollow node and the perf-test client so that in log and in prometheus they can be differentiated for perf analysis.