### PR TITLE
Use explicitly set request context in action creation

### DIFF
--- a/pkg/registry/core/pod/storage/BUILD
+++ b/pkg/registry/core/pod/storage/BUILD
@@ -68,6 +68,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -22,14 +22,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"regexp"
+	"strings"
 	"time"
-
-	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -37,6 +36,7 @@ import (
 	storeerr "k8s.io/apiserver/pkg/storage/errors"
 	"k8s.io/apiserver/pkg/util/dryrun"
 	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
+	"k8s.io/klog"
 	podutil "k8s.io/kubernetes/pkg/api/pod"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
@@ -235,6 +235,10 @@ func (r *ActionREST) NamespaceScoped() bool {
 	return r.store.NamespaceScoped()
 }
 
+func (r *ActionREST) TenantScoped() bool {
+	return r.store.TenantScoped()
+}
+
 // New creates a new CustomAction resource
 func (r *ActionREST) New() runtime.Object {
 	return &api.CustomAction{}
@@ -283,20 +287,22 @@ func (r *ActionREST) Create(ctx context.Context, obj runtime.Object, createValid
 
 	klog.V(4).Infof("ActionREST Create customAction object:\n-------------\n%+v\n------------\n", customAction)
 
-	//TODO: Get rid of this hack, figure out how to get RequestInfo and Name as a struct from context
-	ctxtStr := fmt.Sprintf("%+v", ctx)
-	re := regexp.MustCompile("RequestInfo\\{(.*?)\\}")
-	match := re.FindStringSubmatch(ctxtStr)
-	if match == nil {
-		return nil, errors.NewBadRequest("RequestInfo not found in context")
-	}
-	rePod := regexp.MustCompile(`Name:"(.*?)"`)
-	matchPod := rePod.FindStringSubmatch(match[1])
-	if matchPod == nil {
-		return nil, errors.NewBadRequest("Pod name not found in context")
+	path := request.PathValue(ctx)
+	if path == "" {
+		return nil, fmt.Errorf("invalid URL path: URL path is empty")
 	}
 
-	podObj, getErr := r.store.Get(ctx, matchPod[1], &metav1.GetOptions{})
+	// path format to the action subresource: api/v1/tenants/{tenant}/namespaces/{namespace}/pods/{podName}/action
+	eles := strings.Split(path, "/pods/")
+	if len(eles) != 2 {
+		return nil, fmt.Errorf("invalid URL path format")
+	}
+	podName := strings.Split(eles[1], "/")[0]
+	if podName == "" {
+		return nil, fmt.Errorf("invalid pod name for specified action")
+	}
+
+	podObj, getErr := r.store.Get(ctx, podName, &metav1.GetOptions{})
 	if podObj == nil {
 		return nil, getErr
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -81,6 +81,7 @@ func createHandler(r rest.NamedCreater, scope *RequestScope, admit admission.Int
 		ctx := req.Context()
 		ctx = request.WithNamespace(ctx, namespace)
 		ctx = request.WithTenant(ctx, tenant)
+		ctx = request.WithPath(ctx, req.URL.Path)
 		outputMediaType, _, err := negotiation.NegotiateOutputMediaType(req, scope.Serializer, scope)
 		if err != nil {
 			scope.err(err, w, req)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/request/context.go
@@ -43,6 +43,9 @@ const (
 
 	// tenantKey is the context key for the request tenant.
 	tenantKey
+
+	// pathKey is the context key for the requestURL
+	pathKey
 )
 
 // NewContext instantiates a base context object for request flows.
@@ -81,6 +84,22 @@ func TenantFrom(ctx context.Context) (string, bool) {
 func TenantValue(ctx context.Context) string {
 	tenant, _ := TenantFrom(ctx)
 	return tenant
+}
+
+func WithPath(parent context.Context, path string) context.Context {
+	return WithValue(parent, pathKey, path)
+}
+
+// PathFrom returns the value of the path key on the ctx
+func PathFrom(ctx context.Context) (string, bool) {
+	path, ok := ctx.Value(pathKey).(string)
+	return path, ok
+}
+
+// PathValue returns the value of the path key on the ctx, or the empty string if none
+func PathValue(ctx context.Context) string {
+	path, _ := PathFrom(ctx)
+	return path
 }
 
 // WithNamespace returns a copy of parent in which the namespace value is set


### PR DESCRIPTION

**What type of PR is this?**
Explicitly uses the information set in the handler to retrieve the pod name in the Action handlers. The default context with requestInfo is changed since golang 1.39.

**What this PR does / why we need it**:
VM action is currently broken in Arktos since golang 1.39 upgrade in PR #921 

**Which issue(s) this PR fixes**:
Fixes #1251 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

**Local testing of the fix:
```
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# kubectl get pods -AT
TENANT   NAMESPACE     NAME                              HASHKEY               READY   STATUS    RESTARTS   AGE
system   default       vmdefault                         2682661623882133849   1/1     Running   0          3s
system   kube-system   coredns-default-649bd7994-5js4d   4999381479845460905   1/1     Running   0          34s
system   kube-system   kube-dns-554c5866fc-v57tp         1179906577712763734   3/3     Running   0          34s
system   kube-system   virtlet-97fq6                     3708115272588776804   3/3     Running   0          34s
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# curl -X POST http://127.0.0.1:8080/api/v1/tenants/system/namespaces/default/pods/vmdefault/action -H "Content-Type: application/json" -d @./reboot.json -v
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
> POST /api/v1/tenants/system/namespaces/default/pods/vmdefault/action HTTP/1.1
> Host: 127.0.0.1:8080
> User-Agent: curl/7.58.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 118
> 
* upload completely sent off: 118 out of 118 bytes
< HTTP/1.1 201 Created
< Cache-Control: no-cache, private
< Content-Type: application/json
< Date: Wed, 29 Dec 2021 21:40:40 GMT
< Content-Length: 310
< 
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {
    "resourceVersion": "860259110150471681"
  },
  "status": "Success",
  "message": "Created action 'reboot' for Pod 'vmdefault'",
  "details": {
    "name": "reboot-1640814040",
    "uid": "7f2f4b47-750e-4fff-a1f4-2e289b3b8805"
  },
  "code": 201
* Connection #0 to host 127.0.0.1 left intact
}root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# 
```
