### PR TITLE
Reduce kubelet getting node requests.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1237,6 +1237,9 @@ type Kubelet struct {
 
 	// Mutex to serialize new pod admission and existing pod resizing
 	podResizeMutex sync.Mutex
+
+	// lastestNode is the last node which kubelet updated or created
+	latestNode *v1.Node
 }
 
 // setupDataDirs creates:

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -86,7 +86,8 @@ func (kl *Kubelet) registerWithAPIServer() {
 // value of the annotation for controller-managed attach-detach of attachable
 // persistent volumes for the node.
 func (kl *Kubelet) tryRegisterWithAPIServer(node *v1.Node) bool {
-	_, err := kl.heartbeatClient.CoreV1().Nodes().Create(node)
+	var err error
+	kl.latestNode, err = kl.heartbeatClient.CoreV1().Nodes().Create(node)
 	if err == nil {
 		return true
 	}
@@ -121,7 +122,8 @@ func (kl *Kubelet) tryRegisterWithAPIServer(node *v1.Node) bool {
 	requiresUpdate = kl.updateDefaultLabels(node, existingNode) || requiresUpdate
 	requiresUpdate = kl.reconcileExtendedResource(node, existingNode) || requiresUpdate
 	if requiresUpdate {
-		if _, _, err := nodeutil.PatchNodeStatus(kl.heartbeatClient.CoreV1(), types.NodeName(kl.nodeName), originalNode, existingNode); err != nil {
+		if kl.latestNode, _, err = nodeutil.PatchNodeStatus(kl.heartbeatClient.CoreV1(), types.NodeName(kl.nodeName), originalNode, existingNode); err != nil {
+			kl.latestNode = nil
 			klog.Errorf("Unable to reconcile node %q with API server: error updating node: %v", kl.nodeName, err)
 			return false
 		}
@@ -418,9 +420,14 @@ func (kl *Kubelet) tryUpdateNodeStatus(tryNumber int) error {
 	if tryNumber == 0 {
 		util.FromApiserverCache(&opts)
 	}
-	node, err := kl.heartbeatClient.CoreV1().Nodes().Get(string(kl.nodeName), opts)
-	if err != nil {
-		return fmt.Errorf("error getting node %q: %v", kl.nodeName, err)
+
+	node := kl.latestNode
+	var err error
+	if node == nil {
+		node, err = kl.heartbeatClient.CoreV1().Nodes().Get(string(kl.nodeName), opts)
+		if err != nil {
+			return fmt.Errorf("error getting node %q: %v", kl.nodeName, err)
+		}
 	}
 
 	originalNode := node.DeepCopy()
@@ -467,8 +474,10 @@ func (kl *Kubelet) tryUpdateNodeStatus(tryNumber int) error {
 	// Patch the current status on the API server
 	updatedNode, _, err := nodeutil.PatchNodeStatus(kl.heartbeatClient.CoreV1(), types.NodeName(kl.nodeName), originalNode, node)
 	if err != nil {
+		kl.latestNode = nil // when update failed, force re-read from api server
 		return err
 	}
+	kl.latestNode = updatedNode
 	kl.lastStatusReportTime = now
 	kl.setLastObservedNodeAddresses(updatedNode.Status.Addresses)
 	// If update finishes successfully, mark the volumeInUse as reportedInUse to indicate


### PR DESCRIPTION
Same as PR 835 except test not ported.
Tested on 1TP/1RP 100 node cluster.
. Before change, get node request 17849, patch node request 1499. After change, get node request 303, patch node request 1100
. Depends on when log was pulled, total # of requests might variant. Using patch node request # as an example, get node still reduced a lot.
. There is no non 200 get/patch node requests in audit log.

25K run on 8/3 has 66M get and 4.5M patch. Total request in RP 142M.
