### PR TITLE
write config to stop running of mizar kopf when cluster is arktos

### DIFF
--- a/hack/arktos-up.sh
+++ b/hack/arktos-up.sh
@@ -561,6 +561,7 @@ fi
 
 # Applying mizar cni
 if [[ "${CNIPLUGIN}" == "mizar" ]]; then
+  ${KUBECTL} create configmap system-source --namespace=kube-system --from-literal=name=arktos --from-literal=company=futurewei
   # ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f ${KUBE_ROOT}/hack/testdata/mizar/deploy.mizar.next.yaml 
   ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f https://raw.githubusercontent.com/CentaurusInfra/mizar/dev-next/etc/deploy/deploy.mizar.dev.yaml
 fi

--- a/hack/arktos-up.sh
+++ b/hack/arktos-up.sh
@@ -561,7 +561,7 @@ fi
 
 # Applying mizar cni
 if [[ "${CNIPLUGIN}" == "mizar" ]]; then
-  ${KUBECTL} create configmap system-source --namespace=kube-system --from-literal=name=arktos --from-literal=company=futurewei
+  ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" create configmap system-source --namespace=kube-system --from-literal=name=arktos --from-literal=company=futurewei
   # ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f ${KUBE_ROOT}/hack/testdata/mizar/deploy.mizar.next.yaml 
   ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f https://raw.githubusercontent.com/CentaurusInfra/mizar/dev-next/etc/deploy/deploy.mizar.dev.yaml
 fi


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Write config to stop running of mizar kopf when cluster is arktos.
Mizar depends on such config to decide whether the cluster is arktos or k8s. So the config needs to be written to let mizar know it's arktos.

**Which issue(s) this PR fixes**:
Current mizar controllers and kopf are both running which is unexpected. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE