### PR TITLE
Use watch instead of list pods in node controller

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -137,9 +137,9 @@ func startNodeLifecycleController(ctx ControllerContext) (http.Handler, bool, er
 	var err error
 	// for backward compatibility, when "--tenant-server-kubeconfigs" option is not specified, we fall back to the traditional kubernetes scenario.
 	if len(ctx.ComponentConfig.NodeLifecycleController.TenantPartitionKubeConfig) > 0 {
-		tpAccessors, err = nodeutil.GetTenantPartitionManagersFromKubeConfig(ctx.ComponentConfig.NodeLifecycleController.TenantPartitionKubeConfig, ctx.Stop)
+		tpAccessors, err = nodeutil.GetTenantPartitionManagersFromKubeConfig(ctx.ComponentConfig.NodeLifecycleController.TenantPartitionKubeConfig)
 	} else {
-		tpAccessors, err = nodeutil.GetTenantPartitionManagersFromKubeClients([]clientset.Interface{kubeclient}, ctx.Stop)
+		tpAccessors, err = nodeutil.GetTenantPartitionManagersFromKubeClients([]clientset.Interface{kubeclient})
 	}
 
 	if err != nil {

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -482,6 +482,10 @@ func (nc *Controller) Run(stopCh <-chan struct{}) {
 
 	klog.Infof("Starting node controller")
 	defer klog.Infof("Shutting down node controller")
+	for _, tpManager := range nc.tenantPartitionManagers {
+		go tpManager.PodInformerStartFunc(stopCh)
+		go tpManager.DaemonSetInformerStartFunc(stopCh)
+	}
 
 	if !controller.WaitForCacheSync("taint", stopCh, nc.leaseInformerSynced, nc.nodeInformerSynced, nc.podInformersSynced, nc.daemonSetInformersSynced) {
 		return

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -390,8 +390,6 @@ func NewNodeLifecycleController(
 			})
 
 			podIndexer := podInformer.Informer().GetIndexer()
-			//podLister := podInformer.Lister()
-			//podGetter := func(name, namespace string) (*v1.Pod, error) { return podLister.Pods(namespace).Get(name) }
 			tenantPartitionManager.PodByNodeNameLister = func(nodeName string) ([]v1.Pod, error) {
 				objs, err := podIndexer.ByIndex(nodeNameKeyIndex, nodeName)
 				if err != nil {

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -141,7 +141,7 @@ func newNodeLifecycleControllerFromClient(
 	nodeInformer := factory.Core().V1().Nodes()
 	daemonSetInformer := factory.Apps().V1().DaemonSets()
 
-	tpManager, err := nodeutil.GetTenantPartitionManagersFromKubeClients([]clientset.Interface{kubeClient}, nil)
+	tpManager, err := nodeutil.GetTenantPartitionManagersFromKubeClients([]clientset.Interface{kubeClient})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/nodelifecycle/scheduler/BUILD
+++ b/pkg/controller/nodelifecycle/scheduler/BUILD
@@ -39,10 +39,12 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/controller/testutil:go_default_library",
+        "//pkg/controller/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
-        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",

--- a/pkg/controller/nodelifecycle/scheduler/BUILD
+++ b/pkg/controller/nodelifecycle/scheduler/BUILD
@@ -12,11 +12,10 @@ go_library(
     deps = [
         "//pkg/apis/core/helper:go_default_library",
         "//pkg/apis/core/v1/helper:go_default_library",
+        "//pkg/controller/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/pkg/controller/nodelifecycle/scheduler/taint_manager_test.go
+++ b/pkg/controller/nodelifecycle/scheduler/taint_manager_test.go
@@ -19,15 +19,17 @@ package scheduler
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"sort"
 	"sync"
 	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/controller/testutil"
+	nodeutil "k8s.io/kubernetes/pkg/controller/util/node"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clienttesting "k8s.io/client-go/testing"
@@ -101,6 +103,25 @@ func addTaintsToNode(node *v1.Node, key, value string, indices []int) *v1.Node {
 	}
 	node.Spec.Taints = taints
 	return node
+}
+
+func getFakeTPManagers(clientSet *fake.Clientset) []*nodeutil.TenantPartitionManager {
+	tpManagers := make([]*nodeutil.TenantPartitionManager, 1)
+	tpManagers[0] = &nodeutil.TenantPartitionManager{
+		Client: clientSet,
+		PodByNodeNameLister: func(nodeName string) ([]v1.Pod, error) {
+				selector := fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName})
+				pods, err := clientSet.CoreV1().PodsWithMultiTenancy(v1.NamespaceAll, v1.TenantAll).List(metav1.ListOptions{
+					FieldSelector: selector.String(),
+					LabelSelector: labels.Everything().String(),
+				})
+				if err != nil {
+					return []v1.Pod{}, fmt.Errorf("failed to get Pods assigned to node %v", nodeName)
+				}
+				return pods.Items, nil
+			},
+		}
+	return tpManagers
 }
 
 type timestampedPod struct {
@@ -190,7 +211,7 @@ func TestCreatePod(t *testing.T) {
 		stopCh := make(chan struct{})
 		fakeClientset := fake.NewSimpleClientset()
 
-		controller := NewNoExecuteTaintManager(fakeClientset, []clientset.Interface{fakeClientset}, getNodeFromClientset(fakeClientset))
+		controller := NewNoExecuteTaintManager(fakeClientset, getFakeTPManagers(fakeClientset), getNodeFromClientset(fakeClientset))
 		controller.recorder = testutil.NewFakeRecorder()
 		go controller.Run(stopCh)
 		controller.taintedNodes = item.taintedNodes
@@ -214,7 +235,7 @@ func TestCreatePod(t *testing.T) {
 func TestDeletePod(t *testing.T) {
 	stopCh := make(chan struct{})
 	fakeClientset := fake.NewSimpleClientset()
-	controller := NewNoExecuteTaintManager(fakeClientset, []clientset.Interface{fakeClientset}, getNodeFromClientset(fakeClientset))
+	controller := NewNoExecuteTaintManager(fakeClientset, getFakeTPManagers(fakeClientset), getNodeFromClientset(fakeClientset))
 	controller.recorder = testutil.NewFakeRecorder()
 	go controller.Run(stopCh)
 	controller.taintedNodes = map[string][]v1.Taint{
@@ -278,7 +299,7 @@ func TestUpdatePod(t *testing.T) {
 		stopCh := make(chan struct{})
 		fakeClientset := fake.NewSimpleClientset()
 		holder := &podHolder{}
-		controller := NewNoExecuteTaintManager(fakeClientset, []clientset.Interface{fakeClientset}, getNodeFromClientset(fakeClientset))
+		controller := NewNoExecuteTaintManager(fakeClientset, getFakeTPManagers(fakeClientset), getNodeFromClientset(fakeClientset))
 		controller.recorder = testutil.NewFakeRecorder()
 		go controller.Run(stopCh)
 		controller.taintedNodes = item.taintedNodes
@@ -344,7 +365,7 @@ func TestCreateNode(t *testing.T) {
 	for _, item := range testCases {
 		stopCh := make(chan struct{})
 		fakeClientset := fake.NewSimpleClientset(&v1.PodList{Items: item.pods})
-		controller := NewNoExecuteTaintManager(fakeClientset, []clientset.Interface{fakeClientset}, (&nodeHolder{item.node}).getNode)
+		controller := NewNoExecuteTaintManager(fakeClientset, getFakeTPManagers(fakeClientset), (&nodeHolder{item.node}).getNode)
 		controller.recorder = testutil.NewFakeRecorder()
 		go controller.Run(stopCh)
 		controller.NodeUpdated(nil, item.node)
@@ -367,7 +388,7 @@ func TestCreateNode(t *testing.T) {
 func TestDeleteNode(t *testing.T) {
 	stopCh := make(chan struct{})
 	fakeClientset := fake.NewSimpleClientset()
-	controller := NewNoExecuteTaintManager(fakeClientset, []clientset.Interface{fakeClientset}, getNodeFromClientset(fakeClientset))
+	controller := NewNoExecuteTaintManager(fakeClientset, getFakeTPManagers(fakeClientset), getNodeFromClientset(fakeClientset))
 	controller.recorder = testutil.NewFakeRecorder()
 	controller.taintedNodes = map[string][]v1.Taint{
 		"node1": {createNoExecuteTaint(1)},
@@ -466,7 +487,7 @@ func TestUpdateNode(t *testing.T) {
 	for _, item := range testCases {
 		stopCh := make(chan struct{})
 		fakeClientset := fake.NewSimpleClientset(&v1.PodList{Items: item.pods})
-		controller := NewNoExecuteTaintManager(fakeClientset, []clientset.Interface{fakeClientset}, (&nodeHolder{item.newNode}).getNode)
+		controller := NewNoExecuteTaintManager(fakeClientset, getFakeTPManagers(fakeClientset), (&nodeHolder{item.newNode}).getNode)
 		controller.recorder = testutil.NewFakeRecorder()
 		go controller.Run(stopCh)
 		controller.NodeUpdated(item.oldNode, item.newNode)
@@ -532,7 +553,7 @@ func TestUpdateNodeWithMultiplePods(t *testing.T) {
 		stopCh := make(chan struct{})
 		fakeClientset := fake.NewSimpleClientset(&v1.PodList{Items: item.pods})
 		sort.Sort(item.expectedDeleteTimes)
-		controller := NewNoExecuteTaintManager(fakeClientset, []clientset.Interface{fakeClientset}, (&nodeHolder{item.newNode}).getNode)
+		controller := NewNoExecuteTaintManager(fakeClientset, getFakeTPManagers(fakeClientset), (&nodeHolder{item.newNode}).getNode)
 		controller.recorder = testutil.NewFakeRecorder()
 		go controller.Run(stopCh)
 		controller.NodeUpdated(item.oldNode, item.newNode)
@@ -644,5 +665,113 @@ func TestGetMinTolerationTime(t *testing.T) {
 		if got != test.expected {
 			t.Errorf("Incorrect min toleration time: got %v, expected %v", got, test.expected)
 		}
+	}
+}
+
+// TestEventualConsistency verifies if getPodsAssignedToNode returns incomplete data
+// (e.g. due to watch latency), it will reconcile the remaining pods eventually.
+// This scenario is partially covered by TestUpdatePods, but given this is an important
+// property of TaitManager, it's better to have explicit test for this.
+func TestEventualConsistency(t *testing.T) {
+	testCases := []struct {
+		description  string
+		pods         []v1.Pod
+		prevPod      *v1.Pod
+		newPod       *v1.Pod
+		oldNode      *v1.Node
+		newNode      *v1.Node
+		expectDelete bool
+	}{
+		{
+			description: "existing pod2 scheduled onto tainted Node",
+			pods: []v1.Pod{
+				*testutil.NewPod("pod1", "node1"),
+			},
+			prevPod:      testutil.NewPod("pod2", ""),
+			newPod:       testutil.NewPod("pod2", "node1"),
+			oldNode:      testutil.NewNode("node1"),
+			newNode:      addTaintsToNode(testutil.NewNode("node1"), "testTaint1", "taint1", []int{1}),
+			expectDelete: true,
+		},
+		{
+			description: "existing pod2 with taint toleration scheduled onto tainted Node",
+			pods: []v1.Pod{
+				*testutil.NewPod("pod1", "node1"),
+			},
+			prevPod:      addToleration(testutil.NewPod("pod2", ""), 1, 100),
+			newPod:       addToleration(testutil.NewPod("pod2", "node1"), 1, 100),
+			oldNode:      testutil.NewNode("node1"),
+			newNode:      addTaintsToNode(testutil.NewNode("node1"), "testTaint1", "taint1", []int{1}),
+			expectDelete: false,
+		},
+		{
+			description: "new pod2 created on tainted Node",
+			pods: []v1.Pod{
+				*testutil.NewPod("pod1", "node1"),
+			},
+			prevPod:      nil,
+			newPod:       testutil.NewPod("pod2", "node1"),
+			oldNode:      testutil.NewNode("node1"),
+			newNode:      addTaintsToNode(testutil.NewNode("node1"), "testTaint1", "taint1", []int{1}),
+			expectDelete: true,
+		},
+		{
+			description: "new pod2 with tait toleration created on tainted Node",
+			pods: []v1.Pod{
+				*testutil.NewPod("pod1", "node1"),
+			},
+			prevPod:      nil,
+			newPod:       addToleration(testutil.NewPod("pod2", "node1"), 1, 100),
+			oldNode:      testutil.NewNode("node1"),
+			newNode:      addTaintsToNode(testutil.NewNode("node1"), "testTaint1", "taint1", []int{1}),
+			expectDelete: false,
+		},
+	}
+
+	for _, item := range testCases {
+		stopCh := make(chan struct{})
+		fakeClientset := fake.NewSimpleClientset(&v1.PodList{Items: item.pods})
+		holder := &podHolder{}
+		controller := NewNoExecuteTaintManager(fakeClientset, getFakeTPManagers(fakeClientset), (&nodeHolder{item.newNode}).getNode)
+		controller.recorder = testutil.NewFakeRecorder()
+		go controller.Run(stopCh)
+
+		if item.prevPod != nil {
+			holder.setPod(item.prevPod)
+			controller.PodUpdated(nil, item.prevPod, fakeClientset, holder.getPod)
+		}
+
+		// First we simulate NodeUpdate that should delete 'pod1'. It doesn't know about 'pod2' yet.
+		controller.NodeUpdated(item.oldNode, item.newNode)
+		// TODO(mborsz): Remove this sleep and other sleeps in this file.
+		time.Sleep(timeForControllerToProgress)
+
+		podDeleted := false
+		for _, action := range fakeClientset.Actions() {
+			if action.GetVerb() == "delete" && action.GetResource().Resource == "pods" {
+				podDeleted = true
+			}
+		}
+		if !podDeleted {
+			t.Errorf("%v: Unexpected test result. Expected delete, got: %v", item.description, podDeleted)
+		}
+		fakeClientset.ClearActions()
+
+		// And now the delayed update of 'pod2' comes to the TaintManager. We should delete it as well.
+		holder.setPod(item.newPod)
+		controller.PodUpdated(item.prevPod, item.newPod, fakeClientset, holder.getPod)
+		// wait a bit
+		time.Sleep(timeForControllerToProgress)
+
+		podDeleted = false
+		for _, action := range fakeClientset.Actions() {
+			if action.GetVerb() == "delete" && action.GetResource().Resource == "pods" {
+				podDeleted = true
+			}
+		}
+		if podDeleted != item.expectDelete {
+			t.Errorf("%v: Unexpected test result. Expected delete %v, got %v", item.description, item.expectDelete, podDeleted)
+		}
+		close(stopCh)
 	}
 }

--- a/pkg/controller/nodelifecycle/scheduler/taint_manager_test.go
+++ b/pkg/controller/nodelifecycle/scheduler/taint_manager_test.go
@@ -110,17 +110,17 @@ func getFakeTPManagers(clientSet *fake.Clientset) []*nodeutil.TenantPartitionMan
 	tpManagers[0] = &nodeutil.TenantPartitionManager{
 		Client: clientSet,
 		PodByNodeNameLister: func(nodeName string) ([]v1.Pod, error) {
-				selector := fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName})
-				pods, err := clientSet.CoreV1().PodsWithMultiTenancy(v1.NamespaceAll, v1.TenantAll).List(metav1.ListOptions{
-					FieldSelector: selector.String(),
-					LabelSelector: labels.Everything().String(),
-				})
-				if err != nil {
-					return []v1.Pod{}, fmt.Errorf("failed to get Pods assigned to node %v", nodeName)
-				}
-				return pods.Items, nil
-			},
-		}
+			selector := fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName})
+			pods, err := clientSet.CoreV1().PodsWithMultiTenancy(v1.NamespaceAll, v1.TenantAll).List(metav1.ListOptions{
+				FieldSelector: selector.String(),
+				LabelSelector: labels.Everything().String(),
+			})
+			if err != nil {
+				return []v1.Pod{}, fmt.Errorf("failed to get Pods assigned to node %v", nodeName)
+			}
+			return pods.Items, nil
+		},
+	}
 	return tpManagers
 }
 

--- a/pkg/controller/util/node/controller_utils.go
+++ b/pkg/controller/util/node/controller_utils.go
@@ -323,46 +323,48 @@ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType)
 // The following are util functions for the node lifecycle ontroller, which is in the resource partition, to connect to the Resource Partition.
 // For the time being, the connection is insecure, as the scalablility work is still on the way.
 type TenantPartitionManager struct {
-	Client              clientset.Interface
-	PodInformer         coreinformers.PodInformer
-	PodLister           corelisters.PodLister
-	DaemonSetInformer   appsv1informers.DaemonSetInformer
-	DaemonSetStore      appsv1listers.DaemonSetLister
-	PodByNodeNameLister func(nodeName string) ([]v1.Pod, error)
+	Client                     clientset.Interface
+	PodInformer                coreinformers.PodInformer
+	PodLister                  corelisters.PodLister
+	DaemonSetInformer          appsv1informers.DaemonSetInformer
+	DaemonSetStore             appsv1listers.DaemonSetLister
+	PodByNodeNameLister        func(nodeName string) ([]v1.Pod, error)
+	PodInformerStartFunc       func(stopCh <-chan struct{})
+	DaemonSetInformerStartFunc func(stopCh <-chan struct{})
 }
 
-func getTenantPartitionManagerFromClient(client clientset.Interface, stop <-chan struct{}) *TenantPartitionManager {
+func getTenantPartitionManagerFromClient(client clientset.Interface) *TenantPartitionManager {
 	tpInformer := informers.NewSharedInformerFactory(client, 0)
-	go tpInformer.Core().V1().Pods().Informer().Run(stop)
-	go tpInformer.Apps().V1().DaemonSets().Informer().Run(stop)
 	tpAccessor := &TenantPartitionManager{
-		Client:            client,
-		PodInformer:       tpInformer.Core().V1().Pods(),
-		PodLister:         tpInformer.Core().V1().Pods().Lister(),
-		DaemonSetInformer: tpInformer.Apps().V1().DaemonSets(),
-		DaemonSetStore:    tpInformer.Apps().V1().DaemonSets().Lister(),
+		Client:                     client,
+		PodInformer:                tpInformer.Core().V1().Pods(),
+		PodLister:                  tpInformer.Core().V1().Pods().Lister(),
+		DaemonSetInformer:          tpInformer.Apps().V1().DaemonSets(),
+		DaemonSetStore:             tpInformer.Apps().V1().DaemonSets().Lister(),
+		PodInformerStartFunc:       tpInformer.Core().V1().Pods().Informer().Run,
+		DaemonSetInformerStartFunc: tpInformer.Apps().V1().DaemonSets().Informer().Run,
 	}
 
 	return tpAccessor
 }
 
-func GetTenantPartitionManagersFromKubeClients(clients []clientset.Interface, stop <-chan struct{}) ([]*TenantPartitionManager, error) {
+func GetTenantPartitionManagersFromKubeClients(clients []clientset.Interface) ([]*TenantPartitionManager, error) {
 	tpAccessors := []*TenantPartitionManager{}
 
 	for _, client := range clients {
-		tpAccessors = append(tpAccessors, getTenantPartitionManagerFromClient(client, stop))
+		tpAccessors = append(tpAccessors, getTenantPartitionManagerFromClient(client))
 	}
 
 	return tpAccessors, nil
 }
 
-func GetTenantPartitionManagersFromKubeConfig(tenantServerKubeconfig string, stop <-chan struct{}) ([]*TenantPartitionManager, error) {
+func GetTenantPartitionManagersFromKubeConfig(tenantServerKubeconfig string) ([]*TenantPartitionManager, error) {
 	clients, err := CreateTenantPartitionClients(tenantServerKubeconfig)
 	if err != nil {
 		return nil, err
 	}
 
-	return GetTenantPartitionManagersFromKubeClients(clients, stop)
+	return GetTenantPartitionManagersFromKubeClients(clients)
 }
 
 func CreateTenantPartitionClients(kubeconfigFile string) ([]clientset.Interface, error) {

--- a/pkg/controller/util/node/controller_utils.go
+++ b/pkg/controller/util/node/controller_utils.go
@@ -323,11 +323,12 @@ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType)
 // The following are util functions for the node lifecycle ontroller, which is in the resource partition, to connect to the Resource Partition.
 // For the time being, the connection is insecure, as the scalablility work is still on the way.
 type TenantPartitionManager struct {
-	Client            clientset.Interface
-	PodInformer       coreinformers.PodInformer
-	PodGetter         corelisters.PodLister
-	DaemonSetInformer appsv1informers.DaemonSetInformer
-	DaemonSetStore    appsv1listers.DaemonSetLister
+	Client              clientset.Interface
+	PodInformer         coreinformers.PodInformer
+	PodLister           corelisters.PodLister
+	DaemonSetInformer   appsv1informers.DaemonSetInformer
+	DaemonSetStore      appsv1listers.DaemonSetLister
+	PodByNodeNameLister func(nodeName string) ([]v1.Pod, error)
 }
 
 func getTenantPartitionManagerFromClient(client clientset.Interface, stop <-chan struct{}) *TenantPartitionManager {
@@ -337,7 +338,7 @@ func getTenantPartitionManagerFromClient(client clientset.Interface, stop <-chan
 	tpAccessor := &TenantPartitionManager{
 		Client:            client,
 		PodInformer:       tpInformer.Core().V1().Pods(),
-		PodGetter:         tpInformer.Core().V1().Pods().Lister(),
+		PodLister:         tpInformer.Core().V1().Pods().Lister(),
 		DaemonSetInformer: tpInformer.Apps().V1().DaemonSets(),
 		DaemonSetStore:    tpInformer.Apps().V1().DaemonSets().Lister(),
 	}

--- a/test/integration/scheduler/taint_test.go
+++ b/test/integration/scheduler/taint_test.go
@@ -90,8 +90,7 @@ func TestTaintNodeByCondition(t *testing.T) {
 	informers := context.informerFactory
 	nsName := context.ns.Name
 
-	stopCh := make(chan struct{})
-	tpAccessors, err := nodeutil.GetTenantPartitionManagersFromKubeClients([]kubernetes.Interface{cs}, stopCh)
+	tpAccessors, err := nodeutil.GetTenantPartitionManagersFromKubeClients([]kubernetes.Interface{cs})
 	if err != nil {
 		t.Errorf("Failed to create Tenant Partition Accessor: %v", err)
 		return


### PR DESCRIPTION
Reduced # of list pods requests to ETCD. 1 request per 3 second, 1 call per node. This change significantly reduced system load during large cluster density test.