### PR TITLE
register network crd only for kube-up, not for kubemark

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2684,10 +2684,12 @@ function kube-up() {
       done
       restart_tp_scheduler_and_controller
 
-      echo "DBG: defining CRD networks.arktos.futurewei.com at all TPs"
-      for num in $(seq ${SCALEOUT_TP_COUNT:-1}); do
-        "${KUBE_ROOT}/cluster/kubectl.sh" --kubeconfig="cluster/kubeconfig.tp-${num}" apply -f "${KUBE_ROOT}/pkg/controller/artifacts/crd-network.yaml"
-      done
+      if [[ "${PROVISION_MODE:-}" == "kube-up" ]]; then
+        echo "DBG: defining CRD networks.arktos.futurewei.com at all TPs, in kube-up process"
+        for num in $(seq ${SCALEOUT_TP_COUNT:-1}); do
+          "${KUBE_ROOT}/cluster/kubectl.sh" --kubeconfig="cluster/kubeconfig.tp-${num}" apply -f "${KUBE_ROOT}/pkg/controller/artifacts/crd-network.yaml"
+        done
+      fi
     else
       export ARKTOS_SCALEOUT_SERVER_TYPE=""
       create-master

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2684,7 +2684,9 @@ function kube-up() {
       done
       restart_tp_scheduler_and_controller
 
-      if [[ "${PROVISION_MODE:-}" == "kube-up" ]]; then
+      # start-kubemark.sh sets KUBEMARK_PREFIX default to 'kubemark'
+      # we use this env var to tell whether it is for kube-up or kubemark cluster
+      if [[ "${KUBEMARK_PREFIX:-}" == "" ]]; then
         echo "DBG: defining CRD networks.arktos.futurewei.com at all TPs, in kube-up process"
         for num in $(seq ${SCALEOUT_TP_COUNT:-1}); do
           "${KUBE_ROOT}/cluster/kubectl.sh" --kubeconfig="cluster/kubeconfig.tp-${num}" apply -f "${KUBE_ROOT}/pkg/controller/artifacts/crd-network.yaml"

--- a/cluster/kube-up.sh
+++ b/cluster/kube-up.sh
@@ -25,8 +25,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export PROVISION_MODE="kube-up"
-
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 if [ -f "${KUBE_ROOT}/cluster/env.sh" ]; then

--- a/cluster/kube-up.sh
+++ b/cluster/kube-up.sh
@@ -25,6 +25,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+export PROVISION_MODE="kube-up"
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 if [ -f "${KUBE_ROOT}/cluster/env.sh" ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR only registers network CRD at all TPs in kube-up scale-out, not in kubemark scale-out.

There was a regression introduced by #1278, which registers network CRD during scale-out start up process. For perf test, start-kubemark will hit the code and could not find the kubeconfig files named for kube-up scale-out TPs. The fix is NOT to register this CRD for kubemark, as kubemark does not really need such for testing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1280

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
