### PR TITLE
bug fix: kubeclientmgr.Pick should be concurrent safe

### DIFF
--- a/pkg/kubelet/kubeclientmanager/kubeclient_manager.go
+++ b/pkg/kubelet/kubeclientmanager/kubeclient_manager.go
@@ -84,8 +84,6 @@ func (manager *KubeClientManager) RegisterTenantSourceServer(source string, ref 
 }
 
 func (manager *KubeClientManager) GetTPClient(kubeClients []clientset.Interface, tenant string) clientset.Interface {
-	manager.tenant2apiLock.RLock()
-	defer manager.tenant2apiLock.RUnlock()
 	if kubeClients == nil || len(kubeClients) == 0 {
 		klog.Errorf("invalid kubeClients : %v", kubeClients)
 		return nil
@@ -96,6 +94,8 @@ func (manager *KubeClientManager) GetTPClient(kubeClients []clientset.Interface,
 }
 
 func (manager *KubeClientManager) PickClient(tenant string) int {
+	manager.tenant2apiLock.RLock()
+	defer manager.tenant2apiLock.RUnlock()
 	pick, ok := manager.tenant2api[strings.ToLower(tenant)]
 	if !ok {
 		klog.Warningf("no registered client for tenant %s, defaulted to client #0", tenant)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a subtle defect caused by code change to kubeclientmanager (original code did not have such bug).

Pick method was exposed public; however access to its internal shared data is not guarded properly with the exposure.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE
