### PR TITLE
Kube proxy multi tenant scaleout

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -636,11 +636,11 @@ func (s *ProxyServer) Run() error {
 		// Note: RegisterHandler() calls need to happen before creation of Sources because sources
 		// only notify on changes, and the initial update (on process start) may be lost if no handlers
 		// are registered yet.
-		serviceConfig := config.NewServiceConfig(informerFactory.Core().V1().Services(), s.ConfigSyncPeriod)
+		serviceConfig := config.NewServiceConfig(informerFactory.Core().V1().Services(), s.ConfigSyncPeriod, i)
 		serviceConfig.RegisterEventHandler(s.Proxier)
 		go serviceConfig.Run(wait.NeverStop)
 
-		endpointsConfig := config.NewEndpointsConfig(informerFactory.Core().V1().Endpoints(), s.ConfigSyncPeriod)
+		endpointsConfig := config.NewEndpointsConfig(informerFactory.Core().V1().Endpoints(), s.ConfigSyncPeriod, i)
 		endpointsConfig.RegisterEventHandler(s.Proxier)
 		go endpointsConfig.Run(wait.NeverStop)
 

--- a/pkg/kubemark/hollow_proxy.go
+++ b/pkg/kubemark/hollow_proxy.go
@@ -48,14 +48,14 @@ func (*FakeProxier) Sync() {}
 func (*FakeProxier) SyncLoop() {
 	select {}
 }
-func (*FakeProxier) OnServiceAdd(service *v1.Service)                        {}
-func (*FakeProxier) OnServiceUpdate(oldService, service *v1.Service)         {}
-func (*FakeProxier) OnServiceDelete(service *v1.Service)                     {}
-func (*FakeProxier) OnServiceSynced()                                        {}
-func (*FakeProxier) OnEndpointsAdd(endpoints *v1.Endpoints)                  {}
-func (*FakeProxier) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoints) {}
-func (*FakeProxier) OnEndpointsDelete(endpoints *v1.Endpoints)               {}
-func (*FakeProxier) OnEndpointsSynced()                                      {}
+func (*FakeProxier) OnServiceAdd(service *v1.Service, tenantPartitionId int)                        {}
+func (*FakeProxier) OnServiceUpdate(oldService, service *v1.Service, tenantPartitionId int)         {}
+func (*FakeProxier) OnServiceDelete(service *v1.Service, tenantPartitionId int)                     {}
+func (*FakeProxier) OnServiceSynced(tenantPartitionId int)                                          {}
+func (*FakeProxier) OnEndpointsAdd(endpoints *v1.Endpoints, tenantPartitionId int)                  {}
+func (*FakeProxier) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoints, tenantPartitionId int) {}
+func (*FakeProxier) OnEndpointsDelete(endpoints *v1.Endpoints, tenantPartitionId int)               {}
+func (*FakeProxier) OnEndpointsSynced(tenantPartitionId int)                                        {}
 
 func NewHollowProxyOrDie(
 	nodeName string,

--- a/pkg/proxy/config/config_test.go
+++ b/pkg/proxy/config/config_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/proxy/config/config_test.go
+++ b/pkg/proxy/config/config_test.go
@@ -48,7 +48,7 @@ func (s sortedServices) Less(i, j int) bool {
 type ServiceHandlerMock struct {
 	lock sync.Mutex
 
-	state   map[types.NamespacedName]*v1.Service
+	state   map[types.NamespacednameWithTenantSource]*v1.Service
 	synced  bool
 	updated chan []*v1.Service
 	process func([]*v1.Service)
@@ -56,7 +56,7 @@ type ServiceHandlerMock struct {
 
 func NewServiceHandlerMock() *ServiceHandlerMock {
 	shm := &ServiceHandlerMock{
-		state:   make(map[types.NamespacedName]*v1.Service),
+		state:   make(map[types.NamespacednameWithTenantSource]*v1.Service),
 		updated: make(chan []*v1.Service, 5),
 	}
 	shm.process = func(services []*v1.Service) {
@@ -65,31 +65,31 @@ func NewServiceHandlerMock() *ServiceHandlerMock {
 	return shm
 }
 
-func (h *ServiceHandlerMock) OnServiceAdd(service *v1.Service) {
+func (h *ServiceHandlerMock) OnServiceAdd(service *v1.Service, tenantPartitionId int) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
-	namespacedName := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}
+	namespacedName := types.NamespacednameWithTenantSource{TenantPartitionId: tenantPartitionId, Tenant: service.Tenant, Namespace: service.Namespace, Name: service.Name}
 	h.state[namespacedName] = service
 	h.sendServices()
 }
 
-func (h *ServiceHandlerMock) OnServiceUpdate(oldService, service *v1.Service) {
+func (h *ServiceHandlerMock) OnServiceUpdate(oldService, service *v1.Service, tenantPartitionId int) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
-	namespacedName := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}
+	namespacedName := types.NamespacednameWithTenantSource{TenantPartitionId: tenantPartitionId, Tenant: service.Tenant, Namespace: service.Namespace, Name: service.Name}
 	h.state[namespacedName] = service
 	h.sendServices()
 }
 
-func (h *ServiceHandlerMock) OnServiceDelete(service *v1.Service) {
+func (h *ServiceHandlerMock) OnServiceDelete(service *v1.Service, tenantPartitionId int) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
-	namespacedName := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}
+	namespacedName := types.NamespacednameWithTenantSource{TenantPartitionId: tenantPartitionId, Tenant: service.Tenant, Namespace: service.Namespace, Name: service.Name}
 	delete(h.state, namespacedName)
 	h.sendServices()
 }
 
-func (h *ServiceHandlerMock) OnServiceSynced() {
+func (h *ServiceHandlerMock) OnServiceSynced(tenantPartitionId int) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
 	h.synced = true
@@ -143,7 +143,7 @@ func (s sortedEndpoints) Less(i, j int) bool {
 type EndpointsHandlerMock struct {
 	lock sync.Mutex
 
-	state   map[types.NamespacedName]*v1.Endpoints
+	state   map[types.NamespacednameWithTenantSource]*v1.Endpoints
 	synced  bool
 	updated chan []*v1.Endpoints
 	process func([]*v1.Endpoints)
@@ -151,7 +151,7 @@ type EndpointsHandlerMock struct {
 
 func NewEndpointsHandlerMock() *EndpointsHandlerMock {
 	ehm := &EndpointsHandlerMock{
-		state:   make(map[types.NamespacedName]*v1.Endpoints),
+		state:   make(map[types.NamespacednameWithTenantSource]*v1.Endpoints),
 		updated: make(chan []*v1.Endpoints, 5),
 	}
 	ehm.process = func(endpoints []*v1.Endpoints) {
@@ -160,31 +160,31 @@ func NewEndpointsHandlerMock() *EndpointsHandlerMock {
 	return ehm
 }
 
-func (h *EndpointsHandlerMock) OnEndpointsAdd(endpoints *v1.Endpoints) {
+func (h *EndpointsHandlerMock) OnEndpointsAdd(endpoints *v1.Endpoints, tenantPartitionId int) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
-	namespacedName := types.NamespacedName{Namespace: endpoints.Namespace, Name: endpoints.Name}
+	namespacedName := types.NamespacednameWithTenantSource{TenantPartitionId: tenantPartitionId, Tenant: endpoints.Tenant, Namespace: endpoints.Namespace, Name: endpoints.Name}
 	h.state[namespacedName] = endpoints
 	h.sendEndpoints()
 }
 
-func (h *EndpointsHandlerMock) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoints) {
+func (h *EndpointsHandlerMock) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoints, tenantPartitionId int) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
-	namespacedName := types.NamespacedName{Namespace: endpoints.Namespace, Name: endpoints.Name}
+	namespacedName := types.NamespacednameWithTenantSource{TenantPartitionId: tenantPartitionId, Tenant: endpoints.Tenant, Namespace: endpoints.Namespace, Name: endpoints.Name}
 	h.state[namespacedName] = endpoints
 	h.sendEndpoints()
 }
 
-func (h *EndpointsHandlerMock) OnEndpointsDelete(endpoints *v1.Endpoints) {
+func (h *EndpointsHandlerMock) OnEndpointsDelete(endpoints *v1.Endpoints, tenantPartitionId int) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
-	namespacedName := types.NamespacedName{Namespace: endpoints.Namespace, Name: endpoints.Name}
+	namespacedName := types.NamespacednameWithTenantSource{TenantPartitionId: tenantPartitionId, Tenant: endpoints.Tenant, Namespace: endpoints.Namespace, Name: endpoints.Name}
 	delete(h.state, namespacedName)
 	h.sendEndpoints()
 }
 
-func (h *EndpointsHandlerMock) OnEndpointsSynced() {
+func (h *EndpointsHandlerMock) OnEndpointsSynced(tenantPartitionId int) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
 	h.synced = true
@@ -233,7 +233,7 @@ func TestNewServiceAddedAndNotified(t *testing.T) {
 
 	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
 
-	config := NewServiceConfig(sharedInformers.Core().V1().Services(), time.Minute)
+	config := NewServiceConfig(sharedInformers.Core().V1().Services(), time.Minute, tpId)
 	handler := NewServiceHandlerMock()
 	config.RegisterEventHandler(handler)
 	go sharedInformers.Start(stopCh)
@@ -257,7 +257,7 @@ func TestServiceAddedRemovedSetAndNotified(t *testing.T) {
 
 	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
 
-	config := NewServiceConfig(sharedInformers.Core().V1().Services(), time.Minute)
+	config := NewServiceConfig(sharedInformers.Core().V1().Services(), time.Minute, tpId)
 	handler := NewServiceHandlerMock()
 	config.RegisterEventHandler(handler)
 	go sharedInformers.Start(stopCh)
@@ -293,7 +293,7 @@ func TestNewServicesMultipleHandlersAddedAndNotified(t *testing.T) {
 
 	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
 
-	config := NewServiceConfig(sharedInformers.Core().V1().Services(), time.Minute)
+	config := NewServiceConfig(sharedInformers.Core().V1().Services(), time.Minute, tpId)
 	handler := NewServiceHandlerMock()
 	handler2 := NewServiceHandlerMock()
 	config.RegisterEventHandler(handler)
@@ -327,7 +327,7 @@ func TestNewEndpointsMultipleHandlersAddedAndNotified(t *testing.T) {
 
 	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
 
-	config := NewEndpointsConfig(sharedInformers.Core().V1().Endpoints(), time.Minute)
+	config := NewEndpointsConfig(sharedInformers.Core().V1().Endpoints(), time.Minute, tpId)
 	handler := NewEndpointsHandlerMock()
 	handler2 := NewEndpointsHandlerMock()
 	config.RegisterEventHandler(handler)
@@ -367,7 +367,7 @@ func TestNewEndpointsMultipleHandlersAddRemoveSetAndNotified(t *testing.T) {
 
 	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
 
-	config := NewEndpointsConfig(sharedInformers.Core().V1().Endpoints(), time.Minute)
+	config := NewEndpointsConfig(sharedInformers.Core().V1().Endpoints(), time.Minute, tpId)
 	handler := NewEndpointsHandlerMock()
 	handler2 := NewEndpointsHandlerMock()
 	config.RegisterEventHandler(handler)

--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -48,66 +48,66 @@ func (proxier *FakeProxier) deleteEndpoints(endpoints *v1.Endpoints, tenantParti
 func TestGetLocalEndpointIPs(t *testing.T) {
 	testCases := []struct {
 		endpointsMap EndpointsMap
-		expected     map[types.NamespacedName]sets.String
+		expected     map[types.NamespacednameWithTenantSource]sets.String
 	}{{
 		// Case[0]: nothing
 		endpointsMap: EndpointsMap{},
-		expected:     map[types.NamespacedName]sets.String{},
+		expected:     map[types.NamespacednameWithTenantSource]sets.String{},
 	}, {
 		// Case[1]: unnamed port
 		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", ""): []Endpoint{
+			makeServicePortName("te", "ns1", "ep1", ""): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
-		expected: map[types.NamespacedName]sets.String{},
+		expected: map[types.NamespacednameWithTenantSource]sets.String{},
 	}, {
 		// Case[2]: unnamed port local
 		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", ""): []Endpoint{
+			makeServicePortName("te", "ns1", "ep1", ""): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
-		expected: map[types.NamespacedName]sets.String{
+		expected: map[types.NamespacednameWithTenantSource]sets.String{
 			{Namespace: "ns1", Name: "ep1"}: sets.NewString("1.1.1.1"),
 		},
 	}, {
 		// Case[3]: named local and non-local ports for the same IP.
 		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", "p11"): []Endpoint{
+			makeServicePortName("te", "ns1", "ep1", "p11"): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
 				&BaseEndpointInfo{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): []Endpoint{
+			makeServicePortName("te", "ns1", "ep1", "p12"): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: false},
 				&BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
-		expected: map[types.NamespacedName]sets.String{
+		expected: map[types.NamespacednameWithTenantSource]sets.String{
 			{Namespace: "ns1", Name: "ep1"}: sets.NewString("1.1.1.2"),
 		},
 	}, {
 		// Case[4]: named local and non-local ports for different IPs.
 		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", "p11"): []Endpoint{
+			makeServicePortName("te", "ns1", "ep1", "p11"): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): []Endpoint{
+			makeServicePortName("te", "ns2", "ep2", "p22"): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "2.2.2.2:22", IsLocal: true},
 				&BaseEndpointInfo{Endpoint: "2.2.2.22:22", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p23"): []Endpoint{
+			makeServicePortName("te", "ns2", "ep2", "p23"): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "2.2.2.3:23", IsLocal: true},
 			},
-			makeServicePortName("ns4", "ep4", "p44"): []Endpoint{
+			makeServicePortName("te", "ns4", "ep4", "p44"): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "4.4.4.4:44", IsLocal: true},
 				&BaseEndpointInfo{Endpoint: "4.4.4.5:44", IsLocal: false},
 			},
-			makeServicePortName("ns4", "ep4", "p45"): []Endpoint{
+			makeServicePortName("te", "ns4", "ep4", "p45"): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "4.4.4.6:45", IsLocal: true},
 			},
 		},
-		expected: map[types.NamespacedName]sets.String{
+		expected: map[types.NamespacednameWithTenantSource]sets.String{
 			{Namespace: "ns2", Name: "ep2"}: sets.NewString("2.2.2.2", "2.2.2.22", "2.2.2.3"),
 			{Namespace: "ns4", Name: "ep4"}: sets.NewString("4.4.4.4", "4.4.4.6"),
 		},
@@ -169,7 +169,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", ""): {
+				makeServicePortName("te", "ns1", "ep1", ""): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
 			},
@@ -190,7 +190,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", "port"): {
+				makeServicePortName("te", "ns1", "ep1", "port"): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
 			},
@@ -210,7 +210,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", ""): {
+				makeServicePortName("te", "ns1", "ep1", ""): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
 			},
@@ -241,11 +241,11 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", "p1"): {
+				makeServicePortName("te", "ns1", "ep1", "p1"): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 					{Endpoint: "2.2.2.2:11", IsLocal: false},
 				},
-				makeServicePortName("ns1", "ep1", "p2"): {
+				makeServicePortName("te", "ns1", "ep1", "p2"): {
 					{Endpoint: "1.1.1.1:22", IsLocal: false},
 					{Endpoint: "2.2.2.2:22", IsLocal: false},
 				},
@@ -267,7 +267,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", "p1"): {
+				makeServicePortName("te", "ns1", "ep1", "p1"): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
 			},
@@ -288,7 +288,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", "p2"): {
+				makeServicePortName("te", "ns1", "ep1", "p2"): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
 			},
@@ -309,7 +309,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", "p1"): {
+				makeServicePortName("te", "ns1", "ep1", "p1"): {
 					{Endpoint: "1.1.1.1:22", IsLocal: false},
 				},
 			},
@@ -335,10 +335,10 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", "p1"): {
+				makeServicePortName("te", "ns1", "ep1", "p1"): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
-				makeServicePortName("ns1", "ep1", "p2"): {
+				makeServicePortName("te", "ns1", "ep1", "p2"): {
 					{Endpoint: "1.1.1.1:22", IsLocal: false},
 				},
 			},
@@ -365,10 +365,10 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", "p1"): {
+				makeServicePortName("te", "ns1", "ep1", "p1"): {
 					{Endpoint: "[2001:db8:85a3:0:0:8a2e:370:7334]:11", IsLocal: false},
 				},
-				makeServicePortName("ns1", "ep1", "p2"): {
+				makeServicePortName("te", "ns1", "ep1", "p2"): {
 					{Endpoint: "[2001:db8:85a3:0:0:8a2e:370:7334]:22", IsLocal: false},
 				},
 			},
@@ -715,14 +715,14 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedResult            map[ServicePortName][]*BaseEndpointInfo
 		expectedStaleEndpoints    []ServiceEndpoint
 		expectedStaleServiceNames map[ServicePortName]bool
-		expectedHealthchecks      map[types.NamespacedName]int
+		expectedHealthchecks      map[types.NamespacednameWithTenantSource]int
 	}{{
 		// Case[0]: nothing
 		oldEndpoints:              map[ServicePortName][]*BaseEndpointInfo{},
 		expectedResult:            map[ServicePortName][]*BaseEndpointInfo{},
 		expectedStaleEndpoints:    []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[1]: no change, unnamed port
 		previousEndpoints: []*v1.Endpoints{
@@ -732,18 +732,18 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", unnamedPort),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints:    []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[2]: no change, named port, local
 		previousEndpoints: []*v1.Endpoints{
@@ -753,19 +753,19 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortLocal),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints:    []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[3]: no change, multiple subsets
@@ -776,24 +776,24 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsets),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints:    []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[4]: no change, multiple subsets, multiple ports, local
 		previousEndpoints: []*v1.Endpoints{
@@ -803,31 +803,31 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsMultiplePortsLocal),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.1:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("te", "ns1", "ep1", "p13"): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.1:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("te", "ns1", "ep1", "p13"): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints:    []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[5]: no change, multiple endpoints, subsets, IPs, and ports
@@ -840,62 +840,62 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns2", "ep2", multipleSubsetsIPsPorts2),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("te", "ns1", "ep1", "p13"): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 				{Endpoint: "1.1.1.4:13", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p14"): {
+			makeServicePortName("te", "ns1", "ep1", "p14"): {
 				{Endpoint: "1.1.1.3:14", IsLocal: false},
 				{Endpoint: "1.1.1.4:14", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p21"): {
+			makeServicePortName("te", "ns2", "ep2", "p21"): {
 				{Endpoint: "2.2.2.1:21", IsLocal: false},
 				{Endpoint: "2.2.2.2:21", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("te", "ns2", "ep2", "p22"): {
 				{Endpoint: "2.2.2.1:22", IsLocal: false},
 				{Endpoint: "2.2.2.2:22", IsLocal: true},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("te", "ns1", "ep1", "p13"): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 				{Endpoint: "1.1.1.4:13", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p14"): {
+			makeServicePortName("te", "ns1", "ep1", "p14"): {
 				{Endpoint: "1.1.1.3:14", IsLocal: false},
 				{Endpoint: "1.1.1.4:14", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p21"): {
+			makeServicePortName("te", "ns2", "ep2", "p21"): {
 				{Endpoint: "2.2.2.1:21", IsLocal: false},
 				{Endpoint: "2.2.2.2:21", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("te", "ns2", "ep2", "p22"): {
 				{Endpoint: "2.2.2.1:22", IsLocal: false},
 				{Endpoint: "2.2.2.2:22", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints:    []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 2,
-			makeNSN("ns2", "ep2"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 2,
+			makeNSN("te", "ns2", "ep2"): 1,
 		},
 	}, {
 		// Case[6]: add an Endpoints
@@ -907,16 +907,16 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", ""): true,
+			makeServicePortName("te", "ns1", "ep1", ""): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[7]: remove an Endpoints
@@ -927,17 +927,17 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			nil,
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{},
 		expectedStaleEndpoints: []ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", ""),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", ""),
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[8]: add an IP and port
 		previousEndpoints: []*v1.Endpoints{
@@ -947,26 +947,26 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortsLocalNoLocal),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"): true,
+			makeServicePortName("te", "ns1", "ep1", "p12"): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[9]: remove an IP and port
@@ -977,32 +977,32 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{{
 			Endpoint:        "1.1.1.2:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p11"),
 		}, {
 			Endpoint:        "1.1.1.1:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p12"),
 		}, {
 			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p12"),
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[10]: add a subset
 		previousEndpoints: []*v1.Endpoints{
@@ -1012,24 +1012,24 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsWithLocal),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"): true,
+			makeServicePortName("te", "ns1", "ep1", "p12"): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[11]: remove a subset
@@ -1040,24 +1040,24 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{{
 			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p12"),
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[12]: rename a port
 		previousEndpoints: []*v1.Endpoints{
@@ -1067,23 +1067,23 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortRenamed),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11-2"): {
+			makeServicePortName("te", "ns1", "ep1", "p11-2"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p11"),
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p11-2"): true,
+			makeServicePortName("te", "ns1", "ep1", "p11-2"): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{},
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[13]: renumber a port
 		previousEndpoints: []*v1.Endpoints{
@@ -1093,21 +1093,21 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortRenumbered),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:22", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p11"),
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[14]: complex add and remove
 		previousEndpoints: []*v1.Endpoints{
@@ -1123,65 +1123,65 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns4", "ep4", complexAfter4),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("te", "ns2", "ep2", "p22"): {
 				{Endpoint: "2.2.2.2:22", IsLocal: true},
 				{Endpoint: "2.2.2.22:22", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p23"): {
+			makeServicePortName("te", "ns2", "ep2", "p23"): {
 				{Endpoint: "2.2.2.3:23", IsLocal: true},
 			},
-			makeServicePortName("ns4", "ep4", "p44"): {
+			makeServicePortName("te", "ns4", "ep4", "p44"): {
 				{Endpoint: "4.4.4.4:44", IsLocal: true},
 				{Endpoint: "4.4.4.5:44", IsLocal: true},
 			},
-			makeServicePortName("ns4", "ep4", "p45"): {
+			makeServicePortName("te", "ns4", "ep4", "p45"): {
 				{Endpoint: "4.4.4.6:45", IsLocal: true},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.11:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p122"): {
+			makeServicePortName("te", "ns1", "ep1", "p122"): {
 				{Endpoint: "1.1.1.2:122", IsLocal: false},
 			},
-			makeServicePortName("ns3", "ep3", "p33"): {
+			makeServicePortName("te", "ns3", "ep3", "p33"): {
 				{Endpoint: "3.3.3.3:33", IsLocal: false},
 			},
-			makeServicePortName("ns4", "ep4", "p44"): {
+			makeServicePortName("te", "ns4", "ep4", "p44"): {
 				{Endpoint: "4.4.4.4:44", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{{
 			Endpoint:        "2.2.2.2:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22"),
+			ServicePortName: makeServicePortName("te", "ns2", "ep2", "p22"),
 		}, {
 			Endpoint:        "2.2.2.22:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22"),
+			ServicePortName: makeServicePortName("te", "ns2", "ep2", "p22"),
 		}, {
 			Endpoint:        "2.2.2.3:23",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p23"),
+			ServicePortName: makeServicePortName("te", "ns2", "ep2", "p23"),
 		}, {
 			Endpoint:        "4.4.4.5:44",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p44"),
+			ServicePortName: makeServicePortName("te", "ns4", "ep4", "p44"),
 		}, {
 			Endpoint:        "4.4.4.6:45",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p45"),
+			ServicePortName: makeServicePortName("te", "ns4", "ep4", "p45"),
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"):  true,
-			makeServicePortName("ns1", "ep1", "p122"): true,
-			makeServicePortName("ns3", "ep3", "p33"):  true,
+			makeServicePortName("te", "ns1", "ep1", "p12"):  true,
+			makeServicePortName("te", "ns1", "ep1", "p122"): true,
+			makeServicePortName("te", "ns3", "ep3", "p33"):  true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns4", "ep4"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns4", "ep4"): 1,
 		},
 	}, {
 		// Case[15]: change from 0 endpoint address to 1 unnamed port
@@ -1193,15 +1193,15 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", ""): true,
+			makeServicePortName("te", "ns1", "ep1", ""): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{},
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{},
 	},
 	}
 

--- a/pkg/proxy/healthcheck/healthcheck_test.go
+++ b/pkg/proxy/healthcheck/healthcheck_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/proxy/healthcheck/healthcheck_test.go
+++ b/pkg/proxy/healthcheck/healthcheck_test.go
@@ -95,8 +95,8 @@ func (fake *fakeHTTPServer) Serve(listener net.Listener) error {
 	return nil // Cause the goroutine to return
 }
 
-func mknsn(ns, name string) types.NamespacedName {
-	return types.NamespacedName{
+func mknsn(ns, name string) types.NamespacednameWithTenantSource {
+	return types.NamespacednameWithTenantSource{
 		Namespace: ns,
 		Name:      name,
 	}
@@ -136,14 +136,14 @@ func TestServer(t *testing.T) {
 	}
 
 	// sync unknown endpoints, should be dropped
-	hcs.SyncEndpoints(map[types.NamespacedName]int{mknsn("a", "b"): 93})
+	hcs.SyncEndpoints(map[types.NamespacednameWithTenantSource]int{mknsn("a", "b"): 93})
 	if len(hcs.services) != 0 {
 		t.Errorf("expected 0 services, got %d", len(hcs.services))
 	}
 
 	// sync a real service
 	nsn := mknsn("a", "b")
-	hcs.SyncServices(map[types.NamespacedName]uint16{nsn: 9376})
+	hcs.SyncServices(map[types.NamespacednameWithTenantSource]uint16{nsn: 9376})
 	if len(hcs.services) != 1 {
 		t.Errorf("expected 1 service, got %d", len(hcs.services))
 	}
@@ -160,7 +160,7 @@ func TestServer(t *testing.T) {
 	testHandler(hcs, nsn, http.StatusServiceUnavailable, 0, t)
 
 	// sync an endpoint
-	hcs.SyncEndpoints(map[types.NamespacedName]int{nsn: 18})
+	hcs.SyncEndpoints(map[types.NamespacednameWithTenantSource]int{nsn: 18})
 	if len(hcs.services) != 1 {
 		t.Errorf("expected 1 service, got %d", len(hcs.services))
 	}
@@ -171,7 +171,7 @@ func TestServer(t *testing.T) {
 	testHandler(hcs, nsn, http.StatusOK, 18, t)
 
 	// sync zero endpoints
-	hcs.SyncEndpoints(map[types.NamespacedName]int{nsn: 0})
+	hcs.SyncEndpoints(map[types.NamespacednameWithTenantSource]int{nsn: 0})
 	if len(hcs.services) != 1 {
 		t.Errorf("expected 1 service, got %d", len(hcs.services))
 	}
@@ -182,7 +182,7 @@ func TestServer(t *testing.T) {
 	testHandler(hcs, nsn, http.StatusServiceUnavailable, 0, t)
 
 	// put the endpoint back
-	hcs.SyncEndpoints(map[types.NamespacedName]int{nsn: 11})
+	hcs.SyncEndpoints(map[types.NamespacednameWithTenantSource]int{nsn: 11})
 	if len(hcs.services) != 1 {
 		t.Errorf("expected 1 service, got %d", len(hcs.services))
 	}
@@ -201,7 +201,7 @@ func TestServer(t *testing.T) {
 	testHandler(hcs, nsn, http.StatusServiceUnavailable, 0, t)
 
 	// put the endpoint back
-	hcs.SyncEndpoints(map[types.NamespacedName]int{nsn: 18})
+	hcs.SyncEndpoints(map[types.NamespacednameWithTenantSource]int{nsn: 18})
 	if len(hcs.services) != 1 {
 		t.Errorf("expected 1 service, got %d", len(hcs.services))
 	}
@@ -219,7 +219,7 @@ func TestServer(t *testing.T) {
 	nsn2 := mknsn("c", "d")
 	nsn3 := mknsn("e", "f")
 	nsn4 := mknsn("g", "h")
-	hcs.SyncServices(map[types.NamespacedName]uint16{
+	hcs.SyncServices(map[types.NamespacednameWithTenantSource]uint16{
 		nsn1: 9376,
 		nsn2: 12909,
 		nsn3: 11113,
@@ -245,7 +245,7 @@ func TestServer(t *testing.T) {
 	testHandler(hcs, nsn3, http.StatusServiceUnavailable, 0, t)
 
 	// sync endpoints
-	hcs.SyncEndpoints(map[types.NamespacedName]int{
+	hcs.SyncEndpoints(map[types.NamespacednameWithTenantSource]int{
 		nsn1: 9,
 		nsn2: 3,
 		nsn3: 7,
@@ -268,7 +268,7 @@ func TestServer(t *testing.T) {
 	testHandler(hcs, nsn3, http.StatusOK, 7, t)
 
 	// sync new services
-	hcs.SyncServices(map[types.NamespacedName]uint16{
+	hcs.SyncServices(map[types.NamespacednameWithTenantSource]uint16{
 		//nsn1: 9376, // remove it
 		nsn2: 12909, // leave it
 		nsn3: 11114, // change it
@@ -292,7 +292,7 @@ func TestServer(t *testing.T) {
 	testHandler(hcs, nsn4, http.StatusServiceUnavailable, 0, t)
 
 	// sync endpoints
-	hcs.SyncEndpoints(map[types.NamespacedName]int{
+	hcs.SyncEndpoints(map[types.NamespacednameWithTenantSource]int{
 		nsn1: 9,
 		nsn2: 3,
 		nsn3: 7,
@@ -316,7 +316,7 @@ func TestServer(t *testing.T) {
 	testHandler(hcs, nsn4, http.StatusOK, 6, t)
 
 	// sync endpoints, missing nsn2
-	hcs.SyncEndpoints(map[types.NamespacedName]int{
+	hcs.SyncEndpoints(map[types.NamespacednameWithTenantSource]int{
 		nsn3: 7,
 		nsn4: 6,
 	})
@@ -338,7 +338,7 @@ func TestServer(t *testing.T) {
 	testHandler(hcs, nsn4, http.StatusOK, 6, t)
 }
 
-func testHandler(hcs *server, nsn types.NamespacedName, status int, endpoints int, t *testing.T) {
+func testHandler(hcs *server, nsn types.NamespacednameWithTenantSource, status int, endpoints int, t *testing.T) {
 	handler := hcs.services[nsn].server.(*fakeHTTPServer).handler
 	req, err := http.NewRequest("GET", "/healthz", nil)
 	if err != nil {

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -151,12 +151,13 @@ type serviceInfo struct {
 }
 
 // returns a new proxy.ServicePort which abstracts a serviceInfo
-func newServiceInfo(port *v1.ServicePort, service *v1.Service, baseInfo *proxy.BaseServiceInfo) proxy.ServicePort {
+func newServiceInfo(port *v1.ServicePort, service *v1.Service, baseInfo *proxy.BaseServiceInfo, tenantPartitionId int) proxy.ServicePort {
 	info := &serviceInfo{BaseServiceInfo: baseInfo}
 
 	// Store the following for performance reasons.
-	svcName := types.NamespacedName{Tenant: service.Tenant, Namespace: service.Namespace, Name: service.Name}
-	svcPortName := proxy.ServicePortName{NamespacedName: svcName, Port: port.Name}
+	svcName := types.NamespacednameWithTenantSource{
+		TenantPartitionId: tenantPartitionId, Tenant: service.Tenant, Namespace: service.Namespace, Name: service.Name}
+	svcPortName := proxy.ServicePortName{NamespacednameWithTenantSource: svcName, Port: port.Name}
 	protocol := strings.ToLower(string(info.Protocol()))
 	info.serviceNameString = svcPortName.String()
 	info.servicePortChainName = servicePortChainName(info.serviceNameString, protocol)
@@ -512,28 +513,28 @@ func (proxier *Proxier) isInitialized() bool {
 
 // OnServiceAdd is called whenever creation of new service object
 // is observed.
-func (proxier *Proxier) OnServiceAdd(service *v1.Service) {
-	proxier.OnServiceUpdate(nil, service)
+func (proxier *Proxier) OnServiceAdd(service *v1.Service, tenantParitionId int) {
+	proxier.OnServiceUpdate(nil, service, tenantParitionId)
 }
 
 // OnServiceUpdate is called whenever modification of an existing
 // service object is observed.
-func (proxier *Proxier) OnServiceUpdate(oldService, service *v1.Service) {
-	if proxier.serviceChanges.Update(oldService, service) && proxier.isInitialized() {
+func (proxier *Proxier) OnServiceUpdate(oldService, service *v1.Service, tenantParitionId int) {
+	if proxier.serviceChanges.Update(oldService, service, tenantParitionId) && proxier.isInitialized() {
 		proxier.syncRunner.Run()
 	}
 }
 
 // OnServiceDelete is called whenever deletion of an existing service
 // object is observed.
-func (proxier *Proxier) OnServiceDelete(service *v1.Service) {
-	proxier.OnServiceUpdate(service, nil)
+func (proxier *Proxier) OnServiceDelete(service *v1.Service, tenantParitionId int) {
+	proxier.OnServiceUpdate(service, nil, tenantParitionId)
 
 }
 
 // OnServiceSynced is called once all the initial even handlers were
 // called and the state is fully propagated to local cache.
-func (proxier *Proxier) OnServiceSynced() {
+func (proxier *Proxier) OnServiceSynced(tenantParitionId int) {
 	proxier.mu.Lock()
 	proxier.servicesSynced = true
 	proxier.setInitialized(proxier.servicesSynced && proxier.endpointsSynced)
@@ -545,27 +546,27 @@ func (proxier *Proxier) OnServiceSynced() {
 
 // OnEndpointsAdd is called whenever creation of new endpoints object
 // is observed.
-func (proxier *Proxier) OnEndpointsAdd(endpoints *v1.Endpoints) {
-	proxier.OnEndpointsUpdate(nil, endpoints)
+func (proxier *Proxier) OnEndpointsAdd(endpoints *v1.Endpoints, tenantPartitionId int) {
+	proxier.OnEndpointsUpdate(nil, endpoints, tenantPartitionId)
 }
 
 // OnEndpointsUpdate is called whenever modification of an existing
 // endpoints object is observed.
-func (proxier *Proxier) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoints) {
-	if proxier.endpointsChanges.Update(oldEndpoints, endpoints) && proxier.isInitialized() {
+func (proxier *Proxier) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoints, tenantPartitionId int) {
+	if proxier.endpointsChanges.Update(oldEndpoints, endpoints, tenantPartitionId) && proxier.isInitialized() {
 		proxier.syncRunner.Run()
 	}
 }
 
 // OnEndpointsDelete is called whever deletion of an existing endpoints
 // object is observed.
-func (proxier *Proxier) OnEndpointsDelete(endpoints *v1.Endpoints) {
-	proxier.OnEndpointsUpdate(endpoints, nil)
+func (proxier *Proxier) OnEndpointsDelete(endpoints *v1.Endpoints, tenantPartitionId int) {
+	proxier.OnEndpointsUpdate(endpoints, nil, tenantPartitionId)
 }
 
 // OnEndpointsSynced is called once all the initial event handlers were
 // called and the state is fully propagated to local cache.
-func (proxier *Proxier) OnEndpointsSynced() {
+func (proxier *Proxier) OnEndpointsSynced(tenantPartitionId int) {
 	proxier.mu.Lock()
 	proxier.endpointsSynced = true
 	proxier.setInitialized(proxier.servicesSynced && proxier.endpointsSynced)

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -278,8 +278,8 @@ func TestDeleteEndpointConnections(t *testing.T) {
 		priorGlogErrs := klog.Stats.Error.Lines()
 
 		svc := proxy.ServicePortName{
-			NamespacedName: types.NamespacedName{Namespace: "ns1", Name: tc.svcName},
-			Port:           "p80",
+			NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{TenantPartitionId: tpId, Tenant: "te", Namespace: "ns1", Name: tc.svcName},
+			Port:                           "p80",
 		}
 		input := []proxy.ServiceEndpoint{
 			{
@@ -343,23 +343,23 @@ func (f *fakePortOpener) OpenLocalPort(lp *utilproxy.LocalPort) (utilproxy.Close
 }
 
 type fakeHealthChecker struct {
-	services  map[types.NamespacedName]uint16
-	endpoints map[types.NamespacedName]int
+	services  map[types.NamespacednameWithTenantSource]uint16
+	endpoints map[types.NamespacednameWithTenantSource]int
 }
 
 func newFakeHealthChecker() *fakeHealthChecker {
 	return &fakeHealthChecker{
-		services:  map[types.NamespacedName]uint16{},
-		endpoints: map[types.NamespacedName]int{},
+		services:  map[types.NamespacednameWithTenantSource]uint16{},
+		endpoints: map[types.NamespacednameWithTenantSource]int{},
 	}
 }
 
-func (fake *fakeHealthChecker) SyncServices(newServices map[types.NamespacedName]uint16) error {
+func (fake *fakeHealthChecker) SyncServices(newServices map[types.NamespacednameWithTenantSource]uint16) error {
 	fake.services = newServices
 	return nil
 }
 
-func (fake *fakeHealthChecker) SyncEndpoints(newEndpoints map[types.NamespacedName]int) error {
+func (fake *fakeHealthChecker) SyncEndpoints(newEndpoints map[types.NamespacednameWithTenantSource]int) error {
 	fake.endpoints = newEndpoints
 	return nil
 }
@@ -582,8 +582,8 @@ func TestClusterIPReject(t *testing.T) {
 	svcIP := "10.20.30.41"
 	svcPort := 80
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -616,8 +616,8 @@ func TestClusterIPEndpointsJump(t *testing.T) {
 	svcIP := "10.20.30.41"
 	svcPort := 80
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -675,8 +675,8 @@ func TestLoadBalancer(t *testing.T) {
 	svcNodePort := 3001
 	svcLBIP := "1.2.3.4"
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -734,8 +734,8 @@ func TestNodePort(t *testing.T) {
 	svcPort := 80
 	svcNodePort := 3001
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -792,8 +792,8 @@ func TestExternalIPsReject(t *testing.T) {
 	svcPort := 80
 	svcExternalIPs := "50.60.70.81"
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -826,8 +826,8 @@ func TestNodePortReject(t *testing.T) {
 	svcPort := 80
 	svcNodePort := 3001
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -860,8 +860,8 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 	svcNodePort := 3001
 	svcLBIP := "1.2.3.4"
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 	svcSessionAffinityTimeout := int32(10800)
 
@@ -961,8 +961,8 @@ func onlyLocalNodePorts(t *testing.T, fp *Proxier, ipt *iptablestest.FakeIPTable
 	svcPort := 80
 	svcNodePort := 3001
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -1124,7 +1124,7 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	if len(result.HCServiceNodePorts) != 1 {
 		t.Errorf("expected 1 healthcheck port, got %v", result.HCServiceNodePorts)
 	} else {
-		nsn := makeNSN("somewhere", "only-local-load-balancer")
+		nsn := makeNSN("te", "somewhere", "only-local-load-balancer")
 		if port, found := result.HCServiceNodePorts[nsn]; !found || port != 345 {
 			t.Errorf("expected healthcheck port [%q]=345: got %v", nsn, result.HCServiceNodePorts)
 		}
@@ -1331,14 +1331,14 @@ func makeEndpointsMap(proxier *Proxier, allEndpoints ...*v1.Endpoints) {
 	proxier.endpointsSynced = true
 }
 
-func makeNSN(namespace, name string) types.NamespacedName {
-	return types.NamespacedName{Namespace: namespace, Name: name}
+func makeNSN(tenant, namespace, name string) types.NamespacednameWithTenantSource {
+	return types.NamespacednameWithTenantSource{TenantPartitionId: tpId, Tenant: tenant, Namespace: namespace, Name: name}
 }
 
-func makeServicePortName(ns, name, port string) proxy.ServicePortName {
+func makeServicePortName(te, ns, name, port string) proxy.ServicePortName {
 	return proxy.ServicePortName{
-		NamespacedName: makeNSN(ns, name),
-		Port:           port,
+		NamespacednameWithTenantSource: makeNSN(te, ns, name),
+		Port:                           port,
 	}
 }
 
@@ -1693,14 +1693,14 @@ func Test_updateEndpointsMap(t *testing.T) {
 		expectedResult            map[proxy.ServicePortName][]*endpointsInfo
 		expectedStaleEndpoints    []proxy.ServiceEndpoint
 		expectedStaleServiceNames map[proxy.ServicePortName]bool
-		expectedHealthchecks      map[types.NamespacedName]int
+		expectedHealthchecks      map[types.NamespacednameWithTenantSource]int
 	}{{
 		// Case[0]: nothing
 		oldEndpoints:              map[proxy.ServicePortName][]*endpointsInfo{},
 		expectedResult:            map[proxy.ServicePortName][]*endpointsInfo{},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[1]: no change, unnamed port
 		previousEndpoints: []*v1.Endpoints{
@@ -1710,18 +1710,18 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", unnamedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[2]: no change, named port, local
 		previousEndpoints: []*v1.Endpoints{
@@ -1731,19 +1731,19 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[3]: no change, multiple subsets
@@ -1754,24 +1754,24 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsets),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[4]: no change, multiple subsets, multiple ports, local
 		previousEndpoints: []*v1.Endpoints{
@@ -1781,31 +1781,31 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsMultiplePortsLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("te", "ns1", "ep1", "p13"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.3:13", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("te", "ns1", "ep1", "p13"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.3:13", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[5]: no change, multiple endpoints, subsets, IPs, and ports
@@ -1818,62 +1818,62 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns2", "ep2", multipleSubsetsIPsPorts2),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:11", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("te", "ns1", "ep1", "p13"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.3:13", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.4:13", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p14"): {
+			makeServicePortName("te", "ns1", "ep1", "p14"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.3:14", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.4:14", IsLocal: true}},
 			},
-			makeServicePortName("ns2", "ep2", "p21"): {
+			makeServicePortName("te", "ns2", "ep2", "p21"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.1:21", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.2:21", IsLocal: true}},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("te", "ns2", "ep2", "p22"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.1:22", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.2:22", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:11", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("te", "ns1", "ep1", "p13"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.3:13", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.4:13", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p14"): {
+			makeServicePortName("te", "ns1", "ep1", "p14"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.3:14", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.4:14", IsLocal: true}},
 			},
-			makeServicePortName("ns2", "ep2", "p21"): {
+			makeServicePortName("te", "ns2", "ep2", "p21"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.1:21", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.2:21", IsLocal: true}},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("te", "ns2", "ep2", "p22"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.1:22", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.2:22", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 2,
-			makeNSN("ns2", "ep2"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 2,
+			makeNSN("te", "ns2", "ep2"): 1,
 		},
 	}, {
 		// Case[6]: add an Endpoints
@@ -1885,16 +1885,16 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", ""): true,
+			makeServicePortName("te", "ns1", "ep1", ""): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[7]: remove an Endpoints
@@ -1905,17 +1905,17 @@ func Test_updateEndpointsMap(t *testing.T) {
 			nil,
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", ""),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", ""),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[8]: add an IP and port
 		previousEndpoints: []*v1.Endpoints{
@@ -1925,26 +1925,26 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortsLocalNoLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:11", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"): true,
+			makeServicePortName("te", "ns1", "ep1", "p12"): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[9]: remove an IP and port
@@ -1955,32 +1955,32 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:11", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.2:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p11"),
 		}, {
 			Endpoint:        "1.1.1.1:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p12"),
 		}, {
 			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p12"),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[10]: add a subset
 		previousEndpoints: []*v1.Endpoints{
@@ -1990,24 +1990,24 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsWithLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"): true,
+			makeServicePortName("te", "ns1", "ep1", "p12"): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[11]: remove a subset
@@ -2018,24 +2018,24 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p12"),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[12]: rename a port
 		previousEndpoints: []*v1.Endpoints{
@@ -2045,23 +2045,23 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortRenamed),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11-2"): {
+			makeServicePortName("te", "ns1", "ep1", "p11-2"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p11"),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p11-2"): true,
+			makeServicePortName("te", "ns1", "ep1", "p11-2"): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{},
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[13]: renumber a port
 		previousEndpoints: []*v1.Endpoints{
@@ -2071,21 +2071,21 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortRenumbered),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:22", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p11"),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[14]: complex add and remove
 		previousEndpoints: []*v1.Endpoints{
@@ -2101,65 +2101,65 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns4", "ep4", complexAfter4),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("te", "ns2", "ep2", "p22"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.2:22", IsLocal: true}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.22:22", IsLocal: true}},
 			},
-			makeServicePortName("ns2", "ep2", "p23"): {
+			makeServicePortName("te", "ns2", "ep2", "p23"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.3:23", IsLocal: true}},
 			},
-			makeServicePortName("ns4", "ep4", "p44"): {
+			makeServicePortName("te", "ns4", "ep4", "p44"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "4.4.4.4:44", IsLocal: true}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "4.4.4.5:44", IsLocal: true}},
 			},
-			makeServicePortName("ns4", "ep4", "p45"): {
+			makeServicePortName("te", "ns4", "ep4", "p45"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "4.4.4.6:45", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.11:11", IsLocal: false}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: false}},
 			},
-			makeServicePortName("ns1", "ep1", "p122"): {
+			makeServicePortName("te", "ns1", "ep1", "p122"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:122", IsLocal: false}},
 			},
-			makeServicePortName("ns3", "ep3", "p33"): {
+			makeServicePortName("te", "ns3", "ep3", "p33"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "3.3.3.3:33", IsLocal: false}},
 			},
-			makeServicePortName("ns4", "ep4", "p44"): {
+			makeServicePortName("te", "ns4", "ep4", "p44"): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "4.4.4.4:44", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "2.2.2.2:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22"),
+			ServicePortName: makeServicePortName("te", "ns2", "ep2", "p22"),
 		}, {
 			Endpoint:        "2.2.2.22:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22"),
+			ServicePortName: makeServicePortName("te", "ns2", "ep2", "p22"),
 		}, {
 			Endpoint:        "2.2.2.3:23",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p23"),
+			ServicePortName: makeServicePortName("te", "ns2", "ep2", "p23"),
 		}, {
 			Endpoint:        "4.4.4.5:44",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p44"),
+			ServicePortName: makeServicePortName("te", "ns4", "ep4", "p44"),
 		}, {
 			Endpoint:        "4.4.4.6:45",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p45"),
+			ServicePortName: makeServicePortName("te", "ns4", "ep4", "p45"),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"):  true,
-			makeServicePortName("ns1", "ep1", "p122"): true,
-			makeServicePortName("ns3", "ep3", "p33"):  true,
+			makeServicePortName("te", "ns1", "ep1", "p12"):  true,
+			makeServicePortName("te", "ns1", "ep1", "p122"): true,
+			makeServicePortName("te", "ns3", "ep3", "p33"):  true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns4", "ep4"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns4", "ep4"): 1,
 		},
 	}, {
 		// Case[15]: change from 0 endpoint address to 1 unnamed port
@@ -2171,15 +2171,15 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", ""): true,
+			makeServicePortName("te", "ns1", "ep1", ""): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{},
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{},
 	},
 	}
 

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -258,7 +258,7 @@ func TestDeleteEndpointConnections(t *testing.T) {
 
 	for _, tc := range testCases {
 		makeServiceMap(fp,
-			makeTestService("ns1", tc.svcName, func(svc *v1.Service) {
+			makeTestService("te", "ns1", tc.svcName, func(svc *v1.Service) {
 				svc.Spec.ClusterIP = tc.svcIP
 				svc.Spec.Ports = []v1.ServicePort{{
 					Name:     "p80",
@@ -587,7 +587,7 @@ func TestClusterIPReject(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:     svcPortName.Port,
@@ -621,7 +621,7 @@ func TestClusterIPEndpointsJump(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:     svcPortName.Port,
@@ -633,7 +633,7 @@ func TestClusterIPEndpointsJump(t *testing.T) {
 
 	epIP := "10.180.0.1"
 	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
 					IP: epIP,
@@ -680,7 +680,7 @@ func TestLoadBalancer(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "LoadBalancer"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
@@ -697,7 +697,7 @@ func TestLoadBalancer(t *testing.T) {
 
 	epIP := "10.180.0.1"
 	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
 					IP: epIP,
@@ -739,7 +739,7 @@ func TestNodePort(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "NodePort"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
@@ -753,7 +753,7 @@ func TestNodePort(t *testing.T) {
 
 	epIP := "10.180.0.1"
 	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
 					IP: epIP,
@@ -797,7 +797,7 @@ func TestExternalIPsReject(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "ClusterIP"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.ExternalIPs = []string{svcExternalIPs}
@@ -831,7 +831,7 @@ func TestNodePortReject(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "NodePort"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
@@ -866,7 +866,7 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 	svcSessionAffinityTimeout := int32(10800)
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "LoadBalancer"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
@@ -891,7 +891,7 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 	epStrLocal := fmt.Sprintf("%s:%d", epIP1, svcPort)
 	epStrNonLocal := fmt.Sprintf("%s:%d", epIP2, svcPort)
 	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
 					IP:       epIP1,
@@ -966,7 +966,7 @@ func onlyLocalNodePorts(t *testing.T, fp *Proxier, ipt *iptablestest.FakeIPTable
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "NodePort"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
@@ -984,7 +984,7 @@ func onlyLocalNodePorts(t *testing.T, fp *Proxier, ipt *iptablestest.FakeIPTable
 	epStrLocal := fmt.Sprintf("%s:%d", epIP1, svcPort)
 	epStrNonLocal := fmt.Sprintf("%s:%d", epIP2, svcPort)
 	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
 					IP:       epIP1,
@@ -1040,11 +1040,12 @@ func onlyLocalNodePorts(t *testing.T, fp *Proxier, ipt *iptablestest.FakeIPTable
 	}
 }
 
-func makeTestService(namespace, name string, svcFunc func(*v1.Service)) *v1.Service {
+func makeTestService(tenant, namespace, name string, svcFunc func(*v1.Service)) *v1.Service {
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
+			Tenant:      tenant,
 			Annotations: map[string]string{},
 		},
 		Spec:   v1.ServiceSpec{},
@@ -1070,21 +1071,21 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	fp := NewFakeProxier(ipt)
 
 	services := []*v1.Service{
-		makeTestService("somewhere-else", "cluster-ip", func(svc *v1.Service) {
+		makeTestService("te", "somewhere-else", "cluster-ip", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeClusterIP
 			svc.Spec.ClusterIP = "172.16.55.4"
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "something", "UDP", 1234, 4321, 0)
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "somethingelse", "UDP", 1235, 5321, 0)
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "sctpport", "SCTP", 1236, 6321, 0)
 		}),
-		makeTestService("somewhere-else", "node-port", func(svc *v1.Service) {
+		makeTestService("te", "somewhere-else", "node-port", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeNodePort
 			svc.Spec.ClusterIP = "172.16.55.10"
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "blahblah", "UDP", 345, 678, 0)
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "moreblahblah", "TCP", 344, 677, 0)
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "muchmoreblah", "SCTP", 343, 676, 0)
 		}),
-		makeTestService("somewhere", "load-balancer", func(svc *v1.Service) {
+		makeTestService("te", "somewhere", "load-balancer", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeLoadBalancer
 			svc.Spec.ClusterIP = "172.16.55.11"
 			svc.Spec.LoadBalancerIP = "5.6.7.8"
@@ -1096,7 +1097,7 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 				},
 			}
 		}),
-		makeTestService("somewhere", "only-local-load-balancer", func(svc *v1.Service) {
+		makeTestService("te", "somewhere", "only-local-load-balancer", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeLoadBalancer
 			svc.Spec.ClusterIP = "172.16.55.12"
 			svc.Spec.LoadBalancerIP = "5.6.7.8"
@@ -1137,7 +1138,7 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 
 	// Remove some stuff
 	// oneService is a modification of services[0] with removed first port.
-	oneService := makeTestService("somewhere-else", "cluster-ip", func(svc *v1.Service) {
+	oneService := makeTestService("te", "somewhere-else", "cluster-ip", func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		svc.Spec.ClusterIP = "172.16.55.4"
 		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "somethingelse", "UDP", 1235, 5321, 0)
@@ -1176,12 +1177,12 @@ func TestBuildServiceMapServiceHeadless(t *testing.T) {
 	fp := NewFakeProxier(ipt)
 
 	makeServiceMap(fp,
-		makeTestService("somewhere-else", "headless", func(svc *v1.Service) {
+		makeTestService("te", "somewhere-else", "headless", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeClusterIP
 			svc.Spec.ClusterIP = v1.ClusterIPNone
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "rpc", "UDP", 1234, 0, 0)
 		}),
-		makeTestService("somewhere-else", "headless-without-port", func(svc *v1.Service) {
+		makeTestService("te", "somewhere-else", "headless-without-port", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeClusterIP
 			svc.Spec.ClusterIP = v1.ClusterIPNone
 		}),
@@ -1208,7 +1209,7 @@ func TestBuildServiceMapServiceTypeExternalName(t *testing.T) {
 	fp := NewFakeProxier(ipt)
 
 	makeServiceMap(fp,
-		makeTestService("somewhere-else", "external-name", func(svc *v1.Service) {
+		makeTestService("te", "somewhere-else", "external-name", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeExternalName
 			svc.Spec.ClusterIP = "172.16.55.4" // Should be ignored
 			svc.Spec.ExternalName = "foo2.bar.com"
@@ -1233,13 +1234,13 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	ipt := iptablestest.NewFake()
 	fp := NewFakeProxier(ipt)
 
-	servicev1 := makeTestService("somewhere", "some-service", func(svc *v1.Service) {
+	servicev1 := makeTestService("te", "somewhere", "some-service", func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		svc.Spec.ClusterIP = "172.16.55.4"
 		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "something", "UDP", 1234, 4321, 0)
 		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "somethingelse", "TCP", 1235, 5321, 0)
 	})
-	servicev2 := makeTestService("somewhere", "some-service", func(svc *v1.Service) {
+	servicev2 := makeTestService("te", "somewhere", "some-service", func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeLoadBalancer
 		svc.Spec.ClusterIP = "172.16.55.4"
 		svc.Spec.LoadBalancerIP = "5.6.7.8"
@@ -1310,11 +1311,12 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	}
 }
 
-func makeTestEndpoints(namespace, name string, eptFunc func(*v1.Endpoints)) *v1.Endpoints {
+func makeTestEndpoints(tenant, namespace, name string, eptFunc func(*v1.Endpoints)) *v1.Endpoints {
 	ept := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Tenant:    tenant,
 		},
 	}
 	eptFunc(ept)
@@ -1704,10 +1706,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[1]: no change, unnamed port
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", unnamedPort),
+			makeTestEndpoints("te", "ns1", "ep1", unnamedPort),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", unnamedPort),
+			makeTestEndpoints("te", "ns1", "ep1", unnamedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("te", "ns1", "ep1", ""): {
@@ -1725,10 +1727,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[2]: no change, named port, local
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPortLocal),
+			makeTestEndpoints("te", "ns1", "ep1", namedPortLocal),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPortLocal),
+			makeTestEndpoints("te", "ns1", "ep1", namedPortLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -1748,10 +1750,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[3]: no change, multiple subsets
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsets),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsets),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsets),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsets),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -1775,10 +1777,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[4]: no change, multiple subsets, multiple ports, local
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsetsMultiplePortsLocal),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsetsMultiplePortsLocal),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsetsMultiplePortsLocal),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsetsMultiplePortsLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -1810,12 +1812,12 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[5]: no change, multiple endpoints, subsets, IPs, and ports
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsetsIPsPorts1),
-			makeTestEndpoints("ns2", "ep2", multipleSubsetsIPsPorts2),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsetsIPsPorts1),
+			makeTestEndpoints("te", "ns2", "ep2", multipleSubsetsIPsPorts2),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsetsIPsPorts1),
-			makeTestEndpoints("ns2", "ep2", multipleSubsetsIPsPorts2),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsetsIPsPorts1),
+			makeTestEndpoints("te", "ns2", "ep2", multipleSubsetsIPsPorts2),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -1881,7 +1883,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			nil,
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", unnamedPortLocal),
+			makeTestEndpoints("te", "ns1", "ep1", unnamedPortLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
@@ -1899,7 +1901,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[7]: remove an Endpoints
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", unnamedPortLocal),
+			makeTestEndpoints("te", "ns1", "ep1", unnamedPortLocal),
 		},
 		currentEndpoints: []*v1.Endpoints{
 			nil,
@@ -1919,10 +1921,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[8]: add an IP and port
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPort),
+			makeTestEndpoints("te", "ns1", "ep1", namedPort),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPortsLocalNoLocal),
+			makeTestEndpoints("te", "ns1", "ep1", namedPortsLocalNoLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -1949,10 +1951,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[9]: remove an IP and port
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPortsLocalNoLocal),
+			makeTestEndpoints("te", "ns1", "ep1", namedPortsLocalNoLocal),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPort),
+			makeTestEndpoints("te", "ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -1984,10 +1986,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[10]: add a subset
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPort),
+			makeTestEndpoints("te", "ns1", "ep1", namedPort),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsetsWithLocal),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsetsWithLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2012,10 +2014,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[11]: remove a subset
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsets),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsets),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPort),
+			makeTestEndpoints("te", "ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2039,10 +2041,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[12]: rename a port
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPort),
+			makeTestEndpoints("te", "ns1", "ep1", namedPort),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPortRenamed),
+			makeTestEndpoints("te", "ns1", "ep1", namedPortRenamed),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2065,10 +2067,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[13]: renumber a port
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPort),
+			makeTestEndpoints("te", "ns1", "ep1", namedPort),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPortRenumbered),
+			makeTestEndpoints("te", "ns1", "ep1", namedPortRenumbered),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2089,16 +2091,16 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[14]: complex add and remove
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", complexBefore1),
-			makeTestEndpoints("ns2", "ep2", complexBefore2),
+			makeTestEndpoints("te", "ns1", "ep1", complexBefore1),
+			makeTestEndpoints("te", "ns2", "ep2", complexBefore2),
 			nil,
-			makeTestEndpoints("ns4", "ep4", complexBefore4),
+			makeTestEndpoints("te", "ns4", "ep4", complexBefore4),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", complexAfter1),
+			makeTestEndpoints("te", "ns1", "ep1", complexAfter1),
 			nil,
-			makeTestEndpoints("ns3", "ep3", complexAfter3),
-			makeTestEndpoints("ns4", "ep4", complexAfter4),
+			makeTestEndpoints("te", "ns3", "ep3", complexAfter3),
+			makeTestEndpoints("te", "ns4", "ep4", complexAfter4),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2164,10 +2166,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[15]: change from 0 endpoint address to 1 unnamed port
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", emptyEndpoint),
+			makeTestEndpoints("te", "ns1", "ep1", emptyEndpoint),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", unnamedPort),
+			makeTestEndpoints("te", "ns1", "ep1", unnamedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -59,14 +59,14 @@ func (f *fakeIPGetter) NodeIPs() ([]net.IP, error) {
 }
 
 type fakeHealthChecker struct {
-	services  map[types.NamespacedName]uint16
-	Endpoints map[types.NamespacedName]int
+	services  map[types.NamespacednameWithTenantSource]uint16
+	Endpoints map[types.NamespacednameWithTenantSource]int
 }
 
 func newFakeHealthChecker() *fakeHealthChecker {
 	return &fakeHealthChecker{
-		services:  map[types.NamespacedName]uint16{},
-		Endpoints: map[types.NamespacedName]int{},
+		services:  map[types.NamespacednameWithTenantSource]uint16{},
+		Endpoints: map[types.NamespacednameWithTenantSource]int{},
 	}
 }
 
@@ -82,12 +82,12 @@ func (f *fakePortOpener) OpenLocalPort(lp *utilproxy.LocalPort) (utilproxy.Close
 	return nil, nil
 }
 
-func (fake *fakeHealthChecker) SyncServices(newServices map[types.NamespacedName]uint16) error {
+func (fake *fakeHealthChecker) SyncServices(newServices map[types.NamespacednameWithTenantSource]uint16) error {
 	fake.services = newServices
 	return nil
 }
 
-func (fake *fakeHealthChecker) SyncEndpoints(newEndpoints map[types.NamespacedName]int) error {
+func (fake *fakeHealthChecker) SyncEndpoints(newEndpoints map[types.NamespacednameWithTenantSource]int) error {
 	fake.Endpoints = newEndpoints
 	return nil
 }
@@ -161,8 +161,8 @@ func NewFakeProxier(ipt utiliptables.Interface, ipvs utilipvs.Interface, ipset u
 	}
 }
 
-func makeNSN(namespace, name string) types.NamespacedName {
-	return types.NamespacedName{Namespace: namespace, Name: name}
+func makeNSN(tenant, namespace, name string) types.NamespacednameWithTenantSource {
+	return types.NamespacednameWithTenantSource{TenantPartitionId: tpId, Tenant: tenant, Namespace: namespace, Name: name}
 }
 
 func makeServiceMap(proxier *Proxier, allServices ...*v1.Service) {
@@ -219,8 +219,8 @@ func TestCleanupLeftovers(t *testing.T) {
 	svcPort := 80
 	svcNodePort := 3001
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -410,8 +410,8 @@ func TestNodePortUDP(t *testing.T) {
 	svcPort := 80
 	svcNodePort := 3001
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -486,8 +486,8 @@ func TestNodePort(t *testing.T) {
 	svcPort := 80
 	svcNodePort := 3001
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -564,8 +564,8 @@ func TestNodePortNoEndpoint(t *testing.T) {
 	svcPort := 80
 	svcNodePort := 3001
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -618,8 +618,8 @@ func TestClusterIPNoEndpoint(t *testing.T) {
 	svcIP := "10.20.30.41"
 	svcPort := 80
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -663,14 +663,14 @@ func TestClusterIP(t *testing.T) {
 	svcIPv4 := "10.20.30.41"
 	svcPortV4 := 80
 	svcPortNameV4 := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 	svcIPv6 := "1002:ab8::2:1"
 	svcPortV6 := 8080
 	svcPortNameV6 := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns2", "svc2"),
-		Port:           "p8080",
+		NamespacednameWithTenantSource: makeNSN("te", "ns2", "svc2"),
+		Port:                           "p8080",
 	}
 	makeServiceMap(fp,
 		makeTestService(svcPortNameV4.Namespace, svcPortNameV4.Name, func(svc *v1.Service) {
@@ -770,8 +770,8 @@ func TestExternalIPsNoEndpoint(t *testing.T) {
 	svcPort := 80
 	svcExternalIPs := "50.60.70.81"
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -825,8 +825,8 @@ func TestExternalIPs(t *testing.T) {
 	svcPort := 80
 	svcExternalIPs := sets.NewString("50.60.70.81", "2012::51", "127.0.0.1")
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -893,8 +893,8 @@ func TestLoadBalancer(t *testing.T) {
 	svcNodePort := 3001
 	svcLBIP := "1.2.3.4"
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -969,8 +969,8 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 	svcPort := 80
 	svcNodePort := 3001
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -1068,8 +1068,8 @@ func TestLoadBalanceSourceRanges(t *testing.T) {
 	svcLBIP := "1.2.3.4"
 	svcLBSource := "10.0.0.0/8"
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 	epIP := "10.180.0.1"
 
@@ -1231,8 +1231,8 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 	svcNodePort := 3001
 	svcLBIP := "1.2.3.4"
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 
 	makeServiceMap(fp,
@@ -1397,7 +1397,7 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	if len(result.HCServiceNodePorts) != 1 {
 		t.Errorf("expected 1 healthcheck port, got %v", result.HCServiceNodePorts)
 	} else {
-		nsn := makeNSN("somewhere", "only-local-load-balancer")
+		nsn := makeNSN("te", "somewhere", "only-local-load-balancer")
 		if port, found := result.HCServiceNodePorts[nsn]; !found || port != 345 {
 			t.Errorf("expected healthcheck port [%q]=345: got %v", nsn, result.HCServiceNodePorts)
 		}
@@ -1605,8 +1605,8 @@ func TestSessionAffinity(t *testing.T) {
 	svcNodePort := 3001
 	svcExternalIPs := "50.60.70.81"
 	svcPortName := proxy.ServicePortName{
-		NamespacedName: makeNSN("ns1", "svc1"),
-		Port:           "p80",
+		NamespacednameWithTenantSource: makeNSN("te", "ns1", "svc1"),
+		Port:                           "p80",
 	}
 	timeoutSeconds := v1.DefaultClientIPServiceAffinitySeconds
 
@@ -1645,10 +1645,10 @@ func TestSessionAffinity(t *testing.T) {
 	}
 }
 
-func makeServicePortName(ns, name, port string) proxy.ServicePortName {
+func makeServicePortName(te, ns, name, port string) proxy.ServicePortName {
 	return proxy.ServicePortName{
-		NamespacedName: makeNSN(ns, name),
-		Port:           port,
+		NamespacednameWithTenantSource: makeNSN(te, ns, name),
+		Port:                           port,
 	}
 }
 
@@ -1968,14 +1968,14 @@ func Test_updateEndpointsMap(t *testing.T) {
 		expectedResult            map[proxy.ServicePortName][]*proxy.BaseEndpointInfo
 		expectedStaleEndpoints    []proxy.ServiceEndpoint
 		expectedStaleServiceNames map[proxy.ServicePortName]bool
-		expectedHealthchecks      map[types.NamespacedName]int
+		expectedHealthchecks      map[types.NamespacednameWithTenantSource]int
 	}{{
 		// Case[0]: nothing
 		oldEndpoints:              map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{},
 		expectedResult:            map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[1]: no change, unnamed port
 		previousEndpoints: []*v1.Endpoints{
@@ -1985,18 +1985,18 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", unnamedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[2]: no change, named port, local
 		previousEndpoints: []*v1.Endpoints{
@@ -2006,19 +2006,19 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[3]: no change, multiple subsets
@@ -2029,24 +2029,24 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsets),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[4]: no change, multiple subsets, multiple ports, local
 		previousEndpoints: []*v1.Endpoints{
@@ -2056,31 +2056,31 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsMultiplePortsLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.1:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("te", "ns1", "ep1", "p13"): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.1:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("te", "ns1", "ep1", "p13"): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[5]: no change, multiple endpoints, subsets, IPs, and ports
@@ -2093,62 +2093,62 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns2", "ep2", multipleSubsetsIPsPorts2),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("te", "ns1", "ep1", "p13"): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 				{Endpoint: "1.1.1.4:13", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p14"): {
+			makeServicePortName("te", "ns1", "ep1", "p14"): {
 				{Endpoint: "1.1.1.3:14", IsLocal: false},
 				{Endpoint: "1.1.1.4:14", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p21"): {
+			makeServicePortName("te", "ns2", "ep2", "p21"): {
 				{Endpoint: "2.2.2.1:21", IsLocal: false},
 				{Endpoint: "2.2.2.2:21", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("te", "ns2", "ep2", "p22"): {
 				{Endpoint: "2.2.2.1:22", IsLocal: false},
 				{Endpoint: "2.2.2.2:22", IsLocal: true},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("te", "ns1", "ep1", "p13"): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 				{Endpoint: "1.1.1.4:13", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p14"): {
+			makeServicePortName("te", "ns1", "ep1", "p14"): {
 				{Endpoint: "1.1.1.3:14", IsLocal: false},
 				{Endpoint: "1.1.1.4:14", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p21"): {
+			makeServicePortName("te", "ns2", "ep2", "p21"): {
 				{Endpoint: "2.2.2.1:21", IsLocal: false},
 				{Endpoint: "2.2.2.2:21", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("te", "ns2", "ep2", "p22"): {
 				{Endpoint: "2.2.2.1:22", IsLocal: false},
 				{Endpoint: "2.2.2.2:22", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 2,
-			makeNSN("ns2", "ep2"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 2,
+			makeNSN("te", "ns2", "ep2"): 1,
 		},
 	}, {
 		// Case[6]: add an Endpoints
@@ -2160,16 +2160,16 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", ""): true,
+			makeServicePortName("te", "ns1", "ep1", ""): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[7]: remove an Endpoints
@@ -2180,17 +2180,17 @@ func Test_updateEndpointsMap(t *testing.T) {
 			nil,
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", ""),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", ""),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[8]: add an IP and port
 		previousEndpoints: []*v1.Endpoints{
@@ -2200,26 +2200,26 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortsLocalNoLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"): true,
+			makeServicePortName("te", "ns1", "ep1", "p12"): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[9]: remove an IP and port
@@ -2230,32 +2230,32 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.2:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p11"),
 		}, {
 			Endpoint:        "1.1.1.1:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p12"),
 		}, {
 			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p12"),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[10]: add a subset
 		previousEndpoints: []*v1.Endpoints{
@@ -2265,24 +2265,24 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsWithLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"): true,
+			makeServicePortName("te", "ns1", "ep1", "p12"): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns1", "ep1"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns1", "ep1"): 1,
 		},
 	}, {
 		// Case[11]: remove a subset
@@ -2293,24 +2293,24 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p12"),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[12]: rename a port
 		previousEndpoints: []*v1.Endpoints{
@@ -2320,23 +2320,23 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortRenamed),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11-2"): {
+			makeServicePortName("te", "ns1", "ep1", "p11-2"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p11"),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p11-2"): true,
+			makeServicePortName("te", "ns1", "ep1", "p11-2"): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{},
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[13]: renumber a port
 		previousEndpoints: []*v1.Endpoints{
@@ -2346,21 +2346,21 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortRenumbered),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:22", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("te", "ns1", "ep1", "p11"),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
-		expectedHealthchecks:      map[types.NamespacedName]int{},
+		expectedHealthchecks:      map[types.NamespacednameWithTenantSource]int{},
 	}, {
 		// Case[14]: complex add and remove
 		previousEndpoints: []*v1.Endpoints{
@@ -2376,65 +2376,65 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns4", "ep4", complexAfter4),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("te", "ns2", "ep2", "p22"): {
 				{Endpoint: "2.2.2.2:22", IsLocal: true},
 				{Endpoint: "2.2.2.22:22", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p23"): {
+			makeServicePortName("te", "ns2", "ep2", "p23"): {
 				{Endpoint: "2.2.2.3:23", IsLocal: true},
 			},
-			makeServicePortName("ns4", "ep4", "p44"): {
+			makeServicePortName("te", "ns4", "ep4", "p44"): {
 				{Endpoint: "4.4.4.4:44", IsLocal: true},
 				{Endpoint: "4.4.4.5:44", IsLocal: true},
 			},
-			makeServicePortName("ns4", "ep4", "p45"): {
+			makeServicePortName("te", "ns4", "ep4", "p45"): {
 				{Endpoint: "4.4.4.6:45", IsLocal: true},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("te", "ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.11:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("te", "ns1", "ep1", "p12"): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p122"): {
+			makeServicePortName("te", "ns1", "ep1", "p122"): {
 				{Endpoint: "1.1.1.2:122", IsLocal: false},
 			},
-			makeServicePortName("ns3", "ep3", "p33"): {
+			makeServicePortName("te", "ns3", "ep3", "p33"): {
 				{Endpoint: "3.3.3.3:33", IsLocal: false},
 			},
-			makeServicePortName("ns4", "ep4", "p44"): {
+			makeServicePortName("te", "ns4", "ep4", "p44"): {
 				{Endpoint: "4.4.4.4:44", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "2.2.2.2:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22"),
+			ServicePortName: makeServicePortName("te", "ns2", "ep2", "p22"),
 		}, {
 			Endpoint:        "2.2.2.22:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22"),
+			ServicePortName: makeServicePortName("te", "ns2", "ep2", "p22"),
 		}, {
 			Endpoint:        "2.2.2.3:23",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p23"),
+			ServicePortName: makeServicePortName("te", "ns2", "ep2", "p23"),
 		}, {
 			Endpoint:        "4.4.4.5:44",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p44"),
+			ServicePortName: makeServicePortName("te", "ns4", "ep4", "p44"),
 		}, {
 			Endpoint:        "4.4.4.6:45",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p45"),
+			ServicePortName: makeServicePortName("te", "ns4", "ep4", "p45"),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"):  true,
-			makeServicePortName("ns1", "ep1", "p122"): true,
-			makeServicePortName("ns3", "ep3", "p33"):  true,
+			makeServicePortName("te", "ns1", "ep1", "p12"):  true,
+			makeServicePortName("te", "ns1", "ep1", "p122"): true,
+			makeServicePortName("te", "ns3", "ep3", "p33"):  true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{
-			makeNSN("ns4", "ep4"): 1,
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{
+			makeNSN("te", "ns4", "ep4"): 1,
 		},
 	}, {
 		// Case[15]: change from 0 endpoint address to 1 unnamed port
@@ -2446,15 +2446,15 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("te", "ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", ""): true,
+			makeServicePortName("te", "ns1", "ep1", ""): true,
 		},
-		expectedHealthchecks: map[types.NamespacedName]int{},
+		expectedHealthchecks: map[types.NamespacednameWithTenantSource]int{},
 	},
 	}
 

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -175,11 +175,12 @@ func makeServiceMap(proxier *Proxier, allServices ...*v1.Service) {
 	proxier.servicesSynced = true
 }
 
-func makeTestService(namespace, name string, svcFunc func(*v1.Service)) *v1.Service {
+func makeTestService(tenant, namespace, name string, svcFunc func(*v1.Service)) *v1.Service {
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
+			Tenant:      tenant,
 			Annotations: map[string]string{},
 		},
 		Spec:   v1.ServiceSpec{},
@@ -199,11 +200,12 @@ func makeEndpointsMap(proxier *Proxier, allEndpoints ...*v1.Endpoints) {
 	proxier.endpointsSynced = true
 }
 
-func makeTestEndpoints(namespace, name string, eptFunc func(*v1.Endpoints)) *v1.Endpoints {
+func makeTestEndpoints(tenant, namespace, name string, eptFunc func(*v1.Endpoints)) *v1.Endpoints {
 	ept := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Tenant:    tenant,
 		},
 	}
 	eptFunc(ept)
@@ -224,7 +226,7 @@ func TestCleanupLeftovers(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "NodePort"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
@@ -237,7 +239,7 @@ func TestCleanupLeftovers(t *testing.T) {
 	)
 	epIP := "10.180.0.1"
 	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
 					IP: epIP,
@@ -415,7 +417,7 @@ func TestNodePortUDP(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "NodePort"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
@@ -428,7 +430,7 @@ func TestNodePortUDP(t *testing.T) {
 	)
 	epIP := "10.180.0.1"
 	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
 					IP: epIP,
@@ -491,7 +493,7 @@ func TestNodePort(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "NodePort"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
@@ -506,7 +508,7 @@ func TestNodePort(t *testing.T) {
 	epIPv6 := "1002:ab8::2:10"
 	epIPs := sets.NewString(epIPv4, epIPv6)
 	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
 					IP: epIPv4,
@@ -569,7 +571,7 @@ func TestNodePortNoEndpoint(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "NodePort"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
@@ -623,7 +625,7 @@ func TestClusterIPNoEndpoint(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Namespace, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Namespace, func(svc *v1.Service) {
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:     svcPortName.Port,
@@ -673,7 +675,7 @@ func TestClusterIP(t *testing.T) {
 		Port:                           "p8080",
 	}
 	makeServiceMap(fp,
-		makeTestService(svcPortNameV4.Namespace, svcPortNameV4.Name, func(svc *v1.Service) {
+		makeTestService(svcPortNameV4.Tenant, svcPortNameV4.Namespace, svcPortNameV4.Name, func(svc *v1.Service) {
 			svc.Spec.ClusterIP = svcIPv4
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:     svcPortNameV4.Port,
@@ -681,7 +683,7 @@ func TestClusterIP(t *testing.T) {
 				Protocol: v1.ProtocolTCP,
 			}}
 		}),
-		makeTestService(svcPortNameV6.Namespace, svcPortNameV6.Name, func(svc *v1.Service) {
+		makeTestService(svcPortNameV6.Tenant, svcPortNameV6.Namespace, svcPortNameV6.Name, func(svc *v1.Service) {
 			svc.Spec.ClusterIP = svcIPv6
 			svc.Spec.Ports = []v1.ServicePort{{
 				Name:     svcPortNameV6.Port,
@@ -694,7 +696,7 @@ func TestClusterIP(t *testing.T) {
 	epIPv4 := "10.180.0.1"
 	epIPv6 := "1009:ab8::5:6"
 	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortNameV4.Namespace, svcPortNameV4.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortNameV4.Tenant, svcPortNameV4.Namespace, svcPortNameV4.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
 					IP: epIPv4,
@@ -705,7 +707,7 @@ func TestClusterIP(t *testing.T) {
 				}},
 			}}
 		}),
-		makeTestEndpoints(svcPortNameV6.Namespace, svcPortNameV6.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortNameV6.Tenant, svcPortNameV6.Namespace, svcPortNameV6.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
 					IP: epIPv6,
@@ -775,7 +777,7 @@ func TestExternalIPsNoEndpoint(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "ClusterIP"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.ExternalIPs = []string{svcExternalIPs}
@@ -830,7 +832,7 @@ func TestExternalIPs(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "ClusterIP"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.ExternalIPs = svcExternalIPs.UnsortedList()
@@ -845,7 +847,7 @@ func TestExternalIPs(t *testing.T) {
 
 	epIP := "10.180.0.1"
 	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
 					IP: epIP,
@@ -898,7 +900,7 @@ func TestLoadBalancer(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "LoadBalancer"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
@@ -915,7 +917,7 @@ func TestLoadBalancer(t *testing.T) {
 
 	epIP := "10.180.0.1"
 	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
 					IP: epIP,
@@ -974,7 +976,7 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "NodePort"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
@@ -993,7 +995,7 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 	otherHostname := "other-hostname"
 
 	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{
 				{ // **local** endpoint address, should be added as RS
 					Addresses: []v1.EndpointAddress{{
@@ -1074,7 +1076,7 @@ func TestLoadBalanceSourceRanges(t *testing.T) {
 	epIP := "10.180.0.1"
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "LoadBalancer"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
@@ -1091,7 +1093,7 @@ func TestLoadBalanceSourceRanges(t *testing.T) {
 		}),
 	)
 	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{{
 				Addresses: []v1.EndpointAddress{{
 					IP:       epIP,
@@ -1176,7 +1178,7 @@ func TestAcceptIPVSTraffic(t *testing.T) {
 
 	for _, svcInfo := range svcInfos {
 		makeServiceMap(fp,
-			makeTestService("ns1", svcInfo.svcName, func(svc *v1.Service) {
+			makeTestService("te", "ns1", svcInfo.svcName, func(svc *v1.Service) {
 				svc.Spec.Type = svcInfo.svcType
 				svc.Spec.ClusterIP = svcInfo.svcIP
 				svc.Spec.Ports = []v1.ServicePort{{
@@ -1197,7 +1199,7 @@ func TestAcceptIPVSTraffic(t *testing.T) {
 		)
 
 		makeEndpointsMap(fp,
-			makeTestEndpoints("ns1", "p80", func(ept *v1.Endpoints) {
+			makeTestEndpoints("te", "ns1", "p80", func(ept *v1.Endpoints) {
 				ept.Subsets = []v1.EndpointSubset{{
 					Addresses: []v1.EndpointAddress{{
 						IP: svcInfo.epIP,
@@ -1236,7 +1238,7 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 	}
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "LoadBalancer"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.Ports = []v1.ServicePort{{
@@ -1258,7 +1260,7 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 	otherHostname := "other-hostname"
 
 	makeEndpointsMap(fp,
-		makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
+		makeTestEndpoints(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(ept *v1.Endpoints) {
 			ept.Subsets = []v1.EndpointSubset{
 				{ // **local** endpoint address, should be added as RS
 					Addresses: []v1.EndpointAddress{{
@@ -1341,21 +1343,21 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	fp := NewFakeProxier(ipt, ipvs, ipset, nil, nil)
 
 	services := []*v1.Service{
-		makeTestService("somewhere-else", "cluster-ip", func(svc *v1.Service) {
+		makeTestService("te", "somewhere-else", "cluster-ip", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeClusterIP
 			svc.Spec.ClusterIP = "172.16.55.4"
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "something", "UDP", 1234, 4321, 0)
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "somethingelse", "UDP", 1235, 5321, 0)
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "somesctp", "SCTP", 1236, 6321, 0)
 		}),
-		makeTestService("somewhere-else", "node-port", func(svc *v1.Service) {
+		makeTestService("te", "somewhere-else", "node-port", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeNodePort
 			svc.Spec.ClusterIP = "172.16.55.10"
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "blahblah", "UDP", 345, 678, 0)
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "moreblahblah", "TCP", 344, 677, 0)
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "sctpblah", "SCTP", 343, 676, 0)
 		}),
-		makeTestService("somewhere", "load-balancer", func(svc *v1.Service) {
+		makeTestService("te", "somewhere", "load-balancer", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeLoadBalancer
 			svc.Spec.ClusterIP = "172.16.55.11"
 			svc.Spec.LoadBalancerIP = "5.6.7.8"
@@ -1368,7 +1370,7 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 				},
 			}
 		}),
-		makeTestService("somewhere", "only-local-load-balancer", func(svc *v1.Service) {
+		makeTestService("te", "somewhere", "only-local-load-balancer", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeLoadBalancer
 			svc.Spec.ClusterIP = "172.16.55.12"
 			svc.Spec.LoadBalancerIP = "5.6.7.8"
@@ -1410,7 +1412,7 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 
 	// Remove some stuff
 	// oneService is a modification of services[0] with removed first port.
-	oneService := makeTestService("somewhere-else", "cluster-ip", func(svc *v1.Service) {
+	oneService := makeTestService("te", "somewhere-else", "cluster-ip", func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		svc.Spec.ClusterIP = "172.16.55.4"
 		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "somethingelse", "UDP", 1235, 5321, 0)
@@ -1451,16 +1453,16 @@ func TestBuildServiceMapServiceHeadless(t *testing.T) {
 	fp := NewFakeProxier(ipt, ipvs, ipset, nil, nil)
 
 	makeServiceMap(fp,
-		makeTestService("somewhere-else", "headless", func(svc *v1.Service) {
+		makeTestService("te", "somewhere-else", "headless", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeClusterIP
 			svc.Spec.ClusterIP = v1.ClusterIPNone
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "rpc", "UDP", 1234, 0, 0)
 		}),
-		makeTestService("somewhere-else", "headless-without-port", func(svc *v1.Service) {
+		makeTestService("te", "somewhere-else", "headless-without-port", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeClusterIP
 			svc.Spec.ClusterIP = v1.ClusterIPNone
 		}),
-		makeTestService("somewhere-else", "headless-sctp", func(svc *v1.Service) {
+		makeTestService("te", "somewhere-else", "headless-sctp", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeClusterIP
 			svc.Spec.ClusterIP = v1.ClusterIPNone
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "sip", "SCTP", 1235, 0, 0)
@@ -1490,7 +1492,7 @@ func TestBuildServiceMapServiceTypeExternalName(t *testing.T) {
 	fp := NewFakeProxier(ipt, ipvs, ipset, nil, nil)
 
 	makeServiceMap(fp,
-		makeTestService("somewhere-else", "external-name", func(svc *v1.Service) {
+		makeTestService("te", "somewhere-else", "external-name", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeExternalName
 			svc.Spec.ClusterIP = "172.16.55.4" // Should be ignored
 			svc.Spec.ExternalName = "foo2.bar.com"
@@ -1517,13 +1519,13 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	ipset := ipsettest.NewFake(testIPSetVersion)
 	fp := NewFakeProxier(ipt, ipvs, ipset, nil, nil)
 
-	servicev1 := makeTestService("somewhere", "some-service", func(svc *v1.Service) {
+	servicev1 := makeTestService("te", "somewhere", "some-service", func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		svc.Spec.ClusterIP = "172.16.55.4"
 		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "something", "UDP", 1234, 4321, 0)
 		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "somethingelse", "TCP", 1235, 5321, 0)
 	})
-	servicev2 := makeTestService("somewhere", "some-service", func(svc *v1.Service) {
+	servicev2 := makeTestService("te", "somewhere", "some-service", func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeLoadBalancer
 		svc.Spec.ClusterIP = "172.16.55.4"
 		svc.Spec.LoadBalancerIP = "5.6.7.8"
@@ -1611,7 +1613,7 @@ func TestSessionAffinity(t *testing.T) {
 	timeoutSeconds := v1.DefaultClientIPServiceAffinitySeconds
 
 	makeServiceMap(fp,
-		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
+		makeTestService(svcPortName.Tenant, svcPortName.Namespace, svcPortName.Name, func(svc *v1.Service) {
 			svc.Spec.Type = "NodePort"
 			svc.Spec.ClusterIP = svcIP
 			svc.Spec.ExternalIPs = []string{svcExternalIPs}
@@ -1979,10 +1981,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[1]: no change, unnamed port
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", unnamedPort),
+			makeTestEndpoints("te", "ns1", "ep1", unnamedPort),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", unnamedPort),
+			makeTestEndpoints("te", "ns1", "ep1", unnamedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
 			makeServicePortName("te", "ns1", "ep1", ""): {
@@ -2000,10 +2002,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[2]: no change, named port, local
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPortLocal),
+			makeTestEndpoints("te", "ns1", "ep1", namedPortLocal),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPortLocal),
+			makeTestEndpoints("te", "ns1", "ep1", namedPortLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2023,10 +2025,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[3]: no change, multiple subsets
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsets),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsets),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsets),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsets),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2050,10 +2052,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[4]: no change, multiple subsets, multiple ports, local
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsetsMultiplePortsLocal),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsetsMultiplePortsLocal),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsetsMultiplePortsLocal),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsetsMultiplePortsLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2085,12 +2087,12 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[5]: no change, multiple endpoints, subsets, IPs, and ports
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsetsIPsPorts1),
-			makeTestEndpoints("ns2", "ep2", multipleSubsetsIPsPorts2),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsetsIPsPorts1),
+			makeTestEndpoints("te", "ns2", "ep2", multipleSubsetsIPsPorts2),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsetsIPsPorts1),
-			makeTestEndpoints("ns2", "ep2", multipleSubsetsIPsPorts2),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsetsIPsPorts1),
+			makeTestEndpoints("te", "ns2", "ep2", multipleSubsetsIPsPorts2),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2156,7 +2158,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 			nil,
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", unnamedPortLocal),
+			makeTestEndpoints("te", "ns1", "ep1", unnamedPortLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
@@ -2174,7 +2176,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[7]: remove an Endpoints
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", unnamedPortLocal),
+			makeTestEndpoints("te", "ns1", "ep1", unnamedPortLocal),
 		},
 		currentEndpoints: []*v1.Endpoints{
 			nil,
@@ -2194,10 +2196,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[8]: add an IP and port
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPort),
+			makeTestEndpoints("te", "ns1", "ep1", namedPort),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPortsLocalNoLocal),
+			makeTestEndpoints("te", "ns1", "ep1", namedPortsLocalNoLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2224,10 +2226,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[9]: remove an IP and port
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPortsLocalNoLocal),
+			makeTestEndpoints("te", "ns1", "ep1", namedPortsLocalNoLocal),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPort),
+			makeTestEndpoints("te", "ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2259,10 +2261,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[10]: add a subset
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPort),
+			makeTestEndpoints("te", "ns1", "ep1", namedPort),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsetsWithLocal),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsetsWithLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2287,10 +2289,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[11]: remove a subset
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", multipleSubsets),
+			makeTestEndpoints("te", "ns1", "ep1", multipleSubsets),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPort),
+			makeTestEndpoints("te", "ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2314,10 +2316,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[12]: rename a port
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPort),
+			makeTestEndpoints("te", "ns1", "ep1", namedPort),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPortRenamed),
+			makeTestEndpoints("te", "ns1", "ep1", namedPortRenamed),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2340,10 +2342,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[13]: renumber a port
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPort),
+			makeTestEndpoints("te", "ns1", "ep1", namedPort),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", namedPortRenumbered),
+			makeTestEndpoints("te", "ns1", "ep1", namedPortRenumbered),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2364,16 +2366,16 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[14]: complex add and remove
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", complexBefore1),
-			makeTestEndpoints("ns2", "ep2", complexBefore2),
+			makeTestEndpoints("te", "ns1", "ep1", complexBefore1),
+			makeTestEndpoints("te", "ns2", "ep2", complexBefore2),
 			nil,
-			makeTestEndpoints("ns4", "ep4", complexBefore4),
+			makeTestEndpoints("te", "ns4", "ep4", complexBefore4),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", complexAfter1),
+			makeTestEndpoints("te", "ns1", "ep1", complexAfter1),
 			nil,
-			makeTestEndpoints("ns3", "ep3", complexAfter3),
-			makeTestEndpoints("ns4", "ep4", complexAfter4),
+			makeTestEndpoints("te", "ns3", "ep3", complexAfter3),
+			makeTestEndpoints("te", "ns4", "ep4", complexAfter4),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
 			makeServicePortName("te", "ns1", "ep1", "p11"): {
@@ -2439,10 +2441,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}, {
 		// Case[15]: change from 0 endpoint address to 1 unnamed port
 		previousEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", emptyEndpoint),
+			makeTestEndpoints("te", "ns1", "ep1", emptyEndpoint),
 		},
 		currentEndpoints: []*v1.Endpoints{
-			makeTestEndpoints("ns1", "ep1", unnamedPort),
+			makeTestEndpoints("te", "ns1", "ep1", unnamedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
@@ -3079,18 +3081,18 @@ func TestMultiPortServiceBindAddr(t *testing.T) {
 	ipset := ipsettest.NewFake(testIPSetVersion)
 	fp := NewFakeProxier(ipt, ipvs, ipset, nil, nil)
 
-	service1 := makeTestService("ns1", "svc1", func(svc *v1.Service) {
+	service1 := makeTestService("te", "ns1", "svc1", func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		svc.Spec.ClusterIP = "172.16.55.4"
 		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "port1", "TCP", 1234, 0, 0)
 		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "port2", "TCP", 1235, 0, 0)
 	})
-	service2 := makeTestService("ns1", "svc1", func(svc *v1.Service) {
+	service2 := makeTestService("te", "ns1", "svc1", func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		svc.Spec.ClusterIP = "172.16.55.4"
 		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "port1", "TCP", 1234, 0, 0)
 	})
-	service3 := makeTestService("ns1", "svc1", func(svc *v1.Service) {
+	service3 := makeTestService("te", "ns1", "svc1", func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		svc.Spec.ClusterIP = "172.16.55.4"
 		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "port1", "TCP", 1234, 0, 0)

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -72,14 +72,14 @@ func addTestPort(array []v1.ServicePort, name string, protocol v1.Protocol, port
 	return append(array, svcPort)
 }
 
-func makeNSN(namespace, name string) types.NamespacedName {
-	return types.NamespacedName{Namespace: namespace, Name: name}
+func makeNSN(tenant, namespace, name string) types.NamespacednameWithTenantSource {
+	return types.NamespacednameWithTenantSource{TenantPartitionId: tpId, Tenant: tenant, Namespace: namespace, Name: name}
 }
 
-func makeServicePortName(ns, name, port string) ServicePortName {
+func makeServicePortName(te, ns, name, port string) ServicePortName {
 	return ServicePortName{
-		NamespacedName: makeNSN(ns, name),
-		Port:           port,
+		NamespacednameWithTenantSource: makeNSN(te, ns, name),
+		Port:                           port,
 	}
 }
 
@@ -141,8 +141,8 @@ func TestServiceToServiceMap(t *testing.T) {
 				svc.Spec.Ports = addTestPort(svc.Spec.Ports, "p2", "UDP", 1235, 5321, 0)
 			}),
 			expected: map[ServicePortName]*BaseServiceInfo{
-				makeServicePortName("ns2", "cluster-ip", "p1"): makeTestServiceInfo("172.16.55.4", 1234, "UDP", 0),
-				makeServicePortName("ns2", "cluster-ip", "p2"): makeTestServiceInfo("172.16.55.4", 1235, "UDP", 0),
+				makeServicePortName("te", "ns2", "cluster-ip", "p1"): makeTestServiceInfo("172.16.55.4", 1234, "UDP", 0),
+				makeServicePortName("te", "ns2", "cluster-ip", "p2"): makeTestServiceInfo("172.16.55.4", 1235, "UDP", 0),
 			},
 		},
 		{
@@ -154,8 +154,8 @@ func TestServiceToServiceMap(t *testing.T) {
 				svc.Spec.Ports = addTestPort(svc.Spec.Ports, "port2", "TCP", 344, 677, 0)
 			}),
 			expected: map[ServicePortName]*BaseServiceInfo{
-				makeServicePortName("ns2", "node-port", "port1"): makeTestServiceInfo("172.16.55.10", 345, "UDP", 0),
-				makeServicePortName("ns2", "node-port", "port2"): makeTestServiceInfo("172.16.55.10", 344, "TCP", 0),
+				makeServicePortName("te", "ns2", "node-port", "port1"): makeTestServiceInfo("172.16.55.10", 345, "UDP", 0),
+				makeServicePortName("te", "ns2", "node-port", "port2"): makeTestServiceInfo("172.16.55.10", 344, "TCP", 0),
 			},
 		},
 		{
@@ -173,8 +173,8 @@ func TestServiceToServiceMap(t *testing.T) {
 				}
 			}),
 			expected: map[ServicePortName]*BaseServiceInfo{
-				makeServicePortName("ns1", "load-balancer", "port3"): makeTestServiceInfo("172.16.55.11", 8675, "UDP", 0),
-				makeServicePortName("ns1", "load-balancer", "port4"): makeTestServiceInfo("172.16.55.11", 8676, "UDP", 0),
+				makeServicePortName("te", "ns1", "load-balancer", "port3"): makeTestServiceInfo("172.16.55.11", 8675, "UDP", 0),
+				makeServicePortName("te", "ns1", "load-balancer", "port4"): makeTestServiceInfo("172.16.55.11", 8676, "UDP", 0),
 			},
 		},
 		{
@@ -194,8 +194,8 @@ func TestServiceToServiceMap(t *testing.T) {
 				svc.Spec.HealthCheckNodePort = 345
 			}),
 			expected: map[ServicePortName]*BaseServiceInfo{
-				makeServicePortName("ns1", "only-local-load-balancer", "portx"): makeTestServiceInfo("172.16.55.12", 8677, "UDP", 345),
-				makeServicePortName("ns1", "only-local-load-balancer", "porty"): makeTestServiceInfo("172.16.55.12", 8678, "UDP", 345),
+				makeServicePortName("te", "ns1", "only-local-load-balancer", "portx"): makeTestServiceInfo("172.16.55.12", 8677, "UDP", 345),
+				makeServicePortName("te", "ns1", "only-local-load-balancer", "porty"): makeTestServiceInfo("172.16.55.12", 8678, "UDP", 345),
 			},
 		},
 		{
@@ -269,7 +269,7 @@ func TestServiceToServiceMap(t *testing.T) {
 				},
 			},
 			expected: map[ServicePortName]*BaseServiceInfo{
-				makeServicePortName("test", "validIPv4", "testPort"): makeTestServiceInfo(testClusterIPv4, 12345, "TCP", 0, func(info *BaseServiceInfo) {
+				makeServicePortName("te", "test", "validIPv4", "testPort"): makeTestServiceInfo(testClusterIPv4, 12345, "TCP", 0, func(info *BaseServiceInfo) {
 					info.externalIPs = []string{testExternalIPv4}
 					info.loadBalancerSourceRanges = []string{testSourceRangeIPv4}
 				}),
@@ -297,7 +297,7 @@ func TestServiceToServiceMap(t *testing.T) {
 				},
 			},
 			expected: map[ServicePortName]*BaseServiceInfo{
-				makeServicePortName("test", "validIPv6", "testPort"): makeTestServiceInfo(testClusterIPv6, 12345, "TCP", 0, func(info *BaseServiceInfo) {
+				makeServicePortName("te", "test", "validIPv6", "testPort"): makeTestServiceInfo(testClusterIPv6, 12345, "TCP", 0, func(info *BaseServiceInfo) {
 					info.externalIPs = []string{testExternalIPv6}
 					info.loadBalancerSourceRanges = []string{testSourceRangeIPv6}
 				}),
@@ -325,7 +325,7 @@ func TestServiceToServiceMap(t *testing.T) {
 				},
 			},
 			expected: map[ServicePortName]*BaseServiceInfo{
-				makeServicePortName("test", "filterIPv6InIPV4Mode", "testPort"): makeTestServiceInfo(testClusterIPv4, 12345, "TCP", 0, func(info *BaseServiceInfo) {
+				makeServicePortName("te", "test", "filterIPv6InIPV4Mode", "testPort"): makeTestServiceInfo(testClusterIPv4, 12345, "TCP", 0, func(info *BaseServiceInfo) {
 					info.externalIPs = []string{testExternalIPv4}
 					info.loadBalancerSourceRanges = []string{testSourceRangeIPv4}
 				}),
@@ -353,7 +353,7 @@ func TestServiceToServiceMap(t *testing.T) {
 				},
 			},
 			expected: map[ServicePortName]*BaseServiceInfo{
-				makeServicePortName("test", "filterIPv4InIPV6Mode", "testPort"): makeTestServiceInfo(testClusterIPv6, 12345, "TCP", 0, func(info *BaseServiceInfo) {
+				makeServicePortName("te", "test", "filterIPv4InIPV6Mode", "testPort"): makeTestServiceInfo(testClusterIPv6, 12345, "TCP", 0, func(info *BaseServiceInfo) {
 					info.externalIPs = []string{testExternalIPv6}
 					info.loadBalancerSourceRanges = []string{testSourceRangeIPv6}
 				}),
@@ -533,7 +533,7 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	if len(result.HCServiceNodePorts) != 1 {
 		t.Errorf("expected 1 healthcheck port, got %v", result.HCServiceNodePorts)
 	} else {
-		nsn := makeNSN("ns1", "only-local-load-balancer")
+		nsn := makeNSN("te", "ns1", "only-local-load-balancer")
 		if port, found := result.HCServiceNodePorts[nsn]; !found || port != 345 {
 			t.Errorf("expected healthcheck port [%q]=345: got %v", nsn, result.HCServiceNodePorts)
 		}

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -47,11 +47,12 @@ func makeTestServiceInfo(clusterIP string, port int, protocol string, healthchec
 	return info
 }
 
-func makeTestService(namespace, name string, svcFunc func(*v1.Service)) *v1.Service {
+func makeTestService(tenant, namespace, name string, svcFunc func(*v1.Service)) *v1.Service {
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
+			Tenant:      tenant,
 			Annotations: map[string]string{},
 		},
 		Spec:   v1.ServiceSpec{},
@@ -108,7 +109,7 @@ func TestServiceToServiceMap(t *testing.T) {
 		},
 		{
 			desc: "headless service",
-			service: makeTestService("ns2", "headless", func(svc *v1.Service) {
+			service: makeTestService("te", "ns2", "headless", func(svc *v1.Service) {
 				svc.Spec.Type = v1.ServiceTypeClusterIP
 				svc.Spec.ClusterIP = v1.ClusterIPNone
 				svc.Spec.Ports = addTestPort(svc.Spec.Ports, "rpc", "UDP", 1234, 0, 0)
@@ -117,7 +118,7 @@ func TestServiceToServiceMap(t *testing.T) {
 		},
 		{
 			desc: "headless sctp service",
-			service: makeTestService("ns2", "headless", func(svc *v1.Service) {
+			service: makeTestService("te", "ns2", "headless", func(svc *v1.Service) {
 				svc.Spec.Type = v1.ServiceTypeClusterIP
 				svc.Spec.ClusterIP = v1.ClusterIPNone
 				svc.Spec.Ports = addTestPort(svc.Spec.Ports, "sip", "SCTP", 7777, 0, 0)
@@ -126,7 +127,7 @@ func TestServiceToServiceMap(t *testing.T) {
 		},
 		{
 			desc: "headless service without port",
-			service: makeTestService("ns2", "headless-without-port", func(svc *v1.Service) {
+			service: makeTestService("te", "ns2", "headless-without-port", func(svc *v1.Service) {
 				svc.Spec.Type = v1.ServiceTypeClusterIP
 				svc.Spec.ClusterIP = v1.ClusterIPNone
 			}),
@@ -134,7 +135,7 @@ func TestServiceToServiceMap(t *testing.T) {
 		},
 		{
 			desc: "cluster ip service",
-			service: makeTestService("ns2", "cluster-ip", func(svc *v1.Service) {
+			service: makeTestService("te", "ns2", "cluster-ip", func(svc *v1.Service) {
 				svc.Spec.Type = v1.ServiceTypeClusterIP
 				svc.Spec.ClusterIP = "172.16.55.4"
 				svc.Spec.Ports = addTestPort(svc.Spec.Ports, "p1", "UDP", 1234, 4321, 0)
@@ -147,7 +148,7 @@ func TestServiceToServiceMap(t *testing.T) {
 		},
 		{
 			desc: "nodeport service",
-			service: makeTestService("ns2", "node-port", func(svc *v1.Service) {
+			service: makeTestService("te", "ns2", "node-port", func(svc *v1.Service) {
 				svc.Spec.Type = v1.ServiceTypeNodePort
 				svc.Spec.ClusterIP = "172.16.55.10"
 				svc.Spec.Ports = addTestPort(svc.Spec.Ports, "port1", "UDP", 345, 678, 0)
@@ -160,7 +161,7 @@ func TestServiceToServiceMap(t *testing.T) {
 		},
 		{
 			desc: "load balancer service",
-			service: makeTestService("ns1", "load-balancer", func(svc *v1.Service) {
+			service: makeTestService("te", "ns1", "load-balancer", func(svc *v1.Service) {
 				svc.Spec.Type = v1.ServiceTypeLoadBalancer
 				svc.Spec.ClusterIP = "172.16.55.11"
 				svc.Spec.LoadBalancerIP = "5.6.7.8"
@@ -179,7 +180,7 @@ func TestServiceToServiceMap(t *testing.T) {
 		},
 		{
 			desc: "load balancer service with only local traffic policy",
-			service: makeTestService("ns1", "only-local-load-balancer", func(svc *v1.Service) {
+			service: makeTestService("te", "ns1", "only-local-load-balancer", func(svc *v1.Service) {
 				svc.Spec.Type = v1.ServiceTypeLoadBalancer
 				svc.Spec.ClusterIP = "172.16.55.12"
 				svc.Spec.LoadBalancerIP = "5.6.7.8"
@@ -200,7 +201,7 @@ func TestServiceToServiceMap(t *testing.T) {
 		},
 		{
 			desc: "external name service",
-			service: makeTestService("ns2", "external-name", func(svc *v1.Service) {
+			service: makeTestService("te", "ns2", "external-name", func(svc *v1.Service) {
 				svc.Spec.Type = v1.ServiceTypeExternalName
 				svc.Spec.ClusterIP = "172.16.55.4" // Should be ignored
 				svc.Spec.ExternalName = "foo2.bar.com"
@@ -214,6 +215,7 @@ func TestServiceToServiceMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "invalidIPv6InIPV4Mode",
 					Namespace: "test",
+					Tenant:    "te",
 				},
 				Spec: v1.ServiceSpec{
 					ClusterIP: testClusterIPv6,
@@ -234,6 +236,7 @@ func TestServiceToServiceMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "invalidIPv4InIPV6Mode",
 					Namespace: "test",
+					Tenant:    "te",
 				},
 				Spec: v1.ServiceSpec{
 					ClusterIP: testClusterIPv4,
@@ -254,6 +257,7 @@ func TestServiceToServiceMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "validIPv4",
 					Namespace: "test",
+					Tenant:    "te",
 				},
 				Spec: v1.ServiceSpec{
 					ClusterIP:                testClusterIPv4,
@@ -282,6 +286,7 @@ func TestServiceToServiceMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "validIPv6",
 					Namespace: "test",
+					Tenant:    "te",
 				},
 				Spec: v1.ServiceSpec{
 					ClusterIP:                testClusterIPv6,
@@ -310,6 +315,7 @@ func TestServiceToServiceMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "filterIPv6InIPV4Mode",
 					Namespace: "test",
+					Tenant:    "te",
 				},
 				Spec: v1.ServiceSpec{
 					ClusterIP:                testClusterIPv4,
@@ -338,6 +344,7 @@ func TestServiceToServiceMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "filterIPv4InIPV6Mode",
 					Namespace: "test",
+					Tenant:    "te",
 				},
 				Spec: v1.ServiceSpec{
 					ClusterIP:                testClusterIPv6,
@@ -424,12 +431,12 @@ func TestUpdateServiceMapHeadless(t *testing.T) {
 
 	makeServiceMap(fp,
 		tpId,
-		makeTestService("ns2", "headless", func(svc *v1.Service) {
+		makeTestService("te", "ns2", "headless", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeClusterIP
 			svc.Spec.ClusterIP = v1.ClusterIPNone
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "rpc", "UDP", 1234, 0, 0)
 		}),
-		makeTestService("ns2", "headless-without-port", func(svc *v1.Service) {
+		makeTestService("te", "ns2", "headless-without-port", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeClusterIP
 			svc.Spec.ClusterIP = v1.ClusterIPNone
 		}),
@@ -456,7 +463,7 @@ func TestUpdateServiceTypeExternalName(t *testing.T) {
 
 	makeServiceMap(fp,
 		tpId,
-		makeTestService("ns2", "external-name", func(svc *v1.Service) {
+		makeTestService("te", "ns2", "external-name", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeExternalName
 			svc.Spec.ClusterIP = "172.16.55.4" // Should be ignored
 			svc.Spec.ExternalName = "foo2.bar.com"
@@ -481,19 +488,19 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	fp := newFakeProxier()
 
 	services := []*v1.Service{
-		makeTestService("ns2", "cluster-ip", func(svc *v1.Service) {
+		makeTestService("te", "ns2", "cluster-ip", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeClusterIP
 			svc.Spec.ClusterIP = "172.16.55.4"
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "port1", "UDP", 1234, 4321, 0)
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "port2", "UDP", 1235, 5321, 0)
 		}),
-		makeTestService("ns2", "node-port", func(svc *v1.Service) {
+		makeTestService("te", "ns2", "node-port", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeNodePort
 			svc.Spec.ClusterIP = "172.16.55.10"
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "port1", "UDP", 345, 678, 0)
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "port2", "TCP", 344, 677, 0)
 		}),
-		makeTestService("ns1", "load-balancer", func(svc *v1.Service) {
+		makeTestService("te", "ns1", "load-balancer", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeLoadBalancer
 			svc.Spec.ClusterIP = "172.16.55.11"
 			svc.Spec.LoadBalancerIP = "5.6.7.8"
@@ -505,7 +512,7 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 				},
 			}
 		}),
-		makeTestService("ns1", "only-local-load-balancer", func(svc *v1.Service) {
+		makeTestService("te", "ns1", "only-local-load-balancer", func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeLoadBalancer
 			svc.Spec.ClusterIP = "172.16.55.12"
 			svc.Spec.LoadBalancerIP = "5.6.7.8"
@@ -546,7 +553,7 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 
 	// Remove some stuff
 	// oneService is a modification of services[0] with removed first port.
-	oneService := makeTestService("ns2", "cluster-ip", func(svc *v1.Service) {
+	oneService := makeTestService("te", "ns2", "cluster-ip", func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		svc.Spec.ClusterIP = "172.16.55.4"
 		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "p2", "UDP", 1235, 5321, 0)
@@ -583,13 +590,13 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	fp := newFakeProxier()
 
-	servicev1 := makeTestService("ns1", "svc1", func(svc *v1.Service) {
+	servicev1 := makeTestService("te", "ns1", "svc1", func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeClusterIP
 		svc.Spec.ClusterIP = "172.16.55.4"
 		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "p1", "UDP", 1234, 4321, 0)
 		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "p2", "TCP", 1235, 5321, 0)
 	})
-	servicev2 := makeTestService("ns1", "svc1", func(svc *v1.Service) {
+	servicev2 := makeTestService("te", "ns1", "svc1", func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeLoadBalancer
 		svc.Spec.ClusterIP = "172.16.55.4"
 		svc.Spec.LoadBalancerIP = "5.6.7.8"

--- a/pkg/proxy/types.go
+++ b/pkg/proxy/types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2015 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,12 +42,12 @@ type ProxyProvider interface {
 // ServicePortName carries a namespace + name + portname.  This is the unique
 // identifier for a load-balanced service.
 type ServicePortName struct {
-	types.NamespacedName
+	types.NamespacednameWithTenantSource
 	Port string
 }
 
 func (spn ServicePortName) String() string {
-	return fmt.Sprintf("%s:%s", spn.NamespacedName.String(), spn.Port)
+	return fmt.Sprintf("%s_%d/%s/%s:%s", spn.Tenant, spn.TenantPartitionId, spn.Namespace, spn.Name, spn.Port)
 }
 
 // ServicePort is an interface which abstracts information about a service.

--- a/pkg/proxy/userspace/proxier_test.go
+++ b/pkg/proxy/userspace/proxier_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/proxy/userspace/proxier_test.go
+++ b/pkg/proxy/userspace/proxier_test.go
@@ -242,20 +242,20 @@ func startProxier(p *Proxier, t *testing.T) {
 		p.SyncLoop()
 	}()
 	waitForNumProxyLoops(t, p, 0)
-	p.OnServiceSynced()
-	p.OnEndpointsSynced()
+	p.OnServiceSynced(tpId)
+	p.OnEndpointsSynced(tpId)
 }
 
 func TestTCPProxy(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	fexec := makeFakeExec()
 
@@ -276,14 +276,14 @@ func TestTCPProxy(t *testing.T) {
 
 func TestUDPProxy(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: udpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	fexec := makeFakeExec()
 
@@ -304,14 +304,14 @@ func TestUDPProxy(t *testing.T) {
 
 func TestUDPProxyTimeout(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: udpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	fexec := makeFakeExec()
 
@@ -336,22 +336,22 @@ func TestUDPProxyTimeout(t *testing.T) {
 
 func TestMultiPortProxy(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	serviceP := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo-p"}, Port: "p"}
-	serviceQ := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo-q"}, Port: "q"}
+	serviceP := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo-p"}, Port: "p"}
+	serviceQ := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo-q"}, Port: "q"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceP.Name, Namespace: serviceP.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Protocol: "TCP", Port: tcpServerPort}},
 		}},
-	})
+	}, tpId)
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceQ.Name, Namespace: serviceQ.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "q", Protocol: "UDP", Port: udpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	fexec := makeFakeExec()
 
@@ -379,9 +379,9 @@ func TestMultiPortProxy(t *testing.T) {
 
 func TestMultiPortOnServiceAdd(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	serviceP := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
-	serviceQ := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "q"}
-	serviceX := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "x"}
+	serviceP := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	serviceQ := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "q"}
+	serviceX := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "x"}
 
 	fexec := makeFakeExec()
 
@@ -403,7 +403,7 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 			Port:     81,
 			Protocol: "UDP",
 		}}},
-	})
+	}, tpId)
 	waitForNumProxyLoops(t, p, 2)
 	svcInfo, exists := waitForServiceInfo(p, serviceP)
 	if !exists {
@@ -440,14 +440,14 @@ func stopProxyByName(proxier *Proxier, service proxy.ServicePortName) error {
 
 func TestTCPProxyStop(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Namespace: service.Namespace, Name: service.Name},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	fexec := makeFakeExec()
 
@@ -485,14 +485,14 @@ func TestTCPProxyStop(t *testing.T) {
 
 func TestUDPProxyStop(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Namespace: service.Namespace, Name: service.Name},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: udpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	fexec := makeFakeExec()
 
@@ -524,14 +524,14 @@ func TestUDPProxyStop(t *testing.T) {
 
 func TestTCPProxyUpdateDelete(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	servicePortName := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	servicePortName := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Namespace: servicePortName.Namespace, Name: servicePortName.Name},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	fexec := makeFakeExec()
 
@@ -551,9 +551,9 @@ func TestTCPProxyUpdateDelete(t *testing.T) {
 		}}},
 	}
 
-	p.OnServiceAdd(service)
+	p.OnServiceAdd(service, tpId)
 	waitForNumProxyLoops(t, p, 1)
-	p.OnServiceDelete(service)
+	p.OnServiceDelete(service, tpId)
 	if err := waitForClosedPortTCP(p, int(service.Spec.Ports[0].Port)); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -562,14 +562,14 @@ func TestTCPProxyUpdateDelete(t *testing.T) {
 
 func TestUDPProxyUpdateDelete(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Namespace: service.Namespace, Name: service.Name},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: udpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	fexec := makeFakeExec()
 
@@ -598,7 +598,7 @@ func TestUDPProxyUpdateDelete(t *testing.T) {
 			Port:     int32(svcInfo.proxyPort),
 			Protocol: "UDP",
 		}}},
-	})
+	}, tpId)
 	if err := waitForClosedPortUDP(p, svcInfo.proxyPort); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -607,7 +607,7 @@ func TestUDPProxyUpdateDelete(t *testing.T) {
 
 func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	endpoint := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
@@ -615,7 +615,7 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
 		}},
 	}
-	lb.OnEndpointsAdd(endpoint)
+	lb.OnEndpointsAdd(endpoint, tpId)
 
 	fexec := makeFakeExec()
 
@@ -644,14 +644,14 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 			Port:     int32(svcInfo.proxyPort),
 			Protocol: "TCP",
 		}}},
-	})
+	}, tpId)
 	if err := waitForClosedPortTCP(p, svcInfo.proxyPort); err != nil {
 		t.Fatalf(err.Error())
 	}
 	waitForNumProxyLoops(t, p, 0)
 
 	// need to add endpoint here because it got clean up during service delete
-	lb.OnEndpointsAdd(endpoint)
+	lb.OnEndpointsAdd(endpoint, tpId)
 	p.OnServiceAdd(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Spec: v1.ServiceSpec{ClusterIP: "1.2.3.4", Ports: []v1.ServicePort{{
@@ -659,7 +659,7 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 			Port:     int32(svcInfo.proxyPort),
 			Protocol: "TCP",
 		}}},
-	})
+	}, tpId)
 	svcInfo, exists := waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("can't find serviceInfo for %s", service)
@@ -670,7 +670,7 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 
 func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	endpoint := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
@@ -678,7 +678,7 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 			Ports:     []v1.EndpointPort{{Name: "p", Port: udpServerPort}},
 		}},
 	}
-	lb.OnEndpointsAdd(endpoint)
+	lb.OnEndpointsAdd(endpoint, tpId)
 
 	fexec := makeFakeExec()
 
@@ -707,14 +707,14 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 			Port:     int32(svcInfo.proxyPort),
 			Protocol: "UDP",
 		}}},
-	})
+	}, tpId)
 	if err := waitForClosedPortUDP(p, svcInfo.proxyPort); err != nil {
 		t.Fatalf(err.Error())
 	}
 	waitForNumProxyLoops(t, p, 0)
 
 	// need to add endpoint here because it got clean up during service delete
-	lb.OnEndpointsAdd(endpoint)
+	lb.OnEndpointsAdd(endpoint, tpId)
 	p.OnServiceAdd(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Spec: v1.ServiceSpec{ClusterIP: "1.2.3.4", Ports: []v1.ServicePort{{
@@ -722,7 +722,7 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 			Port:     int32(svcInfo.proxyPort),
 			Protocol: "UDP",
 		}}},
-	})
+	}, tpId)
 	svcInfo, exists := waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("can't find serviceInfo")
@@ -733,14 +733,14 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 
 func TestTCPProxyUpdatePort(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	fexec := makeFakeExec()
 
@@ -765,7 +765,7 @@ func TestTCPProxyUpdatePort(t *testing.T) {
 			Port:     99,
 			Protocol: "TCP",
 		}}},
-	})
+	}, tpId)
 	// Wait for the socket to actually get free.
 	if err := waitForClosedPortTCP(p, svcInfo.proxyPort); err != nil {
 		t.Fatalf(err.Error())
@@ -782,14 +782,14 @@ func TestTCPProxyUpdatePort(t *testing.T) {
 
 func TestUDPProxyUpdatePort(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: udpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	fexec := makeFakeExec()
 
@@ -813,7 +813,7 @@ func TestUDPProxyUpdatePort(t *testing.T) {
 			Port:     99,
 			Protocol: "UDP",
 		}}},
-	})
+	}, tpId)
 	// Wait for the socket to actually get free.
 	if err := waitForClosedPortUDP(p, svcInfo.proxyPort); err != nil {
 		t.Fatalf(err.Error())
@@ -828,14 +828,14 @@ func TestUDPProxyUpdatePort(t *testing.T) {
 
 func TestProxyUpdatePublicIPs(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	fexec := makeFakeExec()
 
@@ -864,7 +864,7 @@ func TestProxyUpdatePublicIPs(t *testing.T) {
 			ClusterIP:   svcInfo.portal.ip.String(),
 			ExternalIPs: []string{"4.3.2.1"},
 		},
-	})
+	}, tpId)
 	// Wait for the socket to actually get free.
 	if err := waitForClosedPortTCP(p, svcInfo.proxyPort); err != nil {
 		t.Fatalf(err.Error())
@@ -881,7 +881,7 @@ func TestProxyUpdatePublicIPs(t *testing.T) {
 
 func TestProxyUpdatePortal(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	endpoint := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
@@ -889,7 +889,7 @@ func TestProxyUpdatePortal(t *testing.T) {
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
 		}},
 	}
-	lb.OnEndpointsAdd(endpoint)
+	lb.OnEndpointsAdd(endpoint, tpId)
 
 	fexec := makeFakeExec()
 
@@ -924,7 +924,7 @@ func TestProxyUpdatePortal(t *testing.T) {
 			Protocol: "TCP",
 		}}},
 	}
-	p.OnServiceUpdate(svcv0, svcv1)
+	p.OnServiceUpdate(svcv0, svcv1, tpId)
 
 	// Wait for the service to be removed because it had an empty ClusterIP
 	var exists bool
@@ -947,7 +947,7 @@ func TestProxyUpdatePortal(t *testing.T) {
 			Protocol: "TCP",
 		}}},
 	}
-	p.OnServiceUpdate(svcv1, svcv2)
+	p.OnServiceUpdate(svcv1, svcv2, tpId)
 	_, exists = p.getServiceInfo(service)
 	if exists {
 		t.Fatalf("service with 'None' as ClusterIP should not be included in the proxy")
@@ -961,8 +961,8 @@ func TestProxyUpdatePortal(t *testing.T) {
 			Protocol: "TCP",
 		}}},
 	}
-	p.OnServiceUpdate(svcv2, svcv3)
-	lb.OnEndpointsAdd(endpoint)
+	p.OnServiceUpdate(svcv2, svcv3, tpId)
+	lb.OnEndpointsAdd(endpoint, tpId)
 	svcInfo, exists = waitForServiceInfo(p, service)
 	if !exists {
 		t.Fatalf("service with ClusterIP set not found in the proxy")
@@ -1106,7 +1106,7 @@ func TestOnServiceAddChangeMap(t *testing.T) {
 
 	for _, test := range tests {
 		for _, change := range test.changes {
-			p.serviceChange(change.previous, change.current, test.detail)
+			p.serviceChange(change.previous, change.current, test.detail, tpId)
 		}
 
 		if test.expectedChange != nil {
@@ -1117,7 +1117,7 @@ func TestOnServiceAddChangeMap(t *testing.T) {
 			if expectedService == nil {
 				expectedService = test.expectedChange.previous
 			}
-			svcName := types.NamespacedName{Namespace: expectedService.Namespace, Name: expectedService.Name}
+			svcName := types.NamespacednameWithTenantSource{Namespace: expectedService.Namespace, Name: expectedService.Name}
 
 			change, ok := p.serviceChanges[svcName]
 			if !ok {

--- a/pkg/proxy/userspace/roundrobin.go
+++ b/pkg/proxy/userspace/roundrobin.go
@@ -262,14 +262,15 @@ func buildPortsToEndpointsMap(endpoints *v1.Endpoints) map[string][]hostPortPair
 	return portsToEndpoints
 }
 
-func (lb *LoadBalancerRR) OnEndpointsAdd(endpoints *v1.Endpoints) {
+func (lb *LoadBalancerRR) OnEndpointsAdd(endpoints *v1.Endpoints, tenantPartitionId int) {
 	portsToEndpoints := buildPortsToEndpointsMap(endpoints)
 
 	lb.lock.Lock()
 	defer lb.lock.Unlock()
 
 	for portname := range portsToEndpoints {
-		svcPort := proxy.ServicePortName{NamespacedName: types.NamespacedName{Tenant: endpoints.Tenant, Namespace: endpoints.Namespace, Name: endpoints.Name}, Port: portname}
+		svcPort := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{
+			TenantPartitionId: tenantPartitionId, Tenant: endpoints.Tenant, Namespace: endpoints.Namespace, Name: endpoints.Name}, Port: portname}
 		newEndpoints := flattenValidEndpoints(portsToEndpoints[portname])
 		state, exists := lb.services[svcPort]
 
@@ -289,7 +290,7 @@ func (lb *LoadBalancerRR) OnEndpointsAdd(endpoints *v1.Endpoints) {
 	}
 }
 
-func (lb *LoadBalancerRR) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoints) {
+func (lb *LoadBalancerRR) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoints, tenantPartitionId int) {
 	portsToEndpoints := buildPortsToEndpointsMap(endpoints)
 	oldPortsToEndpoints := buildPortsToEndpointsMap(oldEndpoints)
 	registeredEndpoints := make(map[proxy.ServicePortName]bool)
@@ -298,7 +299,9 @@ func (lb *LoadBalancerRR) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoint
 	defer lb.lock.Unlock()
 
 	for portname := range portsToEndpoints {
-		svcPort := proxy.ServicePortName{NamespacedName: types.NamespacedName{Tenant: endpoints.Tenant, Namespace: endpoints.Namespace, Name: endpoints.Name}, Port: portname}
+		svcPort := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{
+			Tenant: endpoints.Tenant, TenantPartitionId: tenantPartitionId, Namespace: endpoints.Namespace, Name: endpoints.Name},
+			Port: portname}
 		newEndpoints := flattenValidEndpoints(portsToEndpoints[portname])
 		state, exists := lb.services[svcPort]
 
@@ -325,7 +328,9 @@ func (lb *LoadBalancerRR) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoint
 
 	// Now remove all endpoints missing from the update.
 	for portname := range oldPortsToEndpoints {
-		svcPort := proxy.ServicePortName{NamespacedName: types.NamespacedName{Tenant: oldEndpoints.Tenant, Namespace: oldEndpoints.Namespace, Name: oldEndpoints.Name}, Port: portname}
+		svcPort := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{
+			Tenant: oldEndpoints.Tenant, TenantPartitionId: tenantPartitionId, Namespace: oldEndpoints.Namespace, Name: oldEndpoints.Name},
+			Port: portname}
 		if _, exists := registeredEndpoints[svcPort]; !exists {
 			lb.resetService(svcPort)
 		}
@@ -344,19 +349,21 @@ func (lb *LoadBalancerRR) resetService(svcPort proxy.ServicePortName) {
 	}
 }
 
-func (lb *LoadBalancerRR) OnEndpointsDelete(endpoints *v1.Endpoints) {
+func (lb *LoadBalancerRR) OnEndpointsDelete(endpoints *v1.Endpoints, tenantPartitionId int) {
 	portsToEndpoints := buildPortsToEndpointsMap(endpoints)
 
 	lb.lock.Lock()
 	defer lb.lock.Unlock()
 
 	for portname := range portsToEndpoints {
-		svcPort := proxy.ServicePortName{NamespacedName: types.NamespacedName{Tenant: endpoints.Tenant, Namespace: endpoints.Namespace, Name: endpoints.Name}, Port: portname}
+		svcPort := proxy.ServicePortName{
+			NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{
+				TenantPartitionId: tenantPartitionId, Tenant: endpoints.Tenant, Namespace: endpoints.Namespace, Name: endpoints.Name}, Port: portname}
 		lb.resetService(svcPort)
 	}
 }
 
-func (lb *LoadBalancerRR) OnEndpointsSynced() {
+func (lb *LoadBalancerRR) OnEndpointsSynced(tenantPartitionId int) {
 }
 
 // Tests whether two slices are equivalent.  This sorts both slices in-place.

--- a/pkg/proxy/userspace/roundrobin_test.go
+++ b/pkg/proxy/userspace/roundrobin_test.go
@@ -70,7 +70,7 @@ func TestFilterWorks(t *testing.T) {
 
 func TestLoadBalanceFailsWithNoEndpoints(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "does-not-exist"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "does-not-exist"}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil {
 		t.Errorf("Didn't fail with non-existent service")
@@ -102,7 +102,7 @@ func expectEndpointWithSessionAffinityReset(t *testing.T, loadBalancer *LoadBala
 
 func TestLoadBalanceWorksWithSingleEndpoint(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -139,7 +139,7 @@ func stringsInSlice(haystack []string, needles ...string) bool {
 
 func TestLoadBalanceWorksWithMultipleEndpoints(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -165,8 +165,8 @@ func TestLoadBalanceWorksWithMultipleEndpoints(t *testing.T) {
 
 func TestLoadBalanceWorksWithMultipleEndpointsMultiplePorts(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	serviceP := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
-	serviceQ := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "q"}
+	serviceP := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
+	serviceQ := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "q"}
 	endpoint, err := loadBalancer.NextEndpoint(serviceP, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -207,8 +207,8 @@ func TestLoadBalanceWorksWithMultipleEndpointsMultiplePorts(t *testing.T) {
 
 func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	serviceP := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
-	serviceQ := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "q"}
+	serviceP := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
+	serviceQ := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "q"}
 	endpoint, err := loadBalancer.NextEndpoint(serviceP, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -297,8 +297,8 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 
 func TestLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	fooServiceP := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
-	barServiceP := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "bar"}, Port: "p"}
+	fooServiceP := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
+	barServiceP := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "bar"}, Port: "p"}
 	endpoint, err := loadBalancer.NextEndpoint(fooServiceP, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -353,7 +353,7 @@ func TestLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 
 func TestStickyLoadBalanceWorksWithNewServiceCalledFirst(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: ""}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: ""}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -409,7 +409,7 @@ func TestStickyLoadBalanceWorksWithNewServiceCalledFirst(t *testing.T) {
 
 func TestStickyLoadBalanceWorksWithNewServiceCalledSecond(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: ""}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: ""}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -470,7 +470,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 	client5 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 5), Port: 0}
 	client6 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 6), Port: 0}
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: ""}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: ""}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -543,7 +543,7 @@ func TestStickyLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 	client2 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 2), Port: 0}
 	client3 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 3), Port: 0}
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: ""}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: ""}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -603,7 +603,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	client2 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 2), Port: 0}
 	client3 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 3), Port: 0}
 	loadBalancer := NewLoadBalancerRR()
-	fooService := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: ""}
+	fooService := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: ""}
 	endpoint, err := loadBalancer.NextEndpoint(fooService, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -618,7 +618,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 			},
 		},
 	}
-	barService := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "bar"}, Port: ""}
+	barService := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "bar"}, Port: ""}
 	loadBalancer.NewService(barService, v1.ServiceAffinityClientIP, int(v1.DefaultClientIPServiceAffinitySeconds))
 	endpoints2 := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: barService.Name, Namespace: barService.Namespace},
@@ -670,7 +670,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 
 func TestStickyLoadBalanceWorksWithEndpointFails(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: ""}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: ""}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")

--- a/pkg/proxy/userspace/roundrobin_test.go
+++ b/pkg/proxy/userspace/roundrobin_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/proxy"
 )
+
+const tpId = 0
 
 func TestValidateWorks(t *testing.T) {
 	if isValidEndpoint(&hostPortPair{}) {
@@ -111,7 +114,7 @@ func TestLoadBalanceWorksWithSingleEndpoint(t *testing.T) {
 			Ports:     []v1.EndpointPort{{Name: "p", Port: 40}},
 		}},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints)
+	loadBalancer.OnEndpointsAdd(endpoints, tpId)
 	expectEndpoint(t, loadBalancer, service, "endpoint1:40", nil)
 	expectEndpoint(t, loadBalancer, service, "endpoint1:40", nil)
 	expectEndpoint(t, loadBalancer, service, "endpoint1:40", nil)
@@ -148,7 +151,7 @@ func TestLoadBalanceWorksWithMultipleEndpoints(t *testing.T) {
 			Ports:     []v1.EndpointPort{{Name: "p", Port: 1}, {Name: "p", Port: 2}, {Name: "p", Port: 3}},
 		}},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints)
+	loadBalancer.OnEndpointsAdd(endpoints, tpId)
 
 	shuffledEndpoints := loadBalancer.services[service].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint:1", "endpoint:2", "endpoint:3") {
@@ -181,7 +184,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsMultiplePorts(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints)
+	loadBalancer.OnEndpointsAdd(endpoints, tpId)
 
 	shuffledEndpoints := loadBalancer.services[serviceP].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint1:1", "endpoint2:1", "endpoint3:3") {
@@ -227,7 +230,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpointsv1)
+	loadBalancer.OnEndpointsAdd(endpointsv1, tpId)
 
 	shuffledEndpoints := loadBalancer.services[serviceP].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint1:1", "endpoint2:2", "endpoint3:3") {
@@ -262,7 +265,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2)
+	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2, tpId)
 
 	shuffledEndpoints = loadBalancer.services[serviceP].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint4:4", "endpoint5:5") {
@@ -284,7 +287,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 
 	// Clear endpoints
 	endpointsv3 := &v1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: serviceP.Name, Namespace: serviceP.Namespace}, Subsets: nil}
-	loadBalancer.OnEndpointsUpdate(endpointsv2, endpointsv3)
+	loadBalancer.OnEndpointsUpdate(endpointsv2, endpointsv3, tpId)
 
 	endpoint, err = loadBalancer.NextEndpoint(serviceP, nil, false)
 	if err == nil || len(endpoint) != 0 {
@@ -318,8 +321,8 @@ func TestLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints1)
-	loadBalancer.OnEndpointsAdd(endpoints2)
+	loadBalancer.OnEndpointsAdd(endpoints1, tpId)
+	loadBalancer.OnEndpointsAdd(endpoints2, tpId)
 	shuffledFooEndpoints := loadBalancer.services[fooServiceP].endpoints
 	expectEndpoint(t, loadBalancer, fooServiceP, shuffledFooEndpoints[0], nil)
 	expectEndpoint(t, loadBalancer, fooServiceP, shuffledFooEndpoints[1], nil)
@@ -335,7 +338,7 @@ func TestLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	expectEndpoint(t, loadBalancer, barServiceP, shuffledBarEndpoints[1], nil)
 
 	// Then update the configuration by removing foo
-	loadBalancer.OnEndpointsDelete(endpoints1)
+	loadBalancer.OnEndpointsDelete(endpoints1, tpId)
 	endpoint, err = loadBalancer.NextEndpoint(fooServiceP, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -366,7 +369,7 @@ func TestStickyLoadBalanceWorksWithNewServiceCalledFirst(t *testing.T) {
 			{Addresses: []v1.EndpointAddress{{IP: "endpoint3"}}, Ports: []v1.EndpointPort{{Port: 3}}},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints)
+	loadBalancer.OnEndpointsAdd(endpoints, tpId)
 
 	client1 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
 	client2 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 2), Port: 0}
@@ -420,7 +423,7 @@ func TestStickyLoadBalanceWorksWithNewServiceCalledSecond(t *testing.T) {
 			{Addresses: []v1.EndpointAddress{{IP: "endpoint2"}}, Ports: []v1.EndpointPort{{Port: 2}}},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints)
+	loadBalancer.OnEndpointsAdd(endpoints, tpId)
 	loadBalancer.NewService(service, v1.ServiceAffinityClientIP, int(v1.DefaultClientIPServiceAffinitySeconds))
 
 	client1 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
@@ -483,7 +486,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpointsv1)
+	loadBalancer.OnEndpointsAdd(endpointsv1, tpId)
 	shuffledEndpoints := loadBalancer.services[service].endpoints
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
 	client1Endpoint := shuffledEndpoints[0]
@@ -503,7 +506,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2)
+	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2, tpId)
 	shuffledEndpoints = loadBalancer.services[service].endpoints
 	if client1Endpoint == "endpoint:3" {
 		client1Endpoint = shuffledEndpoints[0]
@@ -525,7 +528,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsUpdate(endpointsv2, endpointsv3)
+	loadBalancer.OnEndpointsUpdate(endpointsv2, endpointsv3, tpId)
 	shuffledEndpoints = loadBalancer.services[service].endpoints
 	expectEndpoint(t, loadBalancer, service, client1Endpoint, client1)
 	expectEndpoint(t, loadBalancer, service, client2Endpoint, client2)
@@ -556,7 +559,7 @@ func TestStickyLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpointsv1)
+	loadBalancer.OnEndpointsAdd(endpointsv1, tpId)
 	shuffledEndpoints := loadBalancer.services[service].endpoints
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
@@ -576,7 +579,7 @@ func TestStickyLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2)
+	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2, tpId)
 	shuffledEndpoints = loadBalancer.services[service].endpoints
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[1], client2)
@@ -587,7 +590,7 @@ func TestStickyLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 
 	// Clear endpoints
 	endpointsv3 := &v1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace}, Subsets: nil}
-	loadBalancer.OnEndpointsUpdate(endpointsv2, endpointsv3)
+	loadBalancer.OnEndpointsUpdate(endpointsv2, endpointsv3, tpId)
 
 	endpoint, err = loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
@@ -626,8 +629,8 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints1)
-	loadBalancer.OnEndpointsAdd(endpoints2)
+	loadBalancer.OnEndpointsAdd(endpoints1, tpId)
+	loadBalancer.OnEndpointsAdd(endpoints2, tpId)
 
 	shuffledFooEndpoints := loadBalancer.services[fooService].endpoints
 	expectEndpoint(t, loadBalancer, fooService, shuffledFooEndpoints[0], client1)
@@ -649,7 +652,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	expectEndpoint(t, loadBalancer, barService, shuffledBarEndpoints[1], client2)
 
 	// Then update the configuration by removing foo
-	loadBalancer.OnEndpointsDelete(endpoints1)
+	loadBalancer.OnEndpointsDelete(endpoints1, tpId)
 	endpoint, err = loadBalancer.NextEndpoint(fooService, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -683,7 +686,7 @@ func TestStickyLoadBalanceWorksWithEndpointFails(t *testing.T) {
 			{Addresses: []v1.EndpointAddress{{IP: "endpoint3"}}, Ports: []v1.EndpointPort{{Port: 3}}},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints)
+	loadBalancer.OnEndpointsAdd(endpoints, tpId)
 
 	client1 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
 	client2 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 2), Port: 0}

--- a/pkg/proxy/util/utils.go
+++ b/pkg/proxy/util/utils.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -117,7 +118,7 @@ func IsLocalIP(ip string) (bool, error) {
 }
 
 // ShouldSkipService checks if a given service should skip proxying
-func ShouldSkipService(svcName types.NamespacedName, service *v1.Service) bool {
+func ShouldSkipService(svcName types.NamespacednameWithTenantSource, service *v1.Service) bool {
 	// if ClusterIP is "None" or empty, skip proxying
 	if !helper.IsServiceIPSet(service) {
 		klog.V(3).Infof("Skipping service %s due to clusterIP = %q", svcName, service.Spec.ClusterIP)

--- a/pkg/proxy/util/utils_test.go
+++ b/pkg/proxy/util/utils_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/proxy/util/utils_test.go
+++ b/pkg/proxy/util/utils_test.go
@@ -99,7 +99,7 @@ func TestIsProxyableHostname(t *testing.T) {
 func TestShouldSkipService(t *testing.T) {
 	testCases := []struct {
 		service    *v1.Service
-		svcName    types.NamespacedName
+		svcName    types.NamespacednameWithTenantSource
 		shouldSkip bool
 	}{
 		{
@@ -110,7 +110,7 @@ func TestShouldSkipService(t *testing.T) {
 					ClusterIP: v1.ClusterIPNone,
 				},
 			},
-			svcName:    types.NamespacedName{Namespace: "foo", Name: "bar"},
+			svcName:    types.NamespacednameWithTenantSource{Namespace: "foo", Name: "bar"},
 			shouldSkip: true,
 		},
 		{
@@ -121,7 +121,7 @@ func TestShouldSkipService(t *testing.T) {
 					ClusterIP: "",
 				},
 			},
-			svcName:    types.NamespacedName{Namespace: "foo", Name: "bar"},
+			svcName:    types.NamespacednameWithTenantSource{Namespace: "foo", Name: "bar"},
 			shouldSkip: true,
 		},
 		{
@@ -133,7 +133,7 @@ func TestShouldSkipService(t *testing.T) {
 					Type:      v1.ServiceTypeExternalName,
 				},
 			},
-			svcName:    types.NamespacedName{Namespace: "foo", Name: "bar"},
+			svcName:    types.NamespacednameWithTenantSource{Namespace: "foo", Name: "bar"},
 			shouldSkip: true,
 		},
 		{
@@ -145,7 +145,7 @@ func TestShouldSkipService(t *testing.T) {
 					Type:      v1.ServiceTypeClusterIP,
 				},
 			},
-			svcName:    types.NamespacedName{Namespace: "foo", Name: "bar"},
+			svcName:    types.NamespacednameWithTenantSource{Namespace: "foo", Name: "bar"},
 			shouldSkip: false,
 		},
 		{
@@ -157,7 +157,7 @@ func TestShouldSkipService(t *testing.T) {
 					Type:      v1.ServiceTypeNodePort,
 				},
 			},
-			svcName:    types.NamespacedName{Namespace: "foo", Name: "bar"},
+			svcName:    types.NamespacednameWithTenantSource{Namespace: "foo", Name: "bar"},
 			shouldSkip: false,
 		},
 		{
@@ -169,7 +169,7 @@ func TestShouldSkipService(t *testing.T) {
 					Type:      v1.ServiceTypeLoadBalancer,
 				},
 			},
-			svcName:    types.NamespacedName{Namespace: "foo", Name: "bar"},
+			svcName:    types.NamespacednameWithTenantSource{Namespace: "foo", Name: "bar"},
 			shouldSkip: false,
 		},
 	}

--- a/pkg/proxy/winuserspace/proxier_test.go
+++ b/pkg/proxy/winuserspace/proxier_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/proxy/winuserspace/proxier_test.go
+++ b/pkg/proxy/winuserspace/proxier_test.go
@@ -39,6 +39,7 @@ import (
 
 const (
 	udpIdleTimeoutForTest = 250 * time.Millisecond
+	tpId                  = 0
 )
 
 func joinHostPort(host string, port int) string {
@@ -240,14 +241,14 @@ func getPortNum(t *testing.T, addr string) int {
 
 func TestTCPProxy(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -256,7 +257,7 @@ func TestTCPProxy(t *testing.T) {
 	}
 	waitForNumProxyLoops(t, p, 0)
 
-	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
+	servicePortPortalName := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
 	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -267,14 +268,14 @@ func TestTCPProxy(t *testing.T) {
 
 func TestUDPProxy(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: udpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -283,7 +284,7 @@ func TestUDPProxy(t *testing.T) {
 	}
 	waitForNumProxyLoops(t, p, 0)
 
-	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
+	servicePortPortalName := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
 	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -294,14 +295,14 @@ func TestUDPProxy(t *testing.T) {
 
 func TestUDPProxyTimeout(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: udpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -310,7 +311,7 @@ func TestUDPProxyTimeout(t *testing.T) {
 	}
 	waitForNumProxyLoops(t, p, 0)
 
-	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
+	servicePortPortalName := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
 	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -325,22 +326,22 @@ func TestUDPProxyTimeout(t *testing.T) {
 
 func TestMultiPortProxy(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	serviceP := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo-p"}, Port: "p"}
-	serviceQ := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo-q"}, Port: "q"}
+	serviceP := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo-p"}, Port: "p"}
+	serviceQ := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo-q"}, Port: "q"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceP.Name, Namespace: serviceP.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Protocol: "TCP", Port: tcpServerPort}},
 		}},
-	})
+	}, tpId)
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceQ.Name, Namespace: serviceQ.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "q", Protocol: "UDP", Port: udpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -349,7 +350,7 @@ func TestMultiPortProxy(t *testing.T) {
 	}
 	waitForNumProxyLoops(t, p, 0)
 
-	servicePortPortalNameP := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: serviceP.Namespace, Name: serviceP.Name}, Port: serviceP.Port, PortalIPName: listenIP}
+	servicePortPortalNameP := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: serviceP.Namespace, Name: serviceP.Name}, Port: serviceP.Port, PortalIPName: listenIP}
 	svcInfoP, err := p.addServicePortPortal(servicePortPortalNameP, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -357,7 +358,7 @@ func TestMultiPortProxy(t *testing.T) {
 	testEchoTCP(t, "127.0.0.1", getPortNum(t, svcInfoP.socket.Addr().String()))
 	waitForNumProxyLoops(t, p, 1)
 
-	servicePortPortalNameQ := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: serviceQ.Namespace, Name: serviceQ.Name}, Port: serviceQ.Port, PortalIPName: listenIP}
+	servicePortPortalNameQ := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: serviceQ.Namespace, Name: serviceQ.Name}, Port: serviceQ.Port, PortalIPName: listenIP}
 	svcInfoQ, err := p.addServicePortPortal(servicePortPortalNameQ, "UDP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -368,9 +369,9 @@ func TestMultiPortProxy(t *testing.T) {
 
 func TestMultiPortOnServiceAdd(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	serviceP := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
-	serviceQ := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "q"}
-	serviceX := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "x"}
+	serviceP := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	serviceQ := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "q"}
+	serviceX := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "x"}
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -390,10 +391,10 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 			Port:     0,
 			Protocol: "UDP",
 		}}},
-	})
+	}, tpId)
 	waitForNumProxyLoops(t, p, 2)
 
-	servicePortPortalNameP := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: serviceP.Namespace, Name: serviceP.Name}, Port: serviceP.Port, PortalIPName: listenIP}
+	servicePortPortalNameP := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: serviceP.Namespace, Name: serviceP.Name}, Port: serviceP.Port, PortalIPName: listenIP}
 	svcInfo, exists := p.getServiceInfo(servicePortPortalNameP)
 	if !exists {
 		t.Fatalf("can't find serviceInfo for %s", servicePortPortalNameP)
@@ -402,7 +403,7 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 		t.Errorf("unexpected serviceInfo for %s: %#v", serviceP, svcInfo)
 	}
 
-	servicePortPortalNameQ := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: serviceQ.Namespace, Name: serviceQ.Name}, Port: serviceQ.Port, PortalIPName: listenIP}
+	servicePortPortalNameQ := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: serviceQ.Namespace, Name: serviceQ.Name}, Port: serviceQ.Port, PortalIPName: listenIP}
 	svcInfo, exists = p.getServiceInfo(servicePortPortalNameQ)
 	if !exists {
 		t.Fatalf("can't find serviceInfo for %s", servicePortPortalNameQ)
@@ -411,7 +412,7 @@ func TestMultiPortOnServiceAdd(t *testing.T) {
 		t.Errorf("unexpected serviceInfo for %s: %#v", serviceQ, svcInfo)
 	}
 
-	servicePortPortalNameX := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: serviceX.Namespace, Name: serviceX.Name}, Port: serviceX.Port, PortalIPName: listenIP}
+	servicePortPortalNameX := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: serviceX.Namespace, Name: serviceX.Name}, Port: serviceX.Port, PortalIPName: listenIP}
 	svcInfo, exists = p.getServiceInfo(servicePortPortalNameX)
 	if exists {
 		t.Fatalf("found unwanted serviceInfo for %s: %#v", serviceX, svcInfo)
@@ -429,14 +430,14 @@ func stopProxyByName(proxier *Proxier, service ServicePortPortalName) error {
 
 func TestTCPProxyStop(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Namespace: service.Namespace, Name: service.Name},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -445,7 +446,7 @@ func TestTCPProxyStop(t *testing.T) {
 	}
 	waitForNumProxyLoops(t, p, 0)
 
-	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
+	servicePortPortalName := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
 	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -473,14 +474,14 @@ func TestTCPProxyStop(t *testing.T) {
 
 func TestUDPProxyStop(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Namespace: service.Namespace, Name: service.Name},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: udpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -489,7 +490,7 @@ func TestUDPProxyStop(t *testing.T) {
 	}
 	waitForNumProxyLoops(t, p, 0)
 
-	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
+	servicePortPortalName := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
 	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -511,14 +512,14 @@ func TestUDPProxyStop(t *testing.T) {
 
 func TestTCPProxyUpdateDelete(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Namespace: service.Namespace, Name: service.Name},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -527,7 +528,7 @@ func TestTCPProxyUpdateDelete(t *testing.T) {
 	}
 	waitForNumProxyLoops(t, p, 0)
 
-	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
+	servicePortPortalName := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
 	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -547,7 +548,7 @@ func TestTCPProxyUpdateDelete(t *testing.T) {
 			Port:     int32(getPortNum(t, svcInfo.socket.Addr().String())),
 			Protocol: "TCP",
 		}}},
-	})
+	}, tpId)
 	if err := waitForClosedPortTCP(p, getPortNum(t, svcInfo.socket.Addr().String())); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -556,14 +557,14 @@ func TestTCPProxyUpdateDelete(t *testing.T) {
 
 func TestUDPProxyUpdateDelete(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Namespace: service.Namespace, Name: service.Name},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: udpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -572,7 +573,7 @@ func TestUDPProxyUpdateDelete(t *testing.T) {
 	}
 	waitForNumProxyLoops(t, p, 0)
 
-	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
+	servicePortPortalName := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
 	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -591,7 +592,7 @@ func TestUDPProxyUpdateDelete(t *testing.T) {
 			Port:     int32(getPortNum(t, svcInfo.socket.Addr().String())),
 			Protocol: "UDP",
 		}}},
-	})
+	}, tpId)
 	if err := waitForClosedPortUDP(p, getPortNum(t, svcInfo.socket.Addr().String())); err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -600,7 +601,7 @@ func TestUDPProxyUpdateDelete(t *testing.T) {
 
 func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	endpoint := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
@@ -608,7 +609,7 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
 		}},
 	}
-	lb.OnEndpointsAdd(endpoint)
+	lb.OnEndpointsAdd(endpoint, tpId)
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -617,7 +618,7 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 	}
 	waitForNumProxyLoops(t, p, 0)
 
-	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
+	servicePortPortalName := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
 	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -636,14 +637,14 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 			Port:     int32(getPortNum(t, svcInfo.socket.Addr().String())),
 			Protocol: "TCP",
 		}}},
-	})
+	}, tpId)
 	if err := waitForClosedPortTCP(p, getPortNum(t, svcInfo.socket.Addr().String())); err != nil {
 		t.Fatalf(err.Error())
 	}
 	waitForNumProxyLoops(t, p, 0)
 
 	// need to add endpoint here because it got clean up during service delete
-	lb.OnEndpointsAdd(endpoint)
+	lb.OnEndpointsAdd(endpoint, tpId)
 	p.OnServiceAdd(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Spec: v1.ServiceSpec{ClusterIP: listenIP, Ports: []v1.ServicePort{{
@@ -651,7 +652,7 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 			Port:     int32(getPortNum(t, svcInfo.socket.Addr().String())),
 			Protocol: "TCP",
 		}}},
-	})
+	}, tpId)
 	svcInfo, exists := p.getServiceInfo(servicePortPortalName)
 	if !exists {
 		t.Fatalf("can't find serviceInfo for %s", servicePortPortalName)
@@ -662,7 +663,7 @@ func TestTCPProxyUpdateDeleteUpdate(t *testing.T) {
 
 func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	endpoint := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
@@ -670,7 +671,7 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 			Ports:     []v1.EndpointPort{{Name: "p", Port: udpServerPort}},
 		}},
 	}
-	lb.OnEndpointsAdd(endpoint)
+	lb.OnEndpointsAdd(endpoint, tpId)
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -679,7 +680,7 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 	}
 	waitForNumProxyLoops(t, p, 0)
 
-	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
+	servicePortPortalName := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
 	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -698,14 +699,14 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 			Port:     int32(getPortNum(t, svcInfo.socket.Addr().String())),
 			Protocol: "UDP",
 		}}},
-	})
+	}, tpId)
 	if err := waitForClosedPortUDP(p, getPortNum(t, svcInfo.socket.Addr().String())); err != nil {
 		t.Fatalf(err.Error())
 	}
 	waitForNumProxyLoops(t, p, 0)
 
 	// need to add endpoint here because it got clean up during service delete
-	lb.OnEndpointsAdd(endpoint)
+	lb.OnEndpointsAdd(endpoint, tpId)
 	p.OnServiceAdd(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Spec: v1.ServiceSpec{ClusterIP: listenIP, Ports: []v1.ServicePort{{
@@ -713,7 +714,7 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 			Port:     int32(getPortNum(t, svcInfo.socket.Addr().String())),
 			Protocol: "UDP",
 		}}},
-	})
+	}, tpId)
 	svcInfo, exists := p.getServiceInfo(servicePortPortalName)
 	if !exists {
 		t.Fatalf("can't find serviceInfo for %s", servicePortPortalName)
@@ -724,14 +725,14 @@ func TestUDPProxyUpdateDeleteUpdate(t *testing.T) {
 
 func TestTCPProxyUpdatePort(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -740,7 +741,7 @@ func TestTCPProxyUpdatePort(t *testing.T) {
 	}
 	waitForNumProxyLoops(t, p, 0)
 
-	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
+	servicePortPortalName := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
 	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -755,7 +756,7 @@ func TestTCPProxyUpdatePort(t *testing.T) {
 			Port:     0,
 			Protocol: "TCP",
 		}}},
-	})
+	}, tpId)
 	// Wait for the socket to actually get free.
 	if err := waitForClosedPortTCP(p, getPortNum(t, svcInfo.socket.Addr().String())); err != nil {
 		t.Fatalf(err.Error())
@@ -772,14 +773,14 @@ func TestTCPProxyUpdatePort(t *testing.T) {
 
 func TestUDPProxyUpdatePort(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: udpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -788,7 +789,7 @@ func TestUDPProxyUpdatePort(t *testing.T) {
 	}
 	waitForNumProxyLoops(t, p, 0)
 
-	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
+	servicePortPortalName := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
 	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "UDP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -802,7 +803,7 @@ func TestUDPProxyUpdatePort(t *testing.T) {
 			Port:     0,
 			Protocol: "UDP",
 		}}},
-	})
+	}, tpId)
 	// Wait for the socket to actually get free.
 	if err := waitForClosedPortUDP(p, getPortNum(t, svcInfo.socket.Addr().String())); err != nil {
 		t.Fatalf(err.Error())
@@ -817,14 +818,14 @@ func TestUDPProxyUpdatePort(t *testing.T) {
 
 func TestProxyUpdatePublicIPs(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	lb.OnEndpointsAdd(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
 			Addresses: []v1.EndpointAddress{{IP: "127.0.0.1"}},
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
 		}},
-	})
+	}, tpId)
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -833,7 +834,7 @@ func TestProxyUpdatePublicIPs(t *testing.T) {
 	}
 	waitForNumProxyLoops(t, p, 0)
 
-	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
+	servicePortPortalName := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
 	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -852,7 +853,7 @@ func TestProxyUpdatePublicIPs(t *testing.T) {
 			ClusterIP:   svcInfo.portal.ip,
 			ExternalIPs: []string{"0.0.0.0"},
 		},
-	})
+	}, tpId)
 	// Wait for the socket to actually get free.
 	if err := waitForClosedPortTCP(p, getPortNum(t, svcInfo.socket.Addr().String())); err != nil {
 		t.Fatalf(err.Error())
@@ -869,7 +870,7 @@ func TestProxyUpdatePublicIPs(t *testing.T) {
 
 func TestProxyUpdatePortal(t *testing.T) {
 	lb := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "echo"}, Port: "p"}
 	endpoint := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace},
 		Subsets: []v1.EndpointSubset{{
@@ -877,7 +878,7 @@ func TestProxyUpdatePortal(t *testing.T) {
 			Ports:     []v1.EndpointPort{{Name: "p", Port: tcpServerPort}},
 		}},
 	}
-	lb.OnEndpointsAdd(endpoint)
+	lb.OnEndpointsAdd(endpoint, tpId)
 
 	listenIP := "0.0.0.0"
 	p, err := createProxier(lb, net.ParseIP(listenIP), netshtest.NewFake(), net.ParseIP("127.0.0.1"), time.Minute, udpIdleTimeoutForTest)
@@ -886,7 +887,7 @@ func TestProxyUpdatePortal(t *testing.T) {
 	}
 	waitForNumProxyLoops(t, p, 0)
 
-	servicePortPortalName := ServicePortPortalName{NamespacedName: types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
+	servicePortPortalName := ServicePortPortalName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: service.Namespace, Name: service.Name}, Port: service.Port, PortalIPName: listenIP}
 	svcInfo, err := p.addServicePortPortal(servicePortPortalName, "TCP", listenIP, 0, time.Second)
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
@@ -912,7 +913,7 @@ func TestProxyUpdatePortal(t *testing.T) {
 		}}},
 	}
 
-	p.OnServiceUpdate(svcv0, svcv1)
+	p.OnServiceUpdate(svcv0, svcv1, tpId)
 	_, exists := p.getServiceInfo(servicePortPortalName)
 	if exists {
 		t.Fatalf("service with empty ClusterIP should not be included in the proxy")
@@ -926,7 +927,7 @@ func TestProxyUpdatePortal(t *testing.T) {
 			Protocol: "TCP",
 		}}},
 	}
-	p.OnServiceUpdate(svcv1, svcv2)
+	p.OnServiceUpdate(svcv1, svcv2, tpId)
 	_, exists = p.getServiceInfo(servicePortPortalName)
 	if exists {
 		t.Fatalf("service with 'None' as ClusterIP should not be included in the proxy")
@@ -940,8 +941,8 @@ func TestProxyUpdatePortal(t *testing.T) {
 			Protocol: "TCP",
 		}}},
 	}
-	p.OnServiceUpdate(svcv2, svcv3)
-	lb.OnEndpointsAdd(endpoint)
+	p.OnServiceUpdate(svcv2, svcv3, tpId)
+	lb.OnEndpointsAdd(endpoint, tpId)
 	svcInfo, exists = p.getServiceInfo(servicePortPortalName)
 	if !exists {
 		t.Fatalf("service with ClusterIP set not found in the proxy")

--- a/pkg/proxy/winuserspace/proxysocket.go
+++ b/pkg/proxy/winuserspace/proxysocket.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/proxy/winuserspace/proxysocket.go
+++ b/pkg/proxy/winuserspace/proxysocket.go
@@ -125,7 +125,7 @@ func tryConnect(service ServicePortPortalName, srcAddr net.Addr, protocol string
 	sessionAffinityReset := false
 	for _, dialTimeout := range endpointDialTimeout {
 		servicePortName := proxy.ServicePortName{
-			NamespacedName: types.NamespacedName{
+			NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{
 				Namespace: service.Namespace,
 				Name:      service.Name,
 			},

--- a/pkg/proxy/winuserspace/roundrobin_test.go
+++ b/pkg/proxy/winuserspace/roundrobin_test.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/proxy/winuserspace/roundrobin_test.go
+++ b/pkg/proxy/winuserspace/roundrobin_test.go
@@ -67,7 +67,7 @@ func TestFilterWorks(t *testing.T) {
 
 func TestLoadBalanceFailsWithNoEndpoints(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "does-not-exist"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "does-not-exist"}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil {
 		t.Errorf("Didn't fail with non-existent service")
@@ -99,7 +99,7 @@ func expectEndpointWithSessionAffinityReset(t *testing.T, loadBalancer *LoadBala
 
 func TestLoadBalanceWorksWithSingleEndpoint(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -111,7 +111,7 @@ func TestLoadBalanceWorksWithSingleEndpoint(t *testing.T) {
 			Ports:     []v1.EndpointPort{{Name: "p", Port: 40}},
 		}},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints)
+	loadBalancer.OnEndpointsAdd(endpoints, tpId)
 	expectEndpoint(t, loadBalancer, service, "endpoint1:40", nil)
 	expectEndpoint(t, loadBalancer, service, "endpoint1:40", nil)
 	expectEndpoint(t, loadBalancer, service, "endpoint1:40", nil)
@@ -136,7 +136,7 @@ func stringsInSlice(haystack []string, needles ...string) bool {
 
 func TestLoadBalanceWorksWithMultipleEndpoints(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -148,7 +148,7 @@ func TestLoadBalanceWorksWithMultipleEndpoints(t *testing.T) {
 			Ports:     []v1.EndpointPort{{Name: "p", Port: 1}, {Name: "p", Port: 2}, {Name: "p", Port: 3}},
 		}},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints)
+	loadBalancer.OnEndpointsAdd(endpoints, tpId)
 
 	shuffledEndpoints := loadBalancer.services[service].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint:1", "endpoint:2", "endpoint:3") {
@@ -162,8 +162,8 @@ func TestLoadBalanceWorksWithMultipleEndpoints(t *testing.T) {
 
 func TestLoadBalanceWorksWithMultipleEndpointsMultiplePorts(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	serviceP := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
-	serviceQ := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "q"}
+	serviceP := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
+	serviceQ := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "q"}
 	endpoint, err := loadBalancer.NextEndpoint(serviceP, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -181,7 +181,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsMultiplePorts(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints)
+	loadBalancer.OnEndpointsAdd(endpoints, tpId)
 
 	shuffledEndpoints := loadBalancer.services[serviceP].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint1:1", "endpoint2:1", "endpoint3:3") {
@@ -204,8 +204,8 @@ func TestLoadBalanceWorksWithMultipleEndpointsMultiplePorts(t *testing.T) {
 
 func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	serviceP := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
-	serviceQ := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "q"}
+	serviceP := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
+	serviceQ := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "q"}
 	endpoint, err := loadBalancer.NextEndpoint(serviceP, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -227,7 +227,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpointsv1)
+	loadBalancer.OnEndpointsAdd(endpointsv1, tpId)
 
 	shuffledEndpoints := loadBalancer.services[serviceP].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint1:1", "endpoint2:2", "endpoint3:3") {
@@ -262,7 +262,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2)
+	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2, tpId)
 
 	shuffledEndpoints = loadBalancer.services[serviceP].endpoints
 	if !stringsInSlice(shuffledEndpoints, "endpoint4:4", "endpoint5:5") {
@@ -284,7 +284,7 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 
 	// Clear endpoints
 	endpointsv3 := &v1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: serviceP.Name, Namespace: serviceP.Namespace}, Subsets: nil}
-	loadBalancer.OnEndpointsUpdate(endpointsv2, endpointsv3)
+	loadBalancer.OnEndpointsUpdate(endpointsv2, endpointsv3, tpId)
 
 	endpoint, err = loadBalancer.NextEndpoint(serviceP, nil, false)
 	if err == nil || len(endpoint) != 0 {
@@ -294,8 +294,8 @@ func TestLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 
 func TestLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	fooServiceP := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
-	barServiceP := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "bar"}, Port: "p"}
+	fooServiceP := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: "p"}
+	barServiceP := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "bar"}, Port: "p"}
 	endpoint, err := loadBalancer.NextEndpoint(fooServiceP, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -318,8 +318,8 @@ func TestLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints1)
-	loadBalancer.OnEndpointsAdd(endpoints2)
+	loadBalancer.OnEndpointsAdd(endpoints1, tpId)
+	loadBalancer.OnEndpointsAdd(endpoints2, tpId)
 	shuffledFooEndpoints := loadBalancer.services[fooServiceP].endpoints
 	expectEndpoint(t, loadBalancer, fooServiceP, shuffledFooEndpoints[0], nil)
 	expectEndpoint(t, loadBalancer, fooServiceP, shuffledFooEndpoints[1], nil)
@@ -335,7 +335,7 @@ func TestLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	expectEndpoint(t, loadBalancer, barServiceP, shuffledBarEndpoints[1], nil)
 
 	// Then update the configuration by removing foo
-	loadBalancer.OnEndpointsDelete(endpoints1)
+	loadBalancer.OnEndpointsDelete(endpoints1, tpId)
 	endpoint, err = loadBalancer.NextEndpoint(fooServiceP, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -350,7 +350,7 @@ func TestLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 
 func TestStickyLoadBalanceWorksWithNewServiceCalledFirst(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: ""}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: ""}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -366,7 +366,7 @@ func TestStickyLoadBalanceWorksWithNewServiceCalledFirst(t *testing.T) {
 			{Addresses: []v1.EndpointAddress{{IP: "endpoint3"}}, Ports: []v1.EndpointPort{{Port: 3}}},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints)
+	loadBalancer.OnEndpointsAdd(endpoints, tpId)
 
 	client1 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
 	client2 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 2), Port: 0}
@@ -406,7 +406,7 @@ func TestStickyLoadBalanceWorksWithNewServiceCalledFirst(t *testing.T) {
 
 func TestStickyLoadBalanceWorksWithNewServiceCalledSecond(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: ""}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: ""}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -420,7 +420,7 @@ func TestStickyLoadBalanceWorksWithNewServiceCalledSecond(t *testing.T) {
 			{Addresses: []v1.EndpointAddress{{IP: "endpoint2"}}, Ports: []v1.EndpointPort{{Port: 2}}},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints)
+	loadBalancer.OnEndpointsAdd(endpoints, tpId)
 	loadBalancer.NewService(service, v1.ServiceAffinityClientIP, int(v1.DefaultClientIPServiceAffinitySeconds))
 
 	client1 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
@@ -467,7 +467,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 	client5 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 5), Port: 0}
 	client6 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 6), Port: 0}
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: ""}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: ""}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -483,7 +483,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpointsv1)
+	loadBalancer.OnEndpointsAdd(endpointsv1, tpId)
 	shuffledEndpoints := loadBalancer.services[service].endpoints
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
 	client1Endpoint := shuffledEndpoints[0]
@@ -503,7 +503,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2)
+	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2, tpId)
 	shuffledEndpoints = loadBalancer.services[service].endpoints
 	if client1Endpoint == "endpoint:3" {
 		client1Endpoint = shuffledEndpoints[0]
@@ -525,7 +525,7 @@ func TestStickyLoadBalanaceWorksWithMultipleEndpointsRemoveOne(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsUpdate(endpointsv2, endpointsv3)
+	loadBalancer.OnEndpointsUpdate(endpointsv2, endpointsv3, tpId)
 	shuffledEndpoints = loadBalancer.services[service].endpoints
 	expectEndpoint(t, loadBalancer, service, client1Endpoint, client1)
 	expectEndpoint(t, loadBalancer, service, client2Endpoint, client2)
@@ -540,7 +540,7 @@ func TestStickyLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 	client2 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 2), Port: 0}
 	client3 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 3), Port: 0}
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: ""}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: ""}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -556,7 +556,7 @@ func TestStickyLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpointsv1)
+	loadBalancer.OnEndpointsAdd(endpointsv1, tpId)
 	shuffledEndpoints := loadBalancer.services[service].endpoints
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
@@ -576,7 +576,7 @@ func TestStickyLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2)
+	loadBalancer.OnEndpointsUpdate(endpointsv1, endpointsv2, tpId)
 	shuffledEndpoints = loadBalancer.services[service].endpoints
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[0], client1)
 	expectEndpoint(t, loadBalancer, service, shuffledEndpoints[1], client2)
@@ -587,7 +587,7 @@ func TestStickyLoadBalanceWorksWithMultipleEndpointsAndUpdates(t *testing.T) {
 
 	// Clear endpoints
 	endpointsv3 := &v1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: service.Name, Namespace: service.Namespace}, Subsets: nil}
-	loadBalancer.OnEndpointsUpdate(endpointsv2, endpointsv3)
+	loadBalancer.OnEndpointsUpdate(endpointsv2, endpointsv3, tpId)
 
 	endpoint, err = loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
@@ -600,7 +600,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	client2 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 2), Port: 0}
 	client3 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 3), Port: 0}
 	loadBalancer := NewLoadBalancerRR()
-	fooService := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: ""}
+	fooService := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: ""}
 	endpoint, err := loadBalancer.NextEndpoint(fooService, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -615,7 +615,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 			},
 		},
 	}
-	barService := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "bar"}, Port: ""}
+	barService := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "bar"}, Port: ""}
 	loadBalancer.NewService(barService, v1.ServiceAffinityClientIP, int(v1.DefaultClientIPServiceAffinitySeconds))
 	endpoints2 := &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Name: barService.Name, Namespace: barService.Namespace},
@@ -626,8 +626,8 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 			},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints1)
-	loadBalancer.OnEndpointsAdd(endpoints2)
+	loadBalancer.OnEndpointsAdd(endpoints1, tpId)
+	loadBalancer.OnEndpointsAdd(endpoints2, tpId)
 
 	shuffledFooEndpoints := loadBalancer.services[fooService].endpoints
 	expectEndpoint(t, loadBalancer, fooService, shuffledFooEndpoints[0], client1)
@@ -649,7 +649,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 	expectEndpoint(t, loadBalancer, barService, shuffledBarEndpoints[1], client2)
 
 	// Then update the configuration by removing foo
-	loadBalancer.OnEndpointsDelete(endpoints1)
+	loadBalancer.OnEndpointsDelete(endpoints1, tpId)
 	endpoint, err = loadBalancer.NextEndpoint(fooService, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -667,7 +667,7 @@ func TestStickyLoadBalanceWorksWithServiceRemoval(t *testing.T) {
 
 func TestStickyLoadBalanceWorksWithEndpointFails(t *testing.T) {
 	loadBalancer := NewLoadBalancerRR()
-	service := proxy.ServicePortName{NamespacedName: types.NamespacedName{Namespace: "testnamespace", Name: "foo"}, Port: ""}
+	service := proxy.ServicePortName{NamespacednameWithTenantSource: types.NamespacednameWithTenantSource{Namespace: "testnamespace", Name: "foo"}, Port: ""}
 	endpoint, err := loadBalancer.NextEndpoint(service, nil, false)
 	if err == nil || len(endpoint) != 0 {
 		t.Errorf("Didn't fail with non-existent service")
@@ -683,7 +683,7 @@ func TestStickyLoadBalanceWorksWithEndpointFails(t *testing.T) {
 			{Addresses: []v1.EndpointAddress{{IP: "endpoint3"}}, Ports: []v1.EndpointPort{{Port: 3}}},
 		},
 	}
-	loadBalancer.OnEndpointsAdd(endpoints)
+	loadBalancer.OnEndpointsAdd(endpoints, tpId)
 
 	client1 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
 	client2 := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 2), Port: 0}

--- a/pkg/proxy/winuserspace/types.go
+++ b/pkg/proxy/winuserspace/types.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2017 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,11 +26,11 @@ import (
 // ServicePortPortalName carries a namespace + name + portname + portalip.  This is the unique
 // identifier for a windows service port portal.
 type ServicePortPortalName struct {
-	types.NamespacedName
+	types.NamespacednameWithTenantSource
 	Port         string
 	PortalIPName string
 }
 
 func (spn ServicePortPortalName) String() string {
-	return fmt.Sprintf("%s:%s:%s", spn.NamespacedName.String(), spn.Port, spn.PortalIPName)
+	return fmt.Sprintf("%s:%s:%s", spn.NamespacednameWithTenantSource.String(), spn.Port, spn.PortalIPName)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/types/namespacedname.go
+++ b/staging/src/k8s.io/apimachinery/pkg/types/namespacedname.go
@@ -43,3 +43,16 @@ const (
 func (n NamespacedName) String() string {
 	return fmt.Sprintf("%s%c%s%c%s", n.Tenant, Separator, n.Namespace, Separator, n.Name)
 }
+
+// NamespacednameWithTenantSource is used to identify a service and endpoint in scale out architecture
+type NamespacednameWithTenantSource struct {
+	TenantPartitionId int
+	Tenant            string
+	Namespace         string
+	Name              string
+}
+
+// String returns the general purpose string representation
+func (n NamespacednameWithTenantSource) String() string {
+	return fmt.Sprintf("%s_%d/%s/%s", n.Tenant, n.TenantPartitionId, n.Namespace, n.Name)
+}


### PR DESCRIPTION
Tested with PR 1244 with 2TP1RP.
Deployed a whoami service in both TP, deployed another pod in both TP for curling purpose. All pods are in system tenant. Was able to curl service endpoint and get back correct whoami container id.

```
---
apiVersion: v1
kind: Service
metadata:
  name: whoami-service
  namespace: default
spec:
  selector:
    app: whoami
  ports:
  - protocol: TCP
    port: 8000
    targetPort: 80
---
apiVersion: apps/v1 
kind: Deployment
metadata:
  name: whoami-deployment
spec:
  replicas: 2
  selector:
    matchLabels:
      app: whoami
  template:
    metadata:
      labels:
        app: whoami
    spec:
      containers:
      - image: ctmagazin/whoami 
        name: whoami-container
        ports:
        - containerPort: 8000
```
