### PR TITLE
Add trace for resync, revert watch timeout changes

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -466,6 +466,7 @@ func buildGenericConfig(
 		lastErr = fmt.Errorf("failed to create real external clientset: %v", err)
 		return
 	}
+	//versionedInformers = clientgoinformers.NewSharedInformerFactory(clientgoExternalClient, 0)
 	versionedInformers = clientgoinformers.NewSharedInformerFactory(clientgoExternalClient, 10*time.Minute)
 
 	genericConfig.Authentication.Authenticator, genericConfig.OpenAPIConfig.SecurityDefinitions, err = BuildAuthenticator(s, clientgoExternalClient, versionedInformers)

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -524,6 +524,7 @@ func (f *DeltaFIFO) Replace(list []interface{}, resourceVersion string) error {
 
 // Resync will send a sync event for each item
 func (f *DeltaFIFO) Resync() error {
+	//klog.Infof("==== DeltaFIFO Resync keys[%v]", f.knownObjects.ListKeys())
 	f.lock.Lock()
 	defer f.lock.Unlock()
 

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -437,7 +437,10 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 			}
 			if r.ShouldResync == nil || r.ShouldResync() {
 				klog.V(4).Infof("%s: forcing resync. type %v. resync period %v", r.name, r.expectedTypeName, r.resyncPeriod)
-				if err := r.store.Resync(); err != nil {
+				initTrace := trace.New(fmt.Sprintf("%s: forcing resync. type %v. resync period %v", r.name, r.expectedTypeName, r.resyncPeriod))
+				err := r.store.Resync()
+				initTrace.LogIfLong(100 * time.Millisecond)
+				if err != nil {
 					resyncerrc <- err
 					return
 				}

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -127,7 +127,7 @@ type Reflector struct {
 var (
 	// We try to spread the load on apiserver by setting timeouts for
 	// watch requests - it is random in [minWatchTimeout, 2*minWatchTimeout].
-	minWatchTimeout = 30 * time.Minute
+	minWatchTimeout = 5 * time.Minute
 )
 
 // NewNamespaceKeyedIndexerAndReflector creates an Indexer and a Reflector


### PR DESCRIPTION
From audit log, there seems a problem when watch is longer than 10 min.

```
/home/sonyali/logs/perf-test/gce-25k/arktos/poc930-081621-1x1x25k/log_density/kubemark_tp_1_master/log$zgrep "\"verb\":\"watch\"" kube-apiserver-audit.log* | grep pods | grep -v "\"userAgent\":\"kubemark" | grep latency-deployment > ~/perf-log/2021-08-16/watch-latency-deployment.pods.audit.log
/home/sonyali/logs/perf-test/gce-25k/arktos/poc930-081621-1x1x25k/log_density/kubemark_tp_1_master/log$ cat ~/perf-log/2021-08-16/watch-latency-deployment.pods.audit.log | grep latency-deployment-39 | grep 098x36-testns
kube-apiserver-audit.log-20210816-1629152119.gz:{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"Request","auditID":"a5bd7ddd-a728-4062-9a2a-9030a63abb42","stage":"ResponseStarted","requestURI":"/api/v1/tenants/arktos/namespaces/098x36-testns/pods?allowWatchBookmarks=true\u0026labelSelector=name%3Dlatency-deployment-39\u0026resourceVersion=3012701\u0026timeout=57m51s\u0026timeoutSeconds=3471\u0026watch=true","verb":"watch","user":{"username":"admin","uid":"admin","groups":["system:masters","system:authenticated"]},"sourceIPs":["34.132.233.190"],"userAgent":"clusterloader/v0.0.0 (linux/amd64) kubernetes/$Format/cluster-loader","objectRef":{"resource":"pods","namespace":"098x36-testns","apiVersion":"v1"},"responseStatus":{"metadata":{},"code":200},"requestReceivedTimestamp":"2021-08-16T22:12:20.825506Z","stageTimestamp":"2021-08-16T22:12:20.844580Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}
kube-apiserver-audit.log-20210816-1629152700.gz:{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"Request","auditID":"a5bd7ddd-a728-4062-9a2a-9030a63abb42","stage":"ResponseComplete","requestURI":"/api/v1/tenants/arktos/namespaces/098x36-testns/pods?allowWatchBookmarks=true\u0026labelSelector=name%3Dlatency-deployment-39\u0026resourceVersion=3012701\u0026timeout=57m51s\u0026timeoutSeconds=3471\u0026watch=true","verb":"watch","user":{"username":"admin","uid":"admin","groups":["system:masters","system:authenticated"]},"sourceIPs":["34.132.233.190"],"userAgent":"clusterloader/v0.0.0 (linux/amd64) kubernetes/$Format/cluster-loader","objectRef":{"resource":"pods","namespace":"098x36-testns","apiVersion":"v1"},"responseStatus":{"metadata":{},"code":200},"requestReceivedTimestamp":"2021-08-16T22:12:20.825506Z","stageTimestamp":"2021-08-16T22:22:22.512800Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}
kube-apiserver-audit.log-20210816-1629157519.gz:{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"Request","auditID":"e55d01cc-8299-4247-8219-4a7f5722f57d","stage":"ResponseStarted","requestURI":"/api/v1/tenants/arktos/namespaces/098x36-testns/pods?allowWatchBookmarks=true\u0026labelSelector=name%3Dlatency-deployment-39\u0026resourceVersion=3332593\u0026timeout=53m12s\u0026timeoutSeconds=3192\u0026watch=true","verb":"watch","user":{"username":"admin","uid":"admin","groups":["system:masters","system:authenticated"]},"sourceIPs":["34.132.233.190"],"userAgent":"clusterloader/v0.0.0 (linux/amd64) kubernetes/$Format/cluster-loader","objectRef":{"resource":"pods","namespace":"098x36-testns","apiVersion":"v1"},"responseStatus":{"metadata":{},"code":200},"requestReceivedTimestamp":"2021-08-16T23:35:57.224054Z","stageTimestamp":"2021-08-16T23:35:57.224316Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}
kube-apiserver-audit.log-20210816-1629158107.gz:{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"Request","auditID":"e55d01cc-8299-4247-8219-4a7f5722f57d","stage":"ResponseComplete","requestURI":"/api/v1/tenants/arktos/namespaces/098x36-testns/pods?allowWatchBookmarks=true\u0026labelSelector=name%3Dlatency-deployment-39\u0026resourceVersion=3332593\u0026timeout=53m12s\u0026timeoutSeconds=3192\u0026watch=true","verb":"watch","user":{"username":"admin","uid":"admin","groups":["system:masters","system:authenticated"]},"sourceIPs":["34.132.233.190"],"userAgent":"clusterloader/v0.0.0 (linux/amd64) kubernetes/$Format/cluster-loader","objectRef":{"resource":"pods","namespace":"098x36-testns","apiVersion":"v1"},"responseStatus":{"metadata":{},"code":200},"requestReceivedTimestamp":"2021-08-16T23:35:57.224054Z","stageTimestamp":"2021-08-16T23:45:58.701340Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}

```
