### PR TITLE
Set watch never expire

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -684,6 +684,7 @@ func (r *Reflector) relistResourceVersion() string {
 		// Since this reflector makes paginated list requests, and all paginated list requests skip the watch cache
 		// if the lastSyncResourceVersion is expired, we set ResourceVersion="" and list again to re-establish reflector
 		// to the latest available ResourceVersion, using a consistent read from etcd.
+		klog.Infof("Set relist resource version to empty!!! Reflector %s (%s) from %s", r.expectedTypeName, r.resyncPeriod, r.name)
 		return ""
 	}
 	if r.lastSyncResourceVersion == "" {

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -140,7 +140,7 @@ func NewSharedIndexInformer(lw ListerWatcher, objType runtime.Object, defaultEve
 		indexer:                         NewIndexer(DeletionHandlingMetaNamespaceKeyFunc, indexers),
 		listerWatcher:                   lw,
 		objectType:                      objType,
-		resyncCheckPeriod:               defaultEventHandlerResyncPeriod,
+		resyncCheckPeriod:               0,
 		defaultEventHandlerResyncPeriod: defaultEventHandlerResyncPeriod,
 		cacheMutationDetector:           NewCacheMutationDetector(fmt.Sprintf("%T", objType)),
 		clock:                           realClock,


### PR DESCRIPTION
Currently scheduler and kubelet both has watch never expire. I don't see why KCM should have watch expire every few minutes and re-establish the watch connection. Trying a short cut to see whether this improve latency.

```
kubelet-hollow-node-1-zw2xm.log-20210804-1628035208.gz:I0803 18:47:52.727101       6 reflector.go:218] Starting reflector *v1.Secret (0s) from object-"arktos"/"nkrldp-testns"/"default-token-pkvvr"
kubelet-hollow-node-1-z6jm9.log-20210804-1628035208.gz:I0803 20:44:45.766528       6 reflector.go:218] Starting reflector *v1.Secret (0s) from object-"arktos"/"sc2tap-testns"/"default-token-qsnq5"
kubelet-hollow-node-1-zw2xm.log-20210804-1628035208.gz:I0803 17:04:19.057921       6 reflector.go:218] Starting reflector *v1.Action (0s) from k8s.io/kubernetes/pkg/kubelet/config/apiserver.go:64
kubelet-hollow-node-1-zw2xm.log-20210804-1628035208.gz:I0803 17:04:19.057944       6 reflector.go:218] Starting reflector *v1.Node (0s) from k8s.io/kubernetes/pkg/kubelet/kubelet.go:453
kubelet-hollow-node-1-zw2xm.log-20210804-1628035208.gz:I0803 17:04:19.057961       6 reflector.go:218] Starting reflector *v1.Service (0s) from k8s.io/kubernetes/pkg/kubelet/kubelet.go:444
kubelet-hollow-node-1-zw2xm.log-20210804-1628035208.gz:I0803 17:04:19.057910       6 reflector.go:218] Starting reflector *v1.Pod (0s) from k8s.io/kubernetes/pkg/kubelet/config/apiserver.go:52
kubelet-hollow-node-1-zw2xm.log-20210804-1628035208.gz:I0803 17:04:19.077622       6 reflector.go:218] Starting reflector *v1beta1.RuntimeClass (0s) from k8s.io/client-go/informers/factory.go:145
kubelet-hollow-node-1-zw2xm.log-20210804-1628035208.gz:I0803 17:04:19.077868       6 reflector.go:218] Starting reflector *v1beta1.CSIDriver (0s) from k8s.io/client-go/informers/factory.go:145
```

```
kube-scheduler.log-20210803-1628017221.gz:I0803 16:56:59.161038       1 reflector.go:218] Starting reflector *v1.StorageClass (0s) from k8s.io/client-go/informers/factory.go:145
kube-scheduler.log-20210803-1628017221.gz:I0803 16:56:59.161106       1 reflector.go:218] Starting reflector *v1.Node (0s) from k8s.io/kubernetes/cmd/kube-scheduler/app/server.go:249
kube-scheduler.log-20210803-1628017221.gz:I0803 16:56:59.161129       1 reflector.go:218] Starting reflector *v1.Service (0s) from k8s.io/client-go/informers/factory.go:145
kube-scheduler.log-20210803-1628017221.gz:I0803 16:56:59.161158       1 reflector.go:218] Starting reflector *v1.Node (0s) from k8s.io/client-go/informers/factory.go:145
kube-scheduler.log-20210803-1628017221.gz:I0803 16:56:59.161415       1 reflector.go:218] Starting reflector *v1.Pod (0s) from k8s.io/kubernetes/cmd/kube-scheduler/app/server.go:239
kube-scheduler.log-20210803-1628017221.gz:I0803 16:56:59.164732       1 reflector.go:218] Starting reflector *v1beta1.PodDisruptionBudget (0s) from k8s.io/client-go/informers/factory.go:145
kube-scheduler.log-20210803-1628017221.gz:I0803 16:56:59.165423       1 reflector.go:218] Starting reflector *v1.PersistentVolume (0s) from k8s.io/client-go/informers/factory.go:145
kube-scheduler.log-20210803-1628017221.gz:I0803 16:56:59.165546       1 reflector.go:218] Starting reflector *v1.PersistentVolumeClaim (0s) from k8s.io/client-go/informers/factory.go:145
kube-scheduler.log-20210803-1628017221.gz:I0803 17:00:47.723411       1 reflector.go:218] Starting reflector *v1.PersistentVolumeClaim (0s) from k8s.io/client-go/informers/factory.go:145
kube-scheduler.log-20210803-1628017221.gz:I0803 17:00:47.723373       1 reflector.go:218] Starting reflector *v1.PersistentVolume (0s) from k8s.io/client-go/informers/factory.go:145
kube-scheduler.log-20210803-1628017221.gz:I0803 17:00:47.723544       1 reflector.go:218] Starting reflector *v1.Service (0s) from k8s.io/client-go/informers/factory.go:145
kube-scheduler.log-20210803-1628017221.gz:I0803 17:00:47.723567       1 reflector.go:218] Starting reflector *v1.Pod (0s) from k8s.io/kubernetes/cmd/kube-scheduler/app/server.go:239
kube-scheduler.log-20210803-1628017221.gz:I0803 17:00:47.723588       1 reflector.go:218] Starting reflector *v1.Node (0s) from k8s.io/kubernetes/cmd/kube-scheduler/app/server.go:249
kube-scheduler.log-20210803-1628017221.gz:I0803 17:00:47.723663       1 reflector.go:218] Starting reflector *v1.StorageClass (0s) from k8s.io/client-go/informers/factory.go:145
kube-scheduler.log-20210803-1628017221.gz:I0803 17:00:47.724089       1 reflector.go:218] Starting reflector *v1beta1.PodDisruptionBudget (0s) from k8s.io/client-go/informers/factory.go:145
```

```
kube-controller-manager.log-20210803-1628017521.gz:I0803 16:57:03.887779       1 reflector.go:218] Starting reflector *v1.ConfigMap (5m28.752695083s) from k8s.io/client-go/informers/factory.go:145
kube-controller-manager.log-20210803-1628017521.gz:I0803 16:57:03.887839       1 reflector.go:218] Starting reflector *v1.ReplicationController (4m46.63006395s) from k8s.io/client-go/informers/factory.go:145
kube-controller-manager.log-20210803-1628017521.gz:I0803 16:57:03.887902       1 reflector.go:218] Starting reflector *v1.RoleBinding (4m2.835851406s) from k8s.io/client-go/informers/factory.go:145
kube-controller-manager.log-20210803-1628017521.gz:I0803 16:57:03.888583       1 reflector.go:218] Starting reflector *v1.StorageCluster (5m58.891587439s) from k8s.io/client-go/informers/factory.go:145
kube-controller-manager.log-20210803-1628017521.gz:I0803 16:57:03.888878       1 reflector.go:218] Starting reflector *v1beta1.CertificateSigningRequest (5m58.891587439s) from k8s.io/client-go/informers/factory.go:145
kube-controller-manager.log-20210803-1628017521.gz:I0803 16:57:03.889358       1 reflector.go:218] Starting reflector *v1beta1.Ingress (4m0.298763989s) from k8s.io/client-go/informers/factory.go:145
kube-controller-manager.log-20210803-1628017521.gz:I0803 17:00:48.264277       1 reflector.go:218] Starting reflector *v1.Node (0s) from k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go:263
kube-controller-manager.log-20210803-1628017521.gz:I0803 17:00:48.265367       1 reflector.go:218] Starting reflector *v1.Node (3m22.409819241s) from k8s.io/client-go/informers/factory.go:145
kube-controller-manager.log-20210803-1628017521.gz:I0803 17:00:48.265396       1 reflector.go:218] Starting reflector *v1.ServiceAccount (3m22.409819241s) from k8s.io/client-go/informers/factory.go:145
kube-controller-manager.log-20210803-1628017521.gz:I0803 17:00:48.265427       1 reflector.go:218] Starting reflector *v1.Secret (3m22.409819241s) from k8s.io/client-go/informers/factory.go:145
kube-controller-manager.log-20210803-1628017521.gz:I0803 17:00:48.268058       1 reflector.go:218] Starting reflector *v1.ConfigMap (10m0s) from k8s.io/legacy-cloud-providers/gce/gce_clusterid.go:117
kube-controller-manager.log-20210803-1628017521.gz:I0803 17:00:48.502088       1 reflector.go:218] Starting reflector *v1beta1.Deployment (3m22.409819241s) from k8s.io/client-go/informers/factory.go:145
kube-controller-manager.log-20210803-1628017521.gz:I0803 17:00:48.502156       1 reflector.go:218] Starting reflector *v1beta1.CertificateSigningRequest (3m22.409819241s) from k8s.io/client-go/informers/factory.go:145
kube-controller-manager.log-20210803-1628017521.gz:I0803 17:00:48.503216       1 reflector.go:218] Starting reflector *v1.HorizontalPodAutoscaler (15s) from k8s.io/client-go/informers/factory.go:145
```