### PR TITLE
kube-up scale-out TP starts daemonset controller on second run

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -3375,7 +3375,7 @@ function restart_tp_scheduler_and_controller {
     gcloud compute ssh --ssh-flag="-o LogLevel=quiet" --ssh-flag="-o ConnectTimeout=30" --project "${PROJECT}" --zone="${ZONE}" "${tp_vm}" --command "${cmd}"
 
     echo "DBG: restart controller manager on TP master: ${tp_vm}"
-    cmd="sudo pkill -f kube-controller-manager"
+    cmd="sudo cp /home/kubernetes/kube-manifests/kubernetes/gci-trusty/kube-controller-manager.manifest_2 /etc/kubernetes/manifests/kube-controller-manager.manifest"
     gcloud compute ssh --ssh-flag="-o LogLevel=quiet" --ssh-flag="-o ConnectTimeout=30" --project "${PROJECT}" --zone="${ZONE}" "${tp_vm}" --command "${cmd}"
   done
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR changes the kube-up to start scale-out cluster about the two runs of TP KCM: the first incarnation it only has smaller capability (no deployment/daemonset controller) to enable RP boot up; the second run it has full feature of deployment/daemonset.

The lack of daemonset/deployment of first run can prevent pod being deployed to TP master pre-maturely.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1269

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
