### PR TITLE
Fix a bug that event client was created with wrong user agent

### DIFF
--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -385,12 +385,12 @@ func createClients(config componentbaseconfig.ClientConnectionConfiguration, mas
 		return nil, nil, nil, err
 	}
 
-	// shallow copy, do not modify the kubeConfig.Timeout.
-	restConfigs := *kubeConfigs
+	// deep copy kubeConfigs to prevent kubeConfig values to be updated
+	restConfigs := restclient.CopyConfigs(kubeConfigs)
 	for _, restConfig := range restConfigs.GetAllConfigs() {
 		restConfig.Timeout = timeout
 	}
-	leaderElectionClient, err := clientset.NewForConfig(restclient.AddUserAgent(&restConfigs, "leader-election"))
+	leaderElectionClient, err := clientset.NewForConfig(restclient.AddUserAgent(restConfigs, "leader-election"))
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
Before fix, debug log:
```
I0716 19:08:32.737344   31665 options.go:383] === kubeConfigs address 0xc000401dc0, user agent []
I0716 19:08:32.738162   31665 options.go:385] === kubeConfigs user agent [hyperkube/v0.7.0 (linux/amd64) kubernetes/$Format/scheduler]
I0716 19:08:32.738180   31665 options.go:392] === restConfigs address 0xc0009ab8c0, user agent [hyperkube/v0.7.0 (linux/amd64) kubernetes/$Format/scheduler]
I0716 19:08:32.738519   31665 options.go:397] === restConfigs user agent [hyperkube/v0.7.0 (linux/amd64) kubernetes/$Format/leader-election]
I0716 19:08:32.738538   31665 options.go:402] === kubeConfigs address 0xc000401dc0, user agent [hyperkube/v0.7.0 (linux/amd64) kubernetes/$Format/leader-election]
```

After fix, debug log:
```
I0716 21:01:36.171693   18541 options.go:383] === kubeConfigs address 0xc000a77480, user agent []
I0716 21:01:36.172744   18541 options.go:385] === kubeConfigs user agent [hyperkube/v0.8.0 (linux/amd64) kubernetes/$Format/scheduler]
I0716 21:01:36.172964   18541 options.go:392] === restConfigs address 0xc000011cf0, user agent [hyperkube/v0.8.0 (linux/amd64) kubernetes/$Format/scheduler]
I0716 21:01:36.173798   18541 options.go:397] === restConfigs user agent [hyperkube/v0.8.0 (linux/amd64) kubernetes/$Format/leader-election]
I0716 21:01:36.173819   18541 options.go:402] === kubeConfigs address 0xc000a77480, user agent [hyperkube/v0.8.0 (linux/amd64) kubernetes/$Format/scheduler]
```
