### PR TITLE
bug fix: provide resolv.conf if the default is unavailable

### DIFF
--- a/hack/lib/common-var-init.sh
+++ b/hack/lib/common-var-init.sh
@@ -215,7 +215,19 @@ REUSE_CERTS=${REUSE_CERTS:-false}
 #
 # Avoid to create loop error at https://coredns.io/plugins/loop/#troubleshooting
 # when create coredns pod
-RESOLV_CONF=${RESOLV_CONF:-"/run/systemd/resolve/resolv.conf"}
+RESOLV_CONF=${RESOLV_CONF:-}
+if [ -z ${RESOLV_CONF} ] && [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]
+then
+  if [ -f "/run/systemd/resolve/resolv.conf" ]; then
+    RESOLV_CONF=${RESOLV_CONF:-"/run/systemd/resolve/resolv.conf"}
+  else
+    RESOLV_CONF=$(mktemp -p /tmp)
+    cat << 'EOF' > ${RESOLV_CONF}
+nameserver 8.8.8.8
+EOF
+  fi
+fi
+
 # --------------------------------------------------------------------------------------------
 # End of 2nd Common environment variables used in arktos-up.sh& arktos-apiserver-partition.sh
 # --------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
service support requires kubelet to have a resolv.conf that points to a valid external DNS root w/o forming a self-loop chain. current arktos-up script uses /run/systemd/resolve/resolv.conf file which is available in Ubuntu 18.04 and 20.04. However, on Ubuntu 16.04, there is no such file, hence kubelet fails.

This PR fixes the problem by providing a minimalist resolv.conf when the default one is not there, and kubelet requires an external anyway ehn service support is enabled.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1196

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE
