### PR TITLE
Set user agent for clients when talking to api servers in the partition

### DIFF
--- a/cmd/kube-controller-manager/app/config/config.go
+++ b/cmd/kube-controller-manager/app/config/config.go
@@ -47,8 +47,8 @@ type Config struct {
 	// the rest config for the master
 	Kubeconfig *restclient.Config
 
-	// the rest clients for resource providers
-	ResourceProviderClients []clientset.Interface
+	// the rest configs for resource providers
+	ResourceProviderKubeconfigs []*restclient.Config
 
 	// the event sink
 	EventRecorder record.EventRecorder

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -116,7 +116,7 @@ func startNodeIpamController(ctx ControllerContext) (http.Handler, bool, error) 
 	nodeIpamController, err := nodeipamcontroller.NewNodeIpamController(
 		ctx.InformerFactory.Core().V1().Nodes(),
 		ctx.Cloud,
-		ctx.ClientBuilder.ClientOrDie("node-controller"),
+		ctx.ClientBuilder.ClientOrDie("node-ipam-controller"),
 		clusterCIDR,
 		serviceCIDR,
 		int(ctx.ComponentConfig.NodeIPAMController.NodeCIDRMaskSize),
@@ -130,14 +130,13 @@ func startNodeIpamController(ctx ControllerContext) (http.Handler, bool, error) 
 }
 
 func startNodeLifecycleController(ctx ControllerContext) (http.Handler, bool, error) {
-
 	kubeclient := ctx.ClientBuilder.ClientOrDie("node-controller")
 
 	var tpAccessors []*nodeutil.TenantPartitionManager
 	var err error
 	// for backward compatibility, when "--tenant-server-kubeconfigs" option is not specified, we fall back to the traditional kubernetes scenario.
 	if len(ctx.ComponentConfig.NodeLifecycleController.TenantPartitionKubeConfig) > 0 {
-		tpAccessors, err = nodeutil.GetTenantPartitionManagersFromKubeConfig(ctx.ComponentConfig.NodeLifecycleController.TenantPartitionKubeConfig)
+		tpAccessors, err = nodeutil.GetTenantPartitionManagersFromKubeConfig(ctx.ComponentConfig.NodeLifecycleController.TenantPartitionKubeConfig, "node-controller")
 	} else {
 		tpAccessors, err = nodeutil.GetTenantPartitionManagersFromKubeClients([]clientset.Interface{kubeclient})
 	}

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -299,7 +299,7 @@ func (o *Options) Config() (*schedulerappconfig.Config, error) {
 			c.NodeInformers = make(map[string]coreinformers.NodeInformer, len(kubeConfigFiles))
 			for i, kubeConfigFile := range kubeConfigFiles {
 				rpId := "rp" + strconv.Itoa(i)
-				c.ResourceProviderClients[rpId], err = clientutil.CreateClientFromKubeconfigFile(kubeConfigFile)
+				c.ResourceProviderClients[rpId], err = clientutil.CreateClientFromKubeconfigFile(kubeConfigFile, "kube-scheduler")
 				if err != nil {
 					klog.Errorf("failed to create resource provider rest client, error: %v", err)
 					return nil, err

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -599,7 +599,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, stopCh <-chan
 			}
 			kubeDeps.KubeTPClients = make([]clientset.Interface, len(kubeConfigFiles))
 			for i, kubeConfigFile := range kubeConfigFiles {
-				kubeDeps.KubeTPClients[i], err = clientutil.CreateClientFromKubeconfigFile(kubeConfigFile)
+				kubeDeps.KubeTPClients[i], err = clientutil.CreateClientFromKubeconfigFile(kubeConfigFile, "kubelet")
 				if err != nil {
 					return fmt.Errorf("failed to initialize kubelet client from kubeconfig [%s]: %v", kubeConfigFile, err)
 				}

--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -99,7 +99,7 @@ func (c *hollowNodeConfig) addFlags(fs *pflag.FlagSet) {
 }
 
 func (c *hollowNodeConfig) createClientConfig() (*restclient.Config, error) {
-	return clientutil.CreateClientConfigFromKubeconfigFileAndSetQps(c.KubeconfigPath, 10, 20, c.ContentType)
+	return clientutil.CreateClientConfigFromKubeconfigFileAndSetQps(c.KubeconfigPath, 10, 20, c.ContentType, "hollow-node")
 }
 
 func (c *hollowNodeConfig) createHollowKubeletOptions() *kubemark.HollowKubletOptions {
@@ -181,7 +181,7 @@ func run(config *hollowNodeConfig) {
 	for i := 0; i < numberTenantPartitions; i++ {
 		kubeconfigFile := config.TenantServerKubeconfigs[i]
 		klog.V(2).Infof("create client config from file: %s", kubeconfigFile)
-		cfg, err := clientutil.CreateClientConfigFromKubeconfigFileAndSetQps(kubeconfigFile, 10, 20, config.ContentType)
+		cfg, err := clientutil.CreateClientConfigFromKubeconfigFileAndSetQps(kubeconfigFile, 10, 20, config.ContentType, "hollow-node")
 		if err != nil {
 			klog.Fatalf("Failed to create a client config: %v. Exiting.", err)
 		}
@@ -199,7 +199,7 @@ func run(config *hollowNodeConfig) {
 		var heartbeatClient *clientset.Clientset
 
 		klog.V(2).Infof("create client config from file: %s", config.ResourceServerKubeconfig)
-		heartbeatClientConfig, err := clientutil.CreateClientConfigFromKubeconfigFileAndSetQps(config.ResourceServerKubeconfig, -1, -1, config.ContentType)
+		heartbeatClientConfig, err := clientutil.CreateClientConfigFromKubeconfigFileAndSetQps(config.ResourceServerKubeconfig, -1, -1, config.ContentType, "hollow-node")
 		if err != nil {
 			klog.Fatalf("Failed to create a client config: %v. Exiting.", err)
 		}

--- a/pkg/controller/util/node/controller_utils.go
+++ b/pkg/controller/util/node/controller_utils.go
@@ -358,8 +358,8 @@ func GetTenantPartitionManagersFromKubeClients(clients []clientset.Interface) ([
 	return tpAccessors, nil
 }
 
-func GetTenantPartitionManagersFromKubeConfig(tenantServerKubeconfig string) ([]*TenantPartitionManager, error) {
-	clients, err := CreateTenantPartitionClients(tenantServerKubeconfig)
+func GetTenantPartitionManagersFromKubeConfig(tenantServerKubeconfig string, userAgent string) ([]*TenantPartitionManager, error) {
+	clients, err := CreateTenantPartitionClients(tenantServerKubeconfig, userAgent)
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +367,7 @@ func GetTenantPartitionManagersFromKubeConfig(tenantServerKubeconfig string) ([]
 	return GetTenantPartitionManagersFromKubeClients(clients)
 }
 
-func CreateTenantPartitionClients(kubeconfigFile string) ([]clientset.Interface, error) {
+func CreateTenantPartitionClients(kubeconfigFile string, userAgent string) ([]clientset.Interface, error) {
 	kubeconfigFiles, existed := genutils.ParseKubeConfigFiles(kubeconfigFile)
 	if !existed {
 		return nil, fmt.Errorf("kubeconfig file(s) [%s] do(es) not exist", kubeconfigFile)
@@ -375,7 +375,7 @@ func CreateTenantPartitionClients(kubeconfigFile string) ([]clientset.Interface,
 
 	clients := []clientset.Interface{}
 	for _, kubeconfig := range kubeconfigFiles {
-		client, err := clientutil.CreateClientFromKubeconfigFile(kubeconfig)
+		client, err := clientutil.CreateClientFromKubeconfigFile(kubeconfig, userAgent)
 		if err != nil {
 			return nil, fmt.Errorf("error in getting client for kubeconfig (%v) ：%v", kubeconfig, err)
 		}

--- a/staging/src/k8s.io/client-go/util/clientutil/clientutil_test.go
+++ b/staging/src/k8s.io/client-go/util/clientutil/clientutil_test.go
@@ -75,7 +75,7 @@ func TestCreateClientUtils(t *testing.T) {
 	for _, test := range tests {
 		t.Logf("execute test case [%s] for CreateClientFromKubeconfigFile", test.description)
 
-		_, err := CreateClientFromKubeconfigFile(test.kubeconfigFile)
+		_, err := CreateClientFromKubeconfigFile(test.kubeconfigFile, "kube-test")
 		if test.expectedError != nil && err.Error() != test.expectedError.Error() {
 			t.Fatalf("failed validate expected error. error: %v", err)
 		}
@@ -84,7 +84,7 @@ func TestCreateClientUtils(t *testing.T) {
 	for _, test := range tests {
 		t.Logf("execute test case [%s] for CreateClientConfigFromKubeconfigFileAndSetQps", test.description)
 
-		config, err := CreateClientConfigFromKubeconfigFileAndSetQps(test.kubeconfigFile, test.qps, test.burst, "")
+		config, err := CreateClientConfigFromKubeconfigFileAndSetQps(test.kubeconfigFile, test.qps, test.burst, "", "kube-test")
 
 		if err != nil && test.expectedError == nil {
 			t.Fatalf("failed validate expected error. error: %v", err)


### PR DESCRIPTION
fix scale out client identity

This fix fill in correct user agent for rest client when components need to talk to API server in another cluster.