### PR TITLE
port community perf test PRs

### DIFF
--- a/perf-tests/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
+++ b/perf-tests/clusterloader2/pkg/measurement/common/slos/pod_startup_latency.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"strings"
 	"time"
 
@@ -55,7 +56,13 @@ func createPodStartupLatencyMeasurement() measurement.Measurement {
 	return &podStartupLatencyMeasurement{
 		selector:          measurementutil.NewObjectSelector(),
 		podStartupEntries: measurementutil.NewObjectTransitionTimes(podStartupLatencyMeasurementName),
+		eventQueue:        workqueue.New(),
 	}
+}
+
+type eventData struct {
+	obj      interface{}
+	recvTime time.Time
 }
 
 type podStartupLatencyMeasurement struct {
@@ -64,6 +71,9 @@ type podStartupLatencyMeasurement struct {
 	stopCh            chan struct{}
 	podStartupEntries *measurementutil.ObjectTransitionTimes
 	threshold         time.Duration
+	// This queue can potentially grow indefinitely, beacause we put all changes here.
+	// Usually it's not recommended pattern, but we need it for measuring PodStartupLatency.
+	eventQueue *workqueue.Type
 }
 
 // Execute supports two actions:
@@ -124,15 +134,43 @@ func (p *podStartupLatencyMeasurement) start(c clientset.Interface) error {
 				return c.CoreV1().PodsWithMultiTenancy(p.selector.Namespace, util.GetTenant()).Watch(options)
 			},
 		},
-		p.checkPod,
+		p.addEvent,
 	)
+	go p.processEvents()
 	return informer.StartAndSync(i, p.stopCh, informerSyncTimeout)
+}
+
+func (p *podStartupLatencyMeasurement) addEvent(_, obj interface{}) {
+	event := &eventData{obj: obj, recvTime: time.Now()}
+	p.eventQueue.Add(event)
+}
+
+func (p *podStartupLatencyMeasurement) processEvents() {
+	for p.processNextWorkItem() {
+	}
+}
+
+func (p *podStartupLatencyMeasurement) processNextWorkItem() bool {
+	item, quit := p.eventQueue.Get()
+	if quit {
+		return false
+	}
+	defer p.eventQueue.Done(item)
+
+	event, ok := item.(*eventData)
+	if !ok {
+		klog.Warningf("Couldn't convert work item to evetData: %v", item)
+		return true
+	}
+	p.processEvent(event)
+	return true
 }
 
 func (p *podStartupLatencyMeasurement) stop() {
 	if p.isRunning {
 		p.isRunning = false
 		close(p.stopCh)
+		p.eventQueue.ShutDown()
 	}
 }
 
@@ -213,7 +251,8 @@ func (p *podStartupLatencyMeasurement) gatherScheduleTimes(c clientset.Interface
 	return nil
 }
 
-func (p *podStartupLatencyMeasurement) checkPod(_, obj interface{}) {
+func (p *podStartupLatencyMeasurement) processEvent(event *eventData) {
+	obj, recvTime := event.obj, event.recvTime
 	if obj == nil {
 		return
 	}
@@ -224,7 +263,7 @@ func (p *podStartupLatencyMeasurement) checkPod(_, obj interface{}) {
 	if pod.Status.Phase == corev1.PodRunning {
 		key := createMetaNamespaceKey(pod.Namespace, pod.Name)
 		if _, found := p.podStartupEntries.Get(key, createPhase); !found {
-			ct := time.Now()
+			ct := recvTime
 			p.podStartupEntries.Set(key, watchPhase, ct)
 			p.podStartupEntries.Set(key, createPhase, pod.CreationTimestamp.Time)
 			var startTime metav1.Time

--- a/perf-tests/clusterloader2/pkg/measurement/util/informer/informer.go
+++ b/perf-tests/clusterloader2/pkg/measurement/util/informer/informer.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
-	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	measurementutil "k8s.io/kubernetes/perf-tests/clusterloader2/pkg/measurement/util"
@@ -32,21 +31,12 @@ import (
 )
 
 // NewInformer creates a new informer
-// for given kind, namespace, fieldSelector and labelSelector.
 func NewInformer(
-	c clientset.Interface,
-	kind string,
-	selector *measurementutil.ObjectSelector,
+	lw cache.ListerWatcher,
 	handleObj func(interface{}, interface{}),
 ) cache.SharedInformer {
-	optionsModifier := func(options *metav1.ListOptions) {
-		options.FieldSelector = selector.FieldSelector
-		options.LabelSelector = selector.LabelSelector
-	}
-	listerWatcher := cache.NewFilteredListWatchFromClientWithMultiTenancy(c.CoreV1(), kind, selector.Namespace, optionsModifier, perfutil.GetTenant())
-	informer := cache.NewSharedInformer(listerWatcher, nil, 0)
+	informer := cache.NewSharedInformer(lw, nil, 0)
 	addEventHandler(informer, handleObj)
-
 	return informer
 }
 

--- a/perf-tests/clusterloader2/pkg/measurement/util/selector.go
+++ b/perf-tests/clusterloader2/pkg/measurement/util/selector.go
@@ -62,6 +62,12 @@ func (o *ObjectSelector) String() string {
 	return CreateSelectorsString(o.Namespace, o.LabelSelector, o.FieldSelector)
 }
 
+// ApplySelectors sets label and field selectors in a given ListOptions object.
+func (o *ObjectSelector) ApplySelectors(options *metav1.ListOptions) {
+	options.FieldSelector = o.FieldSelector
+	options.LabelSelector = o.LabelSelector
+}
+
 // CreateSelectorsString creates a string representation for given namespace, label selector and field selector.
 func CreateSelectorsString(namespace, labelSelector, fieldSelector string) string {
 	var selectorsStrings []string


### PR DESCRIPTION
porting community PRs:
PR 1780: Migrate NewInformer to cache.ListerWatcher
PR 1855 Add channel for events to PodStartupLatency

Tested with 100 node perf run and passed.
