### PR TITLE
Issue#1189: changes in arktos-up-scale-out-poc.sh for automation of local dev 1X1 scale-out setup

### DIFF
--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -653,7 +653,7 @@ if [ "${IS_RESOURCE_PARTITION}" == "true" ]; then
 
   ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" label node ${HOSTNAME_OVERRIDE} extraRuntime=virtlet
 
-  # Verify podCIDR is set correctly
+  # Verify whether podCIDR on RESOURCE_PARTITION node is set correctly
   ${KUBECTL} get nodes -o yaml |grep podCIDR
 fi
 

--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -98,6 +98,8 @@ if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
   FEATURE_GATES="${FEATURE_GATES},MandatoryArktosNetwork=true"
   # tenant controller automatically creates a default network resource for new tenant
   ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/testdata/default-flat-network.tmpl"
+  #CNIPLUGIN is set to use flannel as default
+  CNIPLUGIN="flannel"
 else # when disabled
   # kube-apiserver not to enforce deployment-network validation
   DISABLE_ADMISSION_PLUGINS="DeploymentNetwork"
@@ -640,7 +642,7 @@ echo "*******************************************"
 echo "Setup Arktos components ..."
 echo ""
 
-if [ "${CNIPLUGIN}" == "flannel" ]; then
+if [[ "${CNIPLUGIN}" == "flannel" && "${IS_RESOURCE_PARTITION}" == "true" ]]; then
   echo "Installing Flannel cni plugin... "
   sleep 30  #need sometime for KCM to be fully functioning
   install_flannel
@@ -663,10 +665,6 @@ if [ "${IS_RESOURCE_PARTITION}" != "true" ]; then
   ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" get ds --namespace kube-system
 
   ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f "${KUBE_ROOT}/cluster/addons/rbac/kubelet-network-reader/kubelet-network-reader.yaml"
-
-  echo "Creating clusterrolebinding system-node-role-bound..."
-  ${KUBECTL} create clusterrolebinding system-node-role-bound --clusterrole=system:node --group=system:nodes
-  ${KUBECTL} get clusterrolebinding/system-node-role-bound -o yaml
 fi
  
 echo ""

--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -523,7 +523,7 @@ function kube::common::start_controller_manager {
     if [[ "${IS_SCALE_OUT}" == "true" ]]; then
       # scale out resource partition
       if [ "${IS_RESOURCE_PARTITION}" == "true" ]; then
-        KUBE_CONTROLLERS="daemonset,nodelifecycle,ttl,serviceaccount,serviceaccount-token"
+        KUBE_CONTROLLERS="daemonset,nodelifecycle,nodeipam,ttl,serviceaccount,serviceaccount-token"
 
         ${CONTROLPLANE_SUDO} "${GO_OUT}/hyperkube" kube-controller-manager \
           --v="${LOG_LEVEL}" \


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR automatically helps to set up local dev  1 X 1 scale-out cluster by adding the following three automation steps:
- Automatically install Arktos network controller on TP node,
- Automatically set podCIDR on RP node,
- Automatically install flannel cni on RP node. Before daemonset is fully supported by Arktos, the simple daemonset-based flannel installation is not an option. As a work around, flanneld is installed and running as process on RP node.

**Which issue(s) this PR fixes**:
Fixes # 1189

**Special notes for your reviewer**:
this PR depends on following PRs in queue:
#1181
#1190
#1191

The step "Set up environment variables" for TP setup and RP setup in https://github.com/CentaurusInfra/arktos/blob/master/docs/setup-guide/scale-out-local-dev-setup.md needs to be updated, respectively.

The code changes are verified in PR owner's local dev 1 X 1 scale-out cluster.

**Does this PR introduce a user-facing change?**:
YES