### PR TITLE
bug fix: gc controller deletes pods as it cannot access node resources

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -248,11 +248,11 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 			for i, rpKubeConfig := range c.ResourceProviderKubeconfigs {
 				rpId := "rp" + strconv.Itoa(i)
 
-				clientConfigs := restclient.AnonymousClientConfig(rpKubeConfig)
+				clientConfigs := *rpKubeConfig
 				for _, config := range clientConfigs.GetAllConfigs() {
 					config.UserAgent = userAgent
 				}
-				rpClient := clientset.NewForConfigOrDie(clientConfigs)
+				rpClient := clientset.NewForConfigOrDie(&clientConfigs)
 
 				resourceInformerFactory := informers.NewSharedInformerFactory(rpClient, 0)
 				resourceInformerFactory.Start(controllerContext.Stop)

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -248,11 +248,11 @@ func Run(c *config.CompletedConfig, stopCh <-chan struct{}) error {
 			for i, rpKubeConfig := range c.ResourceProviderKubeconfigs {
 				rpId := "rp" + strconv.Itoa(i)
 
-				clientConfigs := *rpKubeConfig
+				clientConfigs := restclient.CopyConfigs(rpKubeConfig)
 				for _, config := range clientConfigs.GetAllConfigs() {
 					config.UserAgent = userAgent
 				}
-				rpClient := clientset.NewForConfigOrDie(&clientConfigs)
+				rpClient := clientset.NewForConfigOrDie(clientConfigs)
 
 				resourceInformerFactory := informers.NewSharedInformerFactory(rpClient, 0)
 				resourceInformerFactory.Start(controllerContext.Stop)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes the error that was observed during perf test:
```
E0729 19:49:16.787146    8872 wait_for_pods.go:85] WaitForControlledPodsRunning: namespace(ixkj3v-testns), labelSelector(name=saturation-deployment-0): 11 pods disappeared: saturation-deployment-0-866fd6bb84-tlzdt, saturation-deployment-0-866fd6bb84-9hb5w, saturation-deployment-0-866fd6bb84-n9v6b, saturation-deployment-0-866fd6bb84-zh66w, saturation-deployment-0-866fd6bb84-thpcf, saturation-deployment-0-866fd6bb84-ndmgg, saturation-deployment-0-866fd6bb84-xtqt2, saturation-deployment-0-866fd6bb84-svrzm, saturation-deployment-0-866fd6bb84-r29wm, saturation-deployment-0-866fd6bb84-wcnfk, saturation-deployment-0-866fd6bb84-rcdp2
```

The root cause is KCM kubeclient has no authentication, hence no permission to list nodes.
  