### PR TITLE
Bug fix for mizar-arktos network controller watch/update arktos network objects

### DIFF
--- a/cmd/kube-controller-manager/app/mizarcontrollers.go
+++ b/cmd/kube-controller-manager/app/mizarcontrollers.go
@@ -154,13 +154,18 @@ func startArktosNetworkController(ctx *ControllerContext, grpcHost string, grpcA
 	svcKubeClient := clientset.NewForConfigOrDie(netKubeconfigs)
 	informerFactory := externalversions.NewSharedInformerFactory(networkClient, 10*time.Minute)
 
-	go controllers.NewMizarArktosNetworkController(
-		networkClient,
-		svcKubeClient,
-		informerFactory.Arktos().V1().Networks(),
-		grpcHost,
-		grpcAdaptor,
-	).Run(mizarArktosNetworkControllerWorkerCount, ctx.Stop)
+	go func() {
+		networkController := controllers.NewMizarArktosNetworkController(
+			networkClient,
+			svcKubeClient,
+			informerFactory.Arktos().V1().Networks(),
+			grpcHost,
+			grpcAdaptor,
+		)
+
+		informerFactory.Start(ctx.Stop)
+		networkController.Run(mizarArktosNetworkControllerWorkerCount, ctx.Stop)
+	}()
 	return nil, true, nil
 }
 

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -418,7 +418,7 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "mizar-arktos-network-controller"},
 		Rules: []rbacv1.PolicyRule{
 			// mizar arktos network controller needs to watch and update network objects of arktos.futurewei.com
-			rbacv1helpers.NewRule("list", "update").Groups("arktos.futurewei.com").Resources("networks").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "list", "watch", "update").Groups("arktos.futurewei.com").Resources("networks").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -414,6 +414,15 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 		},
 	})
 
+	addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "mizar-arktos-network-controller"},
+		Rules: []rbacv1.PolicyRule{
+			// mizar arktos network controller needs to watch and update network objects of arktos.futurewei.com
+			rbacv1helpers.NewRule("list", "update").Groups("arktos.futurewei.com").Resources("networks").RuleOrDie(),
+			eventsRule(),
+		},
+	})
+
 	return controllerRoles, controllerRoleBindings
 }
 


### PR DESCRIPTION
I1203 02:10:06.131962    4922 mizar-arktos-network-controller.go:162] Mizar-Arktos-Network-controller - get network: &v1.Network{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"default", GenerateName:"", Tenant:"system", Namespace:"", SelfLink:"/apis/arktos.futurewei.com/v1/networks/default", UID:"1d246f89-6f12-4d6c-ba90-94570390a704", HashKey:6021324579093697607, ResourceVersion:"347", Generation:1, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63774094202, loc:(*time.Location)(0x99f8840)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string{"arktos.futurewei.com/network"}, ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, Spec:v1.NetworkSpec{Type:"mizar", VPCID:"system-default-network", Service:v1.NetworkService{IPAM:"", CIDRS:[]string(nil)}}, Status:v1.NetworkStatus{Phase:"Ready", Message:"DNS service IP allocated", DNSServiceIP:"10.0.0.82"}}.
