### PR TITLE
Fix hack/install-etcd.sh error for etcd3.4.3 on linux

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -17,7 +17,7 @@
 
 # A set of helpers for starting/running etcd for tests
 # etcd version pattern  is d.d.d-arktos.d
-ETCD_VERSION=${ETCD_VERSION:-3.4.3.0.1}
+ETCD_VERSION=${ETCD_VERSION:-3.4.3}
 INT_NAME=$(ip route | awk '/default/ { print $5 }')
 ETCD_LOCAL_HOST=${ETCD_LOCAL_HOST:-127.0.0.1}
 ETCD_HOST=$(ip addr show $INT_NAME | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
@@ -151,7 +151,7 @@ kube::etcd::install() {
       ln -fns "etcd-v${ETCD_VERSION}-darwin-amd64" etcd
       rm "${download_file}"
     elif [[ ${os} == "linux" && ${arch} == "amd64" ]]; then
-      url="https://github.com/centaurus-cloud/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
+      url="https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
       download_file="etcd-v${ETCD_VERSION}-${os}-${arch}.tar.gz"
       kube::util::download_file "${url}" "${download_file}"
       tar xzf "${download_file}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:
when run hack/instal-etcd.sh or hack/update-etcd.sh for etcd3.4.3 on linux, it will failed with error:
```
sonyali@sonyaperf1:~/go/src/k8s.io/arktos$ hack/update-etcd.sh

The current installed etcd version is wrong. Updating etcd...

curl: (22) The requested URL returned error: 404
Downloading https://github.com/coreos/etcd/releases/download/v3.4.3.0.1/etcd-v3.4.3.0.1-linux-amd64.tar.gz failed. 4 retries left.
curl: (22) The requested URL returned error: 404
Downloading https://github.com/coreos/etcd/releases/download/v3.4.3.0.1/etcd-v3.4.3.0.1-linux-amd64.tar.gz failed. 3 retries left.
curl: (22) The requested URL returned error: 404
Downloading https://github.com/coreos/etcd/releases/download/v3.4.3.0.1/etcd-v3.4.3.0.1-linux-amd64.tar.gz failed. 2 retries left.
curl: (22) The requested URL returned error: 404
Downloading https://github.com/coreos/etcd/releases/download/v3.4.3.0.1/etcd-v3.4.3.0.1-linux-amd64.tar.gz failed. 1 retries left.
curl: (22) The requested URL returned error: 404
Downloading https://github.com/coreos/etcd/releases/download/v3.4.3.0.1/etcd-v3.4.3.0.1-linux-amd64.tar.gz failed. 0 retries left.
!!! [0825 02:00:58] Call tree:
!!! [0825 02:00:58]  1: hack/update-etcd.sh:25 kube::etcd::install(...)
!!! Error in /home/sonyali/go/src/k8s.io/arktos/hack/lib/etcd.sh:156
  Error in /home/sonyali/go/src/k8s.io/arktos/hack/lib/etcd.sh:156. '((i<3-1))' exited with status 1
Call stack:
  1: /home/sonyali/go/src/k8s.io/arktos/hack/lib/etcd.sh:156 kube::etcd::install(...)
  2: hack/update-etcd.sh:25 main(...)
Exiting with status 1
!!! [0825 02:00:58] Call tree:
!!! [0825 02:00:58]  1: hack/update-etcd.sh:25 kube::etcd::install(...)
!!! Error in /home/sonyali/go/src/k8s.io/arktos/hack/lib/etcd.sh:131
  Error in /home/sonyali/go/src/k8s.io/arktos/hack/lib/etcd.sh:131. '((i<3-1))' exited with status 1
Call stack:
  1: /home/sonyali/go/src/k8s.io/arktos/hack/lib/etcd.sh:131 kube::etcd::install(...)
  2: hack/update-etcd.sh:25 main(...)
Exiting with status 1
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
verified on poc930 branch using 100 nodes 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
