### PR TITLE
Assign pod to default mizar network only when Mizar VPC/subnet annotation is not present in pod

### DIFF
--- a/pkg/controller/mizar/mizar-pod-controller.go
+++ b/pkg/controller/mizar/mizar-pod-controller.go
@@ -209,12 +209,11 @@ func (c *MizarPodController) handle(keyWithEventType KeyWithEventType) error {
 		}
 	}
 
+	//Skip pod when it uses host networking
 	if obj.Spec.HostNetwork {
 		return nil
 	}
 
-	//The annotations of vpc and subnet should not be added into pods
-	//which use host networking
 	if eventType == EventType_Create || eventType == EventType_Update {
 		klog.V(4).Infof("Get hostIP (%s) - podIP(%s)", obj.Status.HostIP, obj.Status.PodIP)
 		network, err := c.networkLister.NetworksWithMultiTenancy(tenant).Get(defaultNetworkName)
@@ -267,7 +266,7 @@ func (c *MizarPodController) handle(keyWithEventType KeyWithEventType) error {
 
 			_, err := c.kubeClient.CoreV1().PodsWithMultiTenancy(obj.Namespace, obj.Tenant).Update(obj)
 			if err != nil {
-				klog.Errorf("Pod %s/%s/%s - update pod's annotation to API server got error (%v)", tenant, namespace, name)
+				klog.Errorf("Pod %s/%s/%s - update pod's annotation to API server got error (%v)", tenant, namespace, name, err)
 				return err
 			}
 			klog.V(4).Infof("Pod %s/%s/%s - update pod's annotation to API server successfully", tenant, namespace, name)


### PR DESCRIPTION
This fix issue https://github.com/CentaurusInfra/arktos/issues/1285

. This change keeps that original implementation that pod created w/o mizar vpc/subnet annotation to be attached to default tenant network.
. It also allows pod created with mizar annotation to be attached to the designated vpc/subnet.
. It is also possible to update mizar annotation so that the pod can be moved across different vpc/subnet - mizar is having issue to support this. see https://github.com/CentaurusInfra/arktos/issues/1286

```
ubuntu@ip-172-30-0-14:~/go/src/k8s.io/arktos$ ./cluster/kubectl.sh get pods -AT -o wide
TENANT   NAMESPACE     NAME                               HASHKEY               READY   STATUS              RESTARTS   AGE   IP            NODE             NOMINATED NODE   READINESS GATES
aaa      default       netpod1-aaa                        3908766484272865849   1/1     Running             0          56m   21.0.21.2     ip-172-30-0-14   <none>           <none>
aaa      default       netpod2-aaa                        5963475252902892960   1/1     Running             0          56m   21.0.21.10    ip-172-30-0-14   <none>           <none>
aaa      kube-system   coredns-default-65df55d94b-bfzf5   5411032390339887240   0/1     CrashLoopBackOff    15         57m   21.0.21.5     ip-172-30-0-14   <none>           <none>
system   default       mizar-daemon-9rdss                 7593643411712881783   1/1     Running             0          60m   172.30.0.14   ip-172-30-0-14   <none>           <none>
system   default       mizar-operator-5c97f7478d-blqvv    7978921042419618136   1/1     Running             0          60m   172.30.0.14   ip-172-30-0-14   <none>           <none>
system   default       netpod1                            1142677440335999305   0/1     ContainerCreating   0          20m   <none>        ip-172-30-0-14   <none>           <none>
system   default       netpod2                            447511401861587042    0/1     ContainerCreating   0          20m   <none>        ip-172-30-0-14   <none>           <none>
system   default       ying-nginx-1                       8821160919168682061   1/1     Running             0          55m   22.0.1.5      ip-172-30-0-14   <none>           <none>
system   default       ying-nginx-2                       7457920908913110836   1/1     Running             0          55m   22.0.1.13     ip-172-30-0-14   <none>           <none>
system   kube-system   coredns-default-65df55d94b-xh9bh   6926818154246951590   0/1     CrashLoopBackOff    16         60m   21.0.21.14    ip-172-30-0-14   <none>           <none>
system   kube-system   kube-dns-554c5866fc-zt5tr          2096958600518597650   1/3     CrashLoopBackOff    44         60m   21.0.21.2     ip-172-30-0-14   <none>           <none>
system   kube-system   virtlet-wtcll                      2852824073873523462   3/3     Running             0          60m   172.30.0.14   ip-172-30-0-14   <none>           <none>

```