### PR TITLE
Bug fix: add pod creation event back to queue when network is not ready

### DIFF
--- a/pkg/controller/mizar/mizar-arktos-network-controller.go
+++ b/pkg/controller/mizar/mizar-arktos-network-controller.go
@@ -182,7 +182,7 @@ func (c *MizarArktosNetworkController) syncNetwork(eventKeyWithType KeyWithEvent
 		return err
 	}
 
-	klog.Infof("Get network: %#v.", net)
+	klog.V(4).Infof("Get network: %#v.", net)
 
 	switch event {
 	case EventType_Create:

--- a/pkg/controller/mizar/mizar-pod-controller.go
+++ b/pkg/controller/mizar/mizar-pod-controller.go
@@ -109,7 +109,7 @@ func (c *MizarPodController) Run(workers int, stopCh <-chan struct{}) {
 	klog.Infof("Starting %v controller", controllerForMizarPod)
 	defer klog.Infof("Shutting down %v controller", controllerForMizarPod)
 
-	if !controller.WaitForCacheSync(controllerForMizarPod, stopCh, c.listerSynced) {
+	if !controller.WaitForCacheSync(controllerForMizarPod, stopCh, c.listerSynced,c.networkListerSynced) {
 		return
 	}
 

--- a/pkg/controller/mizar/mizar-pod-controller.go
+++ b/pkg/controller/mizar/mizar-pod-controller.go
@@ -182,7 +182,7 @@ func (c *MizarPodController) processNextWorkItem() bool {
 func (c *MizarPodController) handle(keyWithEventType KeyWithEventType) error {
 	key := keyWithEventType.Key
 	eventType := keyWithEventType.EventType
-	klog.Infof("Entering handling for %v. key %s, eventType %s", controllerForMizarPod, key, eventType)
+	klog.V(4).Infof("Entering handling for %v. key %s, eventType %s", controllerForMizarPod, key, eventType)
 
 	startTime := time.Now()
 	defer func() {
@@ -219,7 +219,7 @@ func (c *MizarPodController) handle(keyWithEventType KeyWithEventType) error {
 			klog.Warningf("Failed to retrieve network in local cache by tenant %s, name %s: %v", tenant, defaultNetworkName, err)
 			return err
 		}
-		klog.Infof("Get network: %#v.", network)
+		klog.V(4).Infof("Get network: %#v.", network)
 
 		if network.Spec.Type != mizarNetworkType || network.Status.Phase != arktosextv1.NetworkReady {
 			klog.Warningf("The arktos network %s is not mizar type or is not Ready.", network.Name)
@@ -280,7 +280,7 @@ func (c *MizarPodController) handle(keyWithEventType KeyWithEventType) error {
 				klog.Errorf("Pod name (%s) - update pod's annotation to API server in error (%v) when (%v).", obj.Name, err, eventType)
 				return err
 			}
-			klog.Infof("Pod name (%s) - update pod's annotation to API server successfully when (%v).", obj.Name, eventType)
+			klog.V(2).Infof("Pod name (%s) - update pod's annotation to API server successfully when (%v).", obj.Name, eventType)
 
 		}
 	}

--- a/pkg/controller/mizar/mizar-pod-controller.go
+++ b/pkg/controller/mizar/mizar-pod-controller.go
@@ -228,7 +228,10 @@ func (c *MizarPodController) handle(keyWithEventType KeyWithEventType) error {
 		if network.Status.Phase != arktosextv1.NetworkReady {
 			klog.Warningf("The arktos network %s is not Ready.", network.Name)
 			// put key back into queue
-			c.createObj(obj)
+			go func() {
+				time.Sleep(100 * time.Millisecond)	// avoid busy waiting
+				c.createObj(obj)
+			}()
 			return nil
 		}
 		klog.V(4).Infof("Get network %s - VPCID: %s.", network.Name, network.Spec.VPCID)

--- a/pkg/controller/mizar/mizar-service-controller.go
+++ b/pkg/controller/mizar/mizar-service-controller.go
@@ -100,7 +100,7 @@ func (c *MizarServiceController) Run(workers int, stopCh <-chan struct{}) {
 	defer c.queue.ShutDown()
 	klog.Infoln("Starting mizar service controller")
 	klog.Infoln("Waiting cache to be synced.")
-	if ok := cache.WaitForCacheSync(stopCh, c.serviceListerSynced); !ok {
+	if ok := cache.WaitForCacheSync(stopCh, c.serviceListerSynced, c.networkListerSynced); !ok {
 		klog.Fatalln("Timeout expired during waiting for caches to sync.")
 	}
 

--- a/pkg/controller/mizar/mizar-service-controller.go
+++ b/pkg/controller/mizar/mizar-service-controller.go
@@ -192,7 +192,7 @@ func (c *MizarServiceController) syncService(eventKeyWithType KeyWithEventType) 
 		}
 	}
 
-	klog.Infof("Mizar-Service-controller - get service: %#v.", svc)
+	klog.V(4).Infof("Mizar-Service-controller - get service: %#v.", svc)
 
 	switch event {
 	case EventType_Create:


### PR DESCRIPTION
Fix issue https://github.com/CentaurusInfra/arktos/issues/1293.

. Before fix:
```
ubuntu@ip-172-30-0-14:~/go/src/k8s.io/arktos$ ./cluster/kubectl.sh get pods -AT -o wide
TENANT   NAMESPACE     NAME                               HASHKEY               READY   STATUS              RESTARTS   AGE    IP            NODE             NOMINATED NODE   READINESS GATES
aaa      kube-system   coredns-default-65df55d94b-ktptj   8781758764375017681   0/1     ContainerCreating   0          58s    <none>        ip-172-30-0-14   <none>           <none>
system   default       mizar-daemon-dvv86                 8954631230949460177   1/1     Running             0          3m4s   172.30.0.14   ip-172-30-0-14   <none>           <none>
system   default       mizar-operator-5c97f7478d-gdpqb    7393075030848523141   1/1     Running             0          3m7s   172.30.0.14   ip-172-30-0-14   <none>           <none>
system   kube-system   coredns-default-65df55d94b-jq6jm   2477170013707910127   0/1     Running             1          3m7s   21.0.21.5     ip-172-30-0-14   <none>           <none>
system   kube-system   kube-dns-554c5866fc-mc4lh          3627882383812042025   2/3     Running             1          3m7s   21.0.21.2     ip-172-30-0-14   <none>           <none>
system   kube-system   virtlet-wvwwc                      8400159748321755174   3/3     Running             0          3m4s   172.30.0.14   ip-172-30-0-14   <none>           <none>
```

. After fix:
```
ubuntu@ip-172-30-0-14:~/go/src/k8s.io/arktos$ ./cluster/kubectl.sh get pods -AT
TENANT   NAMESPACE     NAME                               HASHKEY               READY   STATUS    RESTARTS   AGE
aaa      kube-system   coredns-default-65df55d94b-4szjs   3406296090117196662   0/1     Running   0          34s
system   default       mizar-daemon-dpqnz                 6232274733376191339   1/1     Running   0          2m9s
system   default       mizar-operator-5c97f7478d-njhfw    7616979122502887935   1/1     Running   0          2m13s
system   kube-system   coredns-default-65df55d94b-qzrk6   8741688014193340115   0/1     Running   0          2m13s
system   kube-system   kube-dns-554c5866fc-g4gfq          6723630275427203182   2/3     Running   0          2m13s
system   kube-system   virtlet-znh8b                      8766091834341508229   3/3     Running   0          2m9s
```