### PR TITLE
Send fake bookmark event to client to reduce size of initEvents

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -1365,6 +1365,13 @@ func (c *cacheWatcher) process(ctx context.Context, initEvents []*watchCacheEven
 	processingTime := time.Since(startTime)
 	if processingTime > initProcessThreshold {
 		klog.V(2).Infof("processing %d initEvents of %s took %v, watcher [%p]", len(initEvents), objType, processingTime, c)
+
+		// send Bookmark event
+		if len(initEvents) > 0 {	// To reach here, it is almost impossible that len(initEvents) == 0. Just in case.
+			fakeBookmarkEvent := &watchCacheEvent{Type: watch.Bookmark, Object: initEvents[len(initEvents)-1].Object.DeepCopyObject()}
+			c.sendWatchCacheEvent(fakeBookmarkEvent)
+			klog.Infof("Sent fake event for next resource version [%v], key [%v]", initEvents[len(initEvents)-1].ResourceVersion, initEvents[len(initEvents)-1].Key)
+		}
 	}
 
 	defer close(c.result)


### PR DESCRIPTION
The first commit helps use to understand the size of channel.

The second commit send fake bookmark event to client to reduce size of initEvents. When reflector get bookmark event, it only update resource version, it will not process event. This shall greatly reduce the size of init pod events in case of large size cluster. 

In 100 node cluster. Did not run perf test.


One watch for action/pod/ per node
```
I0910 22:34:40.596881       1 cacher.go:495] Channel size 10, objectType *core.Pod, key [/pods], RV [375], indexedTrigger [0xc00060e440], triggerSupported [true], pred field [spec.nodeName=hollow-node-1-hlz7f], watcher [0xc014037b90]
I0910 22:34:40.582618       1 cacher.go:495] Channel size 10, objectType *core.Action, key [/actions], RV [1], indexedTrigger [0xc001032520], triggerSupported [true], pred field [spec.nodeName=hollow-node-1-hlz7f], watcher [0xc014149650]
```

82 for Node kubemark-tp-1-master
```
I0910 22:34:14.174611       1 cacher.go:495] Channel size 10, objectType *core.Node, key [/minions/ying-0910-100-kubemark-tp-1-master], RV [311], indexedTrigger [0xc000a98c00], triggerSupported [true], pred field [metadata.name=ying-0910-100-kubemark-tp-1-master], watcher [0xc0113f0fc0]
```

3 secret for dashboard
```
I0910 22:34:34.944465       1 cacher.go:495] Channel size 10, objectType *core.Secret, key [/secrets/system/kube-system/kubernetes-dashboard-certs], RV [285], indexedTrigger [0xc0016ef4e0], triggerSupported [true], pred field [metadata.name=kubernetes-dashboard-certs], watcher [0xc0129b7570]
I0910 22:34:34.944639       1 cacher.go:495] Channel size 10, objectType *core.Secret, key [/secrets/system/kube-system/kubernetes-dashboard-token-xb5kz], RV [285], indexedTrigger [0xc0016ef4e0], triggerSupported [true], pred field [metadata.name=kubernetes-dashboard-token-xb5kz], watcher [0xc0128db260]
I0910 22:43:36.946925       1 cacher.go:495] Channel size 10, objectType *core.Secret, key [/secrets/system/kube-system/kubernetes-dashboard-certs], RV [285], indexedTrigger [0xc0016ef4e0], triggerSupported [true], pred field [metadata.name=kubernetes-dashboard-certs], watcher [0xc0038e8af0]
```