### PR TITLE
openstack essential flavors and images support for VM creations -- part2

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/routes/openstack.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/openstack.go
@@ -58,7 +58,7 @@ func (o Openstack) genericFunc(target string, resp http.ResponseWriter, req *htt
 	klog.V(4).Infof("URL path: %s", path)
 
 	if req.Method != "GET" {
-		resp.WriteHeader(405) // method not allowed for the current release
+		resp.WriteHeader(http.StatusMethodNotAllowed) // only GET method for this release
 		return
 	}
 
@@ -95,7 +95,7 @@ func (o Openstack) genericFunc(target string, resp http.ResponseWriter, req *htt
 		f, err = getter(name)
 		if err != nil {
 			klog.Errorf("Invalid %s %s", target, name)
-			resp.WriteHeader(500)
+			resp.WriteHeader(http.StatusNotFound)
 			return
 		}
 		body, err = json.Marshal(f)
@@ -103,10 +103,10 @@ func (o Openstack) genericFunc(target string, resp http.ResponseWriter, req *htt
 
 	if err != nil {
 		klog.Errorf("failed encoding %s, error %v", target, err)
-		resp.WriteHeader(500)
+		resp.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	resp.WriteHeader(200)
+	resp.WriteHeader(http.StatusOK)
 	resp.Write(body)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/openstack.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/openstack.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/util/openstack"
 	"k8s.io/klog"
@@ -30,19 +31,89 @@ import (
 const (
 	POD_URL_TEMPLATE       = "/api/v1/tenants/%s/namespaces/%s/pods"
 	OPENSTACK_SERVERS_PATH = "/servers"
+	OPENSTACK_FLAVORS_PATH = "/flavors"
+	OPENSTACK_IMAGES_PATH  = "/images"
+
+	TARGET_FLAVORS = "flavors"
+	TARGET_IMAGES  = "images"
 )
 
 type Openstack struct{}
 
 // the url path is /servers/{vmId}
-func getVmFromPath(path string) string {
+func getElementFromPath(path string) string {
 	return strings.Split(path, "/")[2]
+}
+
+func (o Openstack) imageHandler(resp http.ResponseWriter, req *http.Request) {
+	o.genericFunc(TARGET_IMAGES, resp, req)
+}
+
+func (o Openstack) flavorHandler(resp http.ResponseWriter, req *http.Request) {
+	o.genericFunc(TARGET_FLAVORS, resp, req)
+}
+
+func (o Openstack) genericFunc(target string, resp http.ResponseWriter, req *http.Request) {
+	path := req.URL.Path
+	klog.V(4).Infof("URL path: %s", path)
+
+	if req.Method != "GET" {
+		resp.WriteHeader(405) // method not allowed for the current release
+		return
+	}
+
+	var body []byte
+	var err error
+	var f interface{}
+
+	getter := func(name string) (interface{}, error) {
+		switch target {
+		case TARGET_FLAVORS:
+			return openstack.GetFalvor(name)
+		case TARGET_IMAGES:
+			return openstack.GetImage(name)
+		default:
+			return nil, fmt.Errorf("invalid target %s", target)
+		}
+	}
+
+	lister := func() interface{} {
+		switch target {
+		case TARGET_FLAVORS:
+			return openstack.ListFalvors()
+		case TARGET_IMAGES:
+			return openstack.ListImages()
+		default:
+			return nil
+		}
+	}
+
+	if strings.HasSuffix(path, target) {
+		body, err = json.Marshal(lister())
+	} else {
+		name := getElementFromPath(path)
+		f, err = getter(name)
+		if err != nil {
+			klog.Errorf("Invalid %s %s", target, name)
+			resp.WriteHeader(500)
+			return
+		}
+		body, err = json.Marshal(f)
+	}
+
+	if err != nil {
+		klog.Errorf("failed encoding %s, error %v", target, err)
+		resp.WriteHeader(500)
+		return
+	}
+	resp.WriteHeader(200)
+	resp.Write(body)
 }
 
 // TODO: redirect could introduce perf impact to the server, so setup the routes for Openstack requests
 //       in the API installation flow at the api server init state will be a better solution
 func (o Openstack) serverHandler(resp http.ResponseWriter, req *http.Request) {
-	klog.V(4).Infof("handle /servers")
+	klog.V(4).Infof("handle /servers. URL path: %s", req.URL.Path)
 
 	tenant := openstack.GetTenantFromRequest(req)
 	namespace := openstack.GetNamespaceFromRequest(req)
@@ -50,10 +121,10 @@ func (o Openstack) serverHandler(resp http.ResponseWriter, req *http.Request) {
 	redirectUrl := fmt.Sprintf(POD_URL_TEMPLATE, tenant, namespace)
 
 	if openstack.IsActionRequest(req.URL.Path) {
-		redirectUrl += "/" + getVmFromPath(req.URL.Path) + "/action"
+		redirectUrl += "/" + getElementFromPath(req.URL.Path) + "/action"
 	} else if req.Method == "GET" || req.Method == "DELETE" {
 		//Get the VM ID for redirect
-		redirectUrl += "/" + getVmFromPath(req.URL.Path)
+		redirectUrl += "/" + getElementFromPath(req.URL.Path)
 	}
 
 	klog.V(3).Infof("Redirect request to %s", redirectUrl)
@@ -64,4 +135,10 @@ func (o Openstack) serverHandler(resp http.ResponseWriter, req *http.Request) {
 func (o Openstack) Install(c *mux.PathRecorderMux) {
 	c.HandleFunc(OPENSTACK_SERVERS_PATH, o.serverHandler)
 	c.HandlePrefix(OPENSTACK_SERVERS_PATH+"/", http.HandlerFunc(o.serverHandler))
+
+	c.HandleFunc(OPENSTACK_FLAVORS_PATH, o.flavorHandler)
+	c.HandlePrefix(OPENSTACK_FLAVORS_PATH+"/", http.HandlerFunc(o.flavorHandler))
+
+	c.HandleFunc(OPENSTACK_IMAGES_PATH, o.imageHandler)
+	c.HandlePrefix(OPENSTACK_IMAGES_PATH+"/", http.HandlerFunc(o.imageHandler))
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/openstack.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/openstack.go
@@ -46,14 +46,14 @@ func getElementFromPath(path string) string {
 }
 
 func (o Openstack) imageHandler(resp http.ResponseWriter, req *http.Request) {
-	o.genericFunc(TARGET_IMAGES, resp, req)
+	o.genericOpenStackRequestHandler(TARGET_IMAGES, resp, req)
 }
 
 func (o Openstack) flavorHandler(resp http.ResponseWriter, req *http.Request) {
-	o.genericFunc(TARGET_FLAVORS, resp, req)
+	o.genericOpenStackRequestHandler(TARGET_FLAVORS, resp, req)
 }
 
-func (o Openstack) genericFunc(target string, resp http.ResponseWriter, req *http.Request) {
+func (o Openstack) genericOpenStackRequestHandler(target string, resp http.ResponseWriter, req *http.Request) {
 	path := req.URL.Path
 	klog.V(4).Infof("URL path: %s", path)
 
@@ -94,7 +94,7 @@ func (o Openstack) genericFunc(target string, resp http.ResponseWriter, req *htt
 		name := getElementFromPath(path)
 		f, err = getter(name)
 		if err != nil {
-			klog.Errorf("Invalid %s %s", target, name)
+			klog.Infof("Element %s-%s not found", target, name)
 			resp.WriteHeader(http.StatusNotFound)
 			return
 		}

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/flavors.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/flavors.go
@@ -43,7 +43,9 @@ func initFlavorsCache() {
 	flavorList = make([]*FlavorType, len(flavors))
 	i := 0
 	for _, v := range flavors {
-		flavorList[i] = &v
+		temp := v
+		flavorList[i] = &temp
+		i++
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/images.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/images.go
@@ -36,10 +36,12 @@ func initImagesCache() {
 	images["ubuntu-xenial"] = ImageType{1, "ubuntu-xenial", "cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img"}
 	images["cirros-0.5.1"] = ImageType{2, "cirros-0.5.1", "download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img"}
 
-	imageList = make([]*ImageType, len(flavors))
+	imageList = make([]*ImageType, len(images))
 	i := 0
 	for _, v := range images {
-		imageList[i] = &v
+		temp := v
+		imageList[i] = &temp
+		i++
 	}
 }
 


### PR DESCRIPTION
Added /flavors and /images PATH and the GET handlers.

local testing:
```
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# curl http://localhost:8080/images -v | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /images HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Cache-Control: no-cache, private
< Date: Fri, 07 Jan 2022 23:26:48 GMT
< Content-Length: 244
< Content-Type: text/plain; charset=utf-8
< 
{ [244 bytes data]
100   244  100   244    0     0   238k      0 --:--:-- --:--:-- --:--:--  238k
* Connection #0 to host localhost left intact
[
  {
    "Id": 1,
    "Name": "ubuntu-xenial",
    "ImageRef": "cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img"
  },
  {
    "Id": 2,
    "Name": "cirros-0.5.1",
    "ImageRef": "download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img"
  },
  null,
  null,
  null
]
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# curl http://localhost:8080/flavors/m1.tiny -v | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /flavors/m1.tiny HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Cache-Control: no-cache, private
< Date: Fri, 07 Jan 2022 23:27:06 GMT
< Content-Length: 77
< Content-Type: text/plain; charset=utf-8
< 
{ [77 bytes data]
100    77  100    77    0     0  77000      0 --:--:-- --:--:-- --:--:-- 77000
* Connection #0 to host localhost left intact
{
  "Id": 1,
  "Name": "m1.tiny",
  "MemoryMb": 512,
  "Vcpus": 1,
  "RootGb": 0,
  "EphemeralGb": 0
}
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# curl http://localhost:8080/flavors -v | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /flavors HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Cache-Control: no-cache, private
< Date: Fri, 07 Jan 2022 23:27:14 GMT
< Content-Length: 402
< Content-Type: text/plain; charset=utf-8
< 
{ [402 bytes data]
100   402  100   402    0     0   392k      0 --:--:-- --:--:-- --:--:--  392k
* Connection #0 to host localhost left intact
[
  {
    "Id": 1,
    "Name": "m1.tiny",
    "MemoryMb": 512,
    "Vcpus": 1,
    "RootGb": 0,
    "EphemeralGb": 0
  },
  {
    "Id": 2,
    "Name": "m1.small",
    "MemoryMb": 2048,
    "Vcpus": 1,
    "RootGb": 0,
    "EphemeralGb": 0
  },
  {
    "Id": 3,
    "Name": "m1.medium",
    "MemoryMb": 4096,
    "Vcpus": 2,
    "RootGb": 0,
    "EphemeralGb": 0
  },
  {
    "Id": 4,
    "Name": "m1.large",
    "MemoryMb": 8192,
    "Vcpus": 4,
    "RootGb": 0,
    "EphemeralGb": 0
  },
  {
    "Id": 5,
    "Name": "m1.xlarge",
    "MemoryMb": 16384,
    "Vcpus": 8,
    "RootGb": 0,
    "EphemeralGb": 0
  }
]
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# curl http://localhost:8080/images/cirros-0.5.1 -v | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /images/cirros-0.5.1 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Cache-Control: no-cache, private
< Date: Fri, 07 Jan 2022 23:27:24 GMT
< Content-Length: 104
< Content-Type: text/plain; charset=utf-8
< 
{ [104 bytes data]
100   104  100   104    0     0   101k      0 --:--:-- --:--:-- --:--:--  101k
* Connection #0 to host localhost left intact
{
  "Id": 2,
  "Name": "cirros-0.5.1",
  "ImageRef": "download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img"
}
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# 
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# curl http://localhost:8080/images/noimage -v | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /images/noimage HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 500 Internal Server Error
< Cache-Control: no-cache, private
< Date: Fri, 07 Jan 2022 23:30:19 GMT
< Content-Length: 0
< 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Connection #0 to host localhost left intact
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# 
```