### PR TITLE
Reduce perf test list all pods from API server cache

### DIFF
--- a/perf-tests/clusterloader2/pkg/measurement/common/scheduling_throughput.go
+++ b/perf-tests/clusterloader2/pkg/measurement/common/scheduling_throughput.go
@@ -114,7 +114,7 @@ func (s *schedulingThroughputMeasurement) start(clientSet clientset.Interface, s
 			case <-s.stopCh:
 				return
 			case <-time.After(measurmentInterval):
-				pods := ps.List()
+				pods := measurementutil.FilterPods(ps.List(), selector)
 				podsStatus := measurementutil.ComputePodsStartupStatus(pods, 0, nil /* updatePodPredicate */)
 				throughput := float64(podsStatus.Scheduled-lastScheduledCount) / float64(measurmentInterval/time.Second)
 				s.schedulingThroughputs = append(s.schedulingThroughputs, throughput)

--- a/perf-tests/clusterloader2/pkg/measurement/util/wait_for_pods.go
+++ b/perf-tests/clusterloader2/pkg/measurement/util/wait_for_pods.go
@@ -56,7 +56,7 @@ func WaitForPods(clientSet clientset.Interface, stopCh <-chan struct{}, options 
 	}
 	defer ps.Stop()
 
-	oldPods := ps.List()
+	oldPods := FilterPods(ps.List(), options.Selector)
 	scaling := uninitialized
 	var podsStatus PodsStartupStatus
 
@@ -76,7 +76,8 @@ func WaitForPods(clientSet clientset.Interface, stopCh <-chan struct{}, options 
 			return fmt.Errorf("timeout while waiting for %d pods to be running in namespace '%v' with labels '%v' and fields '%v' - only %d found running",
 				options.DesiredPodCount, options.Selector.Namespace, options.Selector.LabelSelector, options.Selector.FieldSelector, podsStatus.Running)
 		case <-time.After(options.WaitForPodsInterval):
-			pods := ps.List()
+			allPods := ps.List()
+			pods := FilterPods(allPods, options.Selector)
 			podsStatus = ComputePodsStartupStatus(pods, options.DesiredPodCount, options.IsPodUpdated)
 
 			diff := DiffPods(oldPods, pods)


### PR DESCRIPTION
Trying avoid excessive list pods from API server during test. Reason: during density test, at the latency pod creation period, each latency pod is created by one deployment. Perf test create pod store for every single deployment and hence caused excessive list pods requests to API server. This may be the reason that perf test has pod start up latency spike every 10-15 seconds.

This change try to reuse pod store across multiple deployments. Pod store list/watch all latency pods, filter out pods that does not belong to current deployment at client side.

This is a preliminary change. Improvements might needed:
1. Scan over all pods at local store might added a lot of time. Need to compare with KCM pod start up latency to see whether additional local index for label selector might need to be added for pod.
2. Alternatively, pick up community change that use event received time as pod start up watch time.
3. Label selector comparison is very premitive. Depends on the usage, might need to support more cases.
4. Field selector comparison is not used in density test. Skipping for now.

5. TODO: Testing in 100 node, 1TP/1RP case.
    1. Run density test.
    2. Check audit log, compare list pods records with previous run.
   