### PR TITLE
PR 96117 - Disable watchcache for events 1.18

### DIFF
--- a/pkg/registry/cachesize/cachesize.go
+++ b/pkg/registry/cachesize/cachesize.go
@@ -41,6 +41,7 @@ func NewHeuristicWatchCacheSizes(expectedRAMCapacityMB int) map[schema.GroupReso
 	watchCacheSizes[schema.GroupResource{Resource: "pods"}] = maxInt(50*clusterSize, 1000)
 	watchCacheSizes[schema.GroupResource{Resource: "services"}] = maxInt(5*clusterSize, 1000)
 	watchCacheSizes[schema.GroupResource{Resource: "events"}] = 0
+	watchCacheSizes[schema.GroupResource{Resource: "events", Group: "events.k8s.io"}] = 0
 	watchCacheSizes[schema.GroupResource{Resource: "apiservices", Group: "apiregistration.k8s.io"}] = maxInt(5*clusterSize, 1000)
 	watchCacheSizes[schema.GroupResource{Resource: "leases", Group: "coordination.k8s.io"}] = maxInt(5*clusterSize, 1000) // 1.18
 	return watchCacheSizes


### PR DESCRIPTION
To reduce apiserver workload