### PR TITLE
[WIP-DO-NOT-MERGE] Mizar-Arktos 2TP-1RP (nTP-1RP) for system tenant with multitenancy network isolation

### DIFF
--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -124,7 +124,7 @@ function create-dirs {
   if [[ "${KUBERNETES_MASTER:-}" == "false" ]]; then
     mkdir -p /var/lib/kube-proxy
   fi
-  if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]] && [[ "${SCALEOUT_CLUSTER:-false}" == "false" ]]; then
+  if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
     mkdir -p /var/lib/kube-proxy
   fi
 }
@@ -3142,6 +3142,459 @@ function start-cluster-networking {
   esac
 }
 
+function create-mizar-crds-yaml {
+  cat <<EOF >/etc/kubernetes/manifests/mizar-crds.yaml
+# mizar CRD bouncers.mizar.com
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bouncers.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Bouncer
+    plural: bouncers
+    singular: bouncer
+    shortNames:
+      - bncr
+      - bncrs
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: vpc
+          type: string
+          priority: 0
+          jsonPath: .spec.vpc
+          description: The VPC of the divider
+        - name: net
+          type: string
+          priority: 0
+          jsonPath: .spec.net
+          description: The Network of the bouncer
+        - name: Ip
+          type: string
+          priority: 0
+          jsonPath: .spec.ip
+          description: The IP of the droplet
+        - name: Mac
+          type: string
+          priority: 0
+          jsonPath: .spec.mac
+          description: The mac address of the divider's droplet
+        - name: Droplet
+          type: string
+          priority: 0
+          jsonPath: .spec.droplet
+          description: The name of the droplet resource
+        - name: Status
+          type: string
+          priority: 0
+          jsonPath: .spec.status
+          description: The Current Status of the divider
+        - name: CreateTime
+          type: string
+          priority: 0
+          jsonPath: .spec.createtime
+          description: Time the object is created
+        - name: ProvisionDelay
+          type: string
+          priority: 0
+          jsonPath: .spec.provisiondelay
+          description: Time to provision an object from creation
+---
+# mizar CRD dividers.mizar.com
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: dividers.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Divider
+    plural: dividers
+    singular: divider
+    shortNames:
+      - divd
+      - divds
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: vpc
+          type: string
+          priority: 0
+          jsonPath: .spec.vpc
+          description: The VPC of the divider
+        - name: Ip
+          type: string
+          priority: 0
+          jsonPath: .spec.ip
+          description: The IP of the divider's droplet
+        - name: Mac
+          type: string
+          priority: 0
+          jsonPath: .spec.mac
+          description: The mac address of the divider's droplet
+        - name: Droplet
+          type: string
+          priority: 0
+          jsonPath: .spec.droplet
+          description: The name of the droplet resource
+        - name: Status
+          type: string
+          priority: 0
+          jsonPath: .spec.status
+          description: The Current Status of the divider
+        - name: CreateTime
+          type: string
+          priority: 0
+          jsonPath: .spec.createtime
+          description: Time the object is created
+        - name: ProvisionDelay
+          type: string
+          priority: 0
+          jsonPath: .spec.provisiondelay
+          description: Time to provision an object from creation
+---
+# mizar CRD droplets.mizar.com
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: droplets.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Droplet
+    plural: droplets
+    singular: droplet
+    shortNames:
+      - drp
+      - drps
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Mac
+          type: string
+          priority: 0
+          jsonPath: .spec.mac
+          description: The mac address of the endpoint
+        - name: Ip
+          type: string
+          priority: 0
+          jsonPath: .spec.ip
+          description: The IP of the endpoint
+        - name: Status
+          type: string
+          priority: 0
+          jsonPath: .spec.status
+          description: The Current Status of the droplet
+        - name: Interface
+          type: string
+          priority: 0
+          jsonPath: .spec.itf
+          description: The main interface of the droplet
+        - name: CreateTime
+          type: string
+          priority: 0
+          jsonPath: .spec.createtime
+          description: Time the object is created
+        - name: ProvisionDelay
+          type: string
+          priority: 0
+          jsonPath: .spec.provisiondelay
+          description: Time to provision an object from creation
+---
+# mizar CRD endpoints.mizar.com
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: endpoints.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Endpoint
+    plural: endpoints
+    singular: endpoint
+    shortNames:
+      - ep
+      - eps
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          priority: 0
+          jsonPath: .spec.type
+          description: The type of the endpoint
+        - name: Mac
+          type: string
+          priority: 0
+          jsonPath: .spec.mac
+          description: The mac address of the endpoint
+        - name: Ip
+          type: string
+          priority: 0
+          jsonPath: .spec.ip
+          description: The IP of the endpoint
+        - name: Gw
+          type: string
+          priority: 0
+          jsonPath: .spec.gw
+          description: The GW of the endpoint
+        - name: Prefix
+          type: string
+          priority: 0
+          jsonPath: .spec.prefix
+          description: The network prefix of the endpoint
+        - name: Status
+          type: string
+          priority: 0
+          jsonPath: .spec.status
+          description: The Current Provisioning Status of the endpoint
+        - name: Network
+          type: string
+          priority: 0
+          jsonPath: .spec.net
+          description: The network of the endpoint
+        - name: Vpc
+          type: string
+          priority: 0
+          jsonPath: .spec.vpc
+          description: The vpc of the endpoint
+        - name: Vni
+          type: string
+          priority: 0
+          jsonPath: .spec.vni
+          description: The VNI of the VPC
+        - name: Droplet
+          type: string
+          priority: 0
+          jsonPath: .spec.droplet
+          description: The droplet hosting the endpoint
+        - name: Interface
+          type: string
+          priority: 0
+          jsonPath: .spec.itf
+          description: The interface name of the endpoint
+        - name: Veth
+          type: string
+          priority: 0
+          jsonPath: .spec.veth
+          description: The veth peer interface name of the endpoint
+        - name: Netns
+          type: string
+          priority: 0
+          jsonPath: .spec.netns
+          description: The netns of the endpoint
+        - name: HostIp
+          type: string
+          priority: 0
+          jsonPath: .spec.hostip
+          description: The Host IP of the endpoint
+        - name: HostMac
+          type: string
+          priority: 0
+          jsonPath: .spec.hostmac
+          description: The Host MAC of the endpoint
+        - name: CreateTime
+          type: string
+          priority: 0
+          jsonPath: .spec.createtime
+          description: Time the object is created
+        - name: ProvisionDelay
+          type: string
+          priority: 0
+          jsonPath: .spec.provisiondelay
+          description: Time to provision an object from creation
+        - name: CniDelay
+          type: string
+          priority: 0
+          jsonPath: .spec.cnidelay
+          description: Time to setup endpoint on droplet
+        - name: Pod
+          type: string
+          priority: 0
+          jsonPath: .spec.pod
+          description: The pod associated with the endpoint
+---
+# mizar CRD subnets.mizar.com
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: subnets.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Subnet
+    plural: subnets
+    singular: subnet
+    shortNames:
+      - subnet
+      - subnets
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Ip
+          type: string
+          priority: 0
+          jsonPath: .spec.ip
+          description: The IP of the NET CIDR block
+        - name: Prefix
+          type: string
+          priority: 0
+          jsonPath: .spec.prefix
+          description: The prefix of the NET CIDR block
+        - name: Vni
+          type: string
+          priority: 0
+          jsonPath: .spec.vni
+          description: The VNI of the VPC
+        - name: Vpc
+          type: string
+          priority: 0
+          jsonPath: .spec.vpc
+          description: The name of the VPC
+        - name: Status
+          type: string
+          priority: 0
+          jsonPath: .spec.status
+          description: The Current Provisioning Status of the net
+        - name: Bouncers
+          type: integer
+          priority: 0
+          jsonPath: .spec.bouncers
+          description: The number of bouncers of the Net
+        - name: CreateTime
+          type: string
+          priority: 0
+          jsonPath: .spec.createtime
+          description: Time the object is created
+        - name: ProvisionDelay
+          type: string
+          priority: 0
+          jsonPath: .spec.provisiondelay
+          description: Time to provision an object from creation
+---
+# mizar CRD vpcs.mizar.com
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: vpcs.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Vpc
+    plural: vpcs
+    singular: vpc
+    shortNames:
+      - vpc
+      - vpcs
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Ip
+          type: string
+          priority: 0
+          jsonPath: .spec.ip
+          description: The IP of the VPC CIDR block
+        - name: Prefix
+          type: string
+          priority: 0
+          jsonPath: .spec.prefix
+          description: The prefix of the VPC CIDR block
+        - name: Vni
+          type: string
+          priority: 0
+          jsonPath: .spec.vni
+          description: The VNI of the VPC
+        - name: Dividers
+          type: integer
+          priority: 0
+          jsonPath: .spec.dividers
+          description: The number of dividers of the VPC
+        - name: Status
+          type: string
+          priority: 0
+          jsonPath: .spec.status
+          description: The Current Provisioning Status of the net
+        - name: CreateTime
+          type: string
+          priority: 0
+          jsonPath: .spec.createtime
+          description: Time the object is created
+        - name: ProvisionDelay
+          type: string
+          priority: 0
+          jsonPath: .spec.provisiondelay
+          description: Time to provision an object from creation
+EOF
+}
+
 function create-mizar-daemon-manifest {
   cat <<EOF >/etc/kubernetes/manifests/mizar-daemon.yaml
 # mizar daemon set of node agents
@@ -3203,10 +3656,22 @@ spec:
   - name: mizar-operator
     image: mizarnet/endpointopr:${NETWORK_PROVIDER_VERSION}
     env:
+    - name: KUBECONFIG
+      value: "/kubeconf/admin.conf"
+    - name: CLUSTER_VPC_VNI
+      value: "${CLUSTER_VPC_VNI_ID}"
     - name: FEATUREGATE_BWQOS
       value: 'false'
     securityContext:
       privileged: true
+    volumeMounts:
+    - name: kubeconfig
+      mountPath: /kubeconf
+  volumes:
+  - name: kubeconfig
+    hostPath:
+      path: /etc/kubernetes
+      type: Directory
 EOF
 }
 
@@ -3232,21 +3697,99 @@ function wait-until-mizar-ready {
   done
 }
 
+function setup-arktos-mizar-haproxy-conf {
+  cat > /etc/haproxy/haproxy.cfg <<EOF
+global
+	log /dev/log	local0
+	log /dev/log	local1 info
+	chroot /var/lib/haproxy
+	stats socket /run/haproxy/admin.sock mode 660 level admin expose-fd listeners
+	stats timeout 	30s
+	user haproxy
+	group haproxy
+	daemon
+
+defaults
+	log	global
+	mode	http
+	option	httplog
+	option	dontlognull
+	timeout connect	5000
+	timeout client	50000
+	timeout server	50000
+	errorfile 400	/etc/haproxy/errors/400.http
+	errorfile 403	/etc/haproxy/errors/403.http
+	errorfile 408	/etc/haproxy/errors/408.http
+	errorfile 500	/etc/haproxy/errors/500.http
+	errorfile 502	/etc/haproxy/errors/502.http
+	errorfile 503	/etc/haproxy/errors/503.http
+	errorfile 504	/etc/haproxy/errors/504.http
+
+frontend api_router
+	bind *:8090	alpn h2,http/1.1
+
+	acl node_request path_reg			^/api/[a-z0-9_.-]+/nodes.*$
+	acl lease_request path_reg			^/apis/coordination.k8s.io/[a-z0-9_.-]+/leases.*$
+	acl individual_lease_request path_reg		^/apis/[a-z0-9_.-]+/[a-z0-9_.-]+/namespaces/kube-node-lease/leases.*$
+	acl individual_tenant_lease_request path_reg	^/apis/[a-z0-9_.-]+/[a-z0-9_.-]+/tenants/system/namespaces/kube-node-lease/leases.*$
+
+	# Note: the order of backend search rules matters. The first matching rule will be used.
+	use_backend rp_api if node_request OR lease_request OR individual_lease_request OR individual_tenant_lease_request
+	default_backend tp_api
+
+backend tp_api
+	option tcp-check
+	tcp-check connect
+	server tp 127.0.0.1:8080 maxconn 500000
+
+backend rp_api
+	option tcp-check
+	tcp-check connect
+	server rp ${RP_NODE_AGGREGATOR_IP}:8080 maxconn 500000
+EOF
+}
+
+function setup-arktos-mizar-local-admin-conf {
+  cat > /etc/kubernetes/admin.conf <<EOF
+apiVersion: v1
+clusters:
+- cluster:
+    server: http://127.0.0.1:8090
+  name: ${PROJECT_ID}_${CLUSTER_NAME}
+contexts:
+- context:
+    cluster: ${PROJECT_ID}_${CLUSTER_NAME}
+    user: ${PROJECT_ID}_${CLUSTER_NAME}
+  name: ${PROJECT_ID}_${CLUSTER_NAME}
+current-context: ${PROJECT_ID}_${CLUSTER_NAME}
+EOF
+}
+
 function start-mizar-scaleout {
     echo "Installing Mizar for scale-out architecture..."
   if [[ "${ARKTOS_SCALEOUT_SERVER_TYPE:-}" == "rp" ]] || [[ "${ARKTOS_SCALEOUT_SERVER_TYPE:-}" == "node" ]]; then
     create-mizar-daemon-manifest
   fi
   if [[ "${ARKTOS_SCALEOUT_SERVER_TYPE:-}" == "tp" ]]; then
+    systemctl stop haproxy
+    rm -f /etc/haproxy/haproxy.cfg
+    #TODO: This should be IP of node info aggregator instead of a single RP API
+    until [ -f "/etc/srv/kubernetes/kube-scheduler/rp-kubeconfig-1" ]; do
+      sleep 5
+    done
+    RP_NODE_AGGREGATOR_IP=$(cat /etc/srv/kubernetes/kube-scheduler/rp-kubeconfig-1 | grep server | cut -d/ -f3)
+    setup-arktos-mizar-haproxy-conf
+    systemctl start haproxy
+    setup-arktos-mizar-local-admin-conf
+    #kubectl create configmap system-source --namespace=kube-system --from-literal=name=arktos --from-literal=company=futurewei
+    create-mizar-crds-yaml
+    kubectl create -f /etc/kubernetes/manifests/mizar-crds.yaml
+    CLUSTER_VPC_VNI_ID="$(echo ${CLUSTER_NAME} | rev | cut -d- -f1)"
     create-mizar-operator-manifest
   fi
 }
 
 function start-mizar-scaleup {
-  #Wait for apiserver to setup default namespace
-  until kubectl get ns | grep default; do
-    sleep 5
-  done
   echo "Installing Mizar for scale-up architecture..."
   kubectl create configmap system-source --namespace=kube-system --from-literal=name=arktos --from-literal=company=futurewei
   kubectl create -f "${KUBE_HOME}/mizar/deploy.mizar.yaml"
@@ -3255,6 +3798,10 @@ function start-mizar-scaleup {
 
 function start-mizar {
   wait-for-node-registered
+  #Wait for apiserver to setup default namespace
+  until kubectl get ns | grep default; do
+    sleep 5
+  done
   kubectl label node `hostname` node-role.kubernetes.io/master=""
   if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
     start-mizar-scaleout

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -93,7 +93,7 @@ function main() {
     create-master-etcd-apiserver-auth
     override-pv-recycler
     gke-master-start
-    if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]] && [[ "${SCALEOUT_CLUSTER:-false}" == "false" ]]; then
+    if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
       create-kubeproxy-user-kubeconfig
     fi
   else
@@ -135,7 +135,7 @@ function main() {
 
     start-kube-apiserver
     start-kube-controller-manager
-    if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]] && [[ "${SCALEOUT_CLUSTER:-false}" == "false" ]]; then
+    if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
       start-kube-proxy
     fi
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**: 
This change be used to deploy Mizar on 2(or more) TP - 1 RP scale-out cluster with multi-tenancy network isolation. 

This is not the option 1 we decided upon - this does not use Mizar controller in arktos. However this PR can be a scaffolding/platform where parts of this change can potentially be used towards experimenting and implementing option 1. (i.e: Enable mizar controller use, investigate the operator-controller connectivity issues, and get option 1 working)

Note: There's a scheduler bug in Arktos which requires specifying spec.nodeName to get pods to the nodes and come up running.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

```
root@fw0000357:~/go/src/k8s.io/varktos# 
root@fw0000357:~/go/src/k8s.io/varktos# export SCALEOUT_CLUSTER=true NUM_NODES=2 SCALEOUT_TP_COUNT=2 SCALEOUT_RP_COUNT=1 RUN_PREFIX=vinay-mark
root@fw0000357:~/go/src/k8s.io/varktos# export MASTER_DISK_SIZE=500GB MASTER_ROOT_DISK_SIZE=500GB KUBE_GCE_ZONE=us-west2-b MASTER_SIZE=n1-highmem-32 NODE_SIZE=n1-highmem-16 NODE_DISK_SIZE=500GB GOPATH=$HOME/go KUBE_GCE_ENABLE_IP_ALIASES=true KUBE_GCE_PRIVATE_CLUSTER=true CREATE_CUSTOM_NETWORK=true KUBE_GCE_INSTANCE_PREFIX=${RUN_PREFIX} KUBE_GCE_NETWORK=${RUN_PREFIX} ENABLE_KCM_LEADER_ELECT=false ENABLE_SCHEDULER_LEADER_ELECT=false ETCD_QUOTA_BACKEND_BYTES=8589934592 SHARE_PARTITIONSERVER=false LOGROTATE_FILES_MAX_COUNT=200 LOGROTATE_MAX_SIZE=200M KUBE_ENABLE_APISERVER_INSECURE_PORT=true KUBE_ENABLE_PROMETHEUS_DEBUG=true KUBE_ENABLE_PPROF_DEBUG=true TEST_CLUSTER_LOG_LEVEL=--v=2 HOLLOW_KUBELET_TEST_LOG_LEVEL=--v=2 GCE_REGION=us-west2-b
root@fw0000357:~/go/src/k8s.io/varktos#
root@fw0000357:~/go/src/k8s.io/varktos# 
root@fw0000357:~/go/src/k8s.io/varktos# KUBECONFIG=./cluster/kubeconfig-proxy ./cluster/kubectl.sh get no -owide
NAME                                STATUS                     ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP     OS-IMAGE             KERNEL-VERSION    CONTAINER-RUNTIME
vinay-mark-rp-1-master              Ready,SchedulingDisabled   <none>   27m   v0.9.0    10.40.0.4     34.94.21.155    Ubuntu 20.04.3 LTS   5.11.0-1023-gcp   docker://19.3.15
vinay-mark-rp-1-minion-group-rr6h   Ready                      <none>   24m   v0.9.0    10.40.0.5     34.102.83.215   Ubuntu 20.04.3 LTS   5.11.0-1023-gcp   docker://19.3.15
vinay-mark-rp-1-minion-group-vl3f   Ready                      <none>   24m   v0.9.0    10.40.0.6     34.94.118.242   Ubuntu 20.04.3 LTS   5.11.0-1023-gcp   docker://19.3.15
root@fw0000357:~/go/src/k8s.io/varktos# 
root@fw0000357:~/go/src/k8s.io/varktos# KUBECONFIG=./cluster/kubeconfig.tp-1 ./cluster/kubectl.sh get vpcs
NAME   IP         PREFIX   VNI   DIVIDERS   STATUS        CREATETIME                   PROVISIONDELAY
vpc0   20.0.0.0   8        1     1          Provisioned   2022-01-21T03:49:00.432161   81.344043
root@fw0000357:~/go/src/k8s.io/varktos# KUBECONFIG=./cluster/kubeconfig.tp-1 ./cluster/kubectl.sh get subnets
NAME   IP         PREFIX   VNI   VPC    STATUS        BOUNCERS   CREATETIME                   PROVISIONDELAY
net0   20.0.0.0   8        1     vpc0   Provisioned   1          2022-01-21T03:49:00.484290   101.445363
root@fw0000357:~/go/src/k8s.io/varktos# KUBECONFIG=./cluster/kubeconfig.tp-2 ./cluster/kubectl.sh get bouncers
NAME                                          VPC    NET    IP          MAC                 DROPLET                             STATUS        CREATETIME                   PROVISIONDELAY
net0-b-caab30b5-7a76-4725-aed6-31c8dbece2a6   vpc0   net0   10.40.0.5   42:01:0a:28:00:05   vinay-mark-rp-1-minion-group-rr6h   Provisioned   2022-01-21T03:50:36.234530   1.047676
root@fw0000357:~/go/src/k8s.io/varktos# 
root@fw0000357:~/go/src/k8s.io/varktos# KUBECONFIG=./cluster/kubeconfig.tp-1 ./cluster/kubectl.sh get po -owide
NAME                                             HASHKEY               READY   STATUS    RESTARTS   AGE   IP          NODE                                NOMINATED NODE   READINESS GATES
mizar-daemon-vinay-mark-rp-1-minion-group-rr6h   8536270369083156335   1/1     Running   0          24m   10.40.0.5   vinay-mark-rp-1-minion-group-rr6h   <none>           <none>
mizar-daemon-vinay-mark-rp-1-minion-group-vl3f   8536270369083156335   1/1     Running   0          24m   10.40.0.6   vinay-mark-rp-1-minion-group-vl3f   <none>           <none>
mizar-operator-vinay-mark-tp-1-master            4897509646032053362   1/1     Running   0          24m   10.40.0.2   vinay-mark-tp-1-master              <none>           <none>
tp1netpod1                                       3275695436674551567   1/1     Running   0          13m   20.0.0.37   vinay-mark-rp-1-minion-group-vl3f   <none>           <none>
tp1netpod2                                       4016777476037655139   1/1     Running   0          13m   20.0.0.22   vinay-mark-rp-1-minion-group-rr6h   <none>           <none>
root@fw0000357:~/go/src/k8s.io/varktos# 
root@fw0000357:~/go/src/k8s.io/varktos# KUBECONFIG=./cluster/kubeconfig.tp-2 ./cluster/kubectl.sh get vpcs
NAME   IP         PREFIX   VNI   DIVIDERS   STATUS        CREATETIME                   PROVISIONDELAY
vpc0   20.0.0.0   8        2     1          Provisioned   2022-01-21T03:49:14.800005   61.301504
root@fw0000357:~/go/src/k8s.io/varktos# KUBECONFIG=./cluster/kubeconfig.tp-2 ./cluster/kubectl.sh get subnets
NAME   IP         PREFIX   VNI   VPC    STATUS        BOUNCERS   CREATETIME                   PROVISIONDELAY
net0   20.0.0.0   8        2     vpc0   Provisioned   1          2022-01-21T03:49:14.854850   81.388007
root@fw0000357:~/go/src/k8s.io/varktos# KUBECONFIG=./cluster/kubeconfig.tp-2 ./cluster/kubectl.sh get bouncers
NAME                                          VPC    NET    IP          MAC                 DROPLET                             STATUS        CREATETIME                   PROVISIONDELAY
net0-b-caab30b5-7a76-4725-aed6-31c8dbece2a6   vpc0   net0   10.40.0.5   42:01:0a:28:00:05   vinay-mark-rp-1-minion-group-rr6h   Provisioned   2022-01-21T03:50:36.234530   1.047676
root@fw0000357:~/go/src/k8s.io/varktos# 
root@fw0000357:~/go/src/k8s.io/varktos# KUBECONFIG=./cluster/kubeconfig.tp-2 ./cluster/kubectl.sh get po -owide
NAME                                    HASHKEY               READY   STATUS    RESTARTS   AGE   IP          NODE                                NOMINATED NODE   READINESS GATES
mizar-operator-vinay-mark-tp-2-master   2477969793031257862   1/1     Running   0          26m   10.40.0.3   vinay-mark-tp-2-master              <none>           <none>
tp2netpod1                              143645887145061707    1/1     Running   0          58s   20.0.0.18   vinay-mark-rp-1-minion-group-vl3f   <none>           <none>
tp2netpod2                              2650211431551107280   1/1     Running   0          58s   20.0.0.26   vinay-mark-rp-1-minion-group-rr6h   <none>           <none>
root@fw0000357:~/go/src/k8s.io/varktos# 
root@fw0000357:~/go/src/k8s.io/varktos#
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
