### PR TITLE
ensure resolv.conf for Ubuntu 16.04

### DIFF
--- a/hack/lib/common-var-init.sh
+++ b/hack/lib/common-var-init.sh
@@ -219,12 +219,16 @@ RESOLV_CONF=${RESOLV_CONF:-}
 if [ -z ${RESOLV_CONF} ] && [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]
 then
   if [ -f "/run/systemd/resolve/resolv.conf" ]; then
-    RESOLV_CONF=${RESOLV_CONF:-"/run/systemd/resolve/resolv.conf"}
+    # ubuntu 18.04/20.04
+    RESOLV_CONF="/run/systemd/resolve/resolv.conf"
+  elif [ -f "/run/resolvconf/resolv.conf" ]; then
+    # ubuntu 16.04
+    RESOLV_CONF="/run/resolvconf/resolv.conf"
   else
     if [ -z ${UPSTREAM_DNS_IP:-} ]
     then
-      echo "please specify the upstream DNS ip address in env var UPSTREAM_DNS_IP" >&2
-      exit 1
+      echo "Warning: no upstream DNS ip address is provided; fall back to 8.8.8.8"
+      UPSTREAM_DNS_IP="8.8.8.8"
     fi
     RESOLV_CONF=$(mktemp -p /tmp)
     cat << EOF > ${RESOLV_CONF}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR identify the available resolv.conf on Ubuntu 16.04 and use it in arktos cluster start up process; If no available file can be identified, it uses env var UPSTREAM_DNS_IP to compose a minimum resolv.conf; if that var is not provided, it falls back to the well known public DNS server 8.8.8.8. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1196

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE
