### PR TITLE
Simplify worker up

### DIFF
--- a/hack/arktos-worker-up.sh
+++ b/hack/arktos-worker-up.sh
@@ -31,7 +31,7 @@ function write_client_kubeconfig {
     local api_port=$5
     local client_id=$6
     local token=${7:-}
-    local protocol=${8:-"https"}
+    local protocol=${8:-"http"}
 
     cat <<EOF | ${sudo} tee "${dest_dir}"/"${client_id}".kubeconfig > /dev/null
 apiVersion: v1

--- a/hack/arktos-worker-up.sh
+++ b/hack/arktos-worker-up.sh
@@ -77,7 +77,7 @@ fi
 make all WHAT=cmd/hyperkube
 
 sudo ./_output/local/bin/linux/amd64/hyperkube kubelet \
---v=3 \
+--v="${LOG_LEVEL}" \
 --container-runtime=remote \
 --hostname-override=${HOSTNAME_OVERRIDE} \
 --address='0.0.0.0' \

--- a/hack/arktos-worker-up.sh
+++ b/hack/arktos-worker-up.sh
@@ -17,10 +17,6 @@
 set -e
 die() { echo "$*" 1>&2 ; exit 1; }
 
-if [[ ! -n "${KUBELET_IP}" ]]; then
-    die "KUBELET_IP env var not set"
-fi
-
 # install cni plugin related packages
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source ${KUBE_ROOT}/hack/arktos-cni.rc
@@ -53,7 +49,7 @@ sudo ./_output/local/bin/linux/amd64/hyperkube kubelet \
 --v=3 \
 --container-runtime=remote \
 --hostname-override=${HOSTNAME_OVERRIDE} \
---address=${KUBELET_IP} \
+--address='0.0.0.0' \
 --kubeconfig=${KUBELET_KUBECONFIG} \
 --authorization-mode=Webhook \
 --authentication-token-webhook \

--- a/hack/arktos-worker-up.sh
+++ b/hack/arktos-worker-up.sh
@@ -56,13 +56,14 @@ EOF
 # Ensure CERT_DIR is created for auto-generated kubeconfig
 mkdir -p "${CERT_DIR}" &>/dev/null || sudo mkdir -p "${CERT_DIR}"
 CONTROLPLANE_SUDO=$(test -w "${CERT_DIR}" || echo "sudo -E")
+
+# Generate kubeconfig
 write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "" "${API_HOST}" "${API_PORT}" kubelet "" "http"
 ${CONTROLPLANE_SUDO} chown "$(whoami)" "${CERT_DIR}/kubelet.kubeconfig"
 
-mkdir -p /tmp/arktos
+KUBELET_CLIENTCA=${KUBELET_CLIENTCA:-"${CERT_DIR}/client-ca.crt"}
+${CONTROLPLANE_SUDO} chown "$(whoami)" "${KUBELET_CLIENTCA}"
 
-SECRET_FOLDER=${SECRET_FOLDER:-"/tmp/arktos"}
-KUBELET_CLIENTCA=${KUBELET_CLIENTCA:-"${SECRET_FOLDER}/client-ca.crt"}
 HOSTNAME_OVERRIDE=${HOSTNAME_OVERRIDE:-"$(hostname)"}
 CLUSTER_DNS=${CLUSTER_DNS:-"10.0.0.10"}
 


### PR DESCRIPTION
Run worker up for arktos up with Mizar (aws):
1. Set up dev host with https://github.com/q131172019/arktos/blob/CarlXie_singleNodeArktosCluster/docs/setup-guide/single-node-dev-scale-up-cluster-with-Mizar.md
2. Start master node with Mizar
3. Copy /var/run/kubernetes/client-ca.crt from master to worker
4. Start worker with Mizar: 
```
API_HOST=<master node name:-ip-172-30-0-14> CNIPLUGIN=mizar ./hack/arktos-worker-up.sh
```

Tested with 1 master and 3 workers