### PR TITLE
[kube-up][scale-out]Automatically create default network object (flat or mizar) of for system tenant

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -932,6 +932,16 @@ EOF
 SCHEDULER_TEST_LOG_LEVEL: $(yaml-quote ${SCHEDULER_TEST_LOG_LEVEL})
 EOF
     fi
+    if [ -n "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]; then
+      cat >>$file <<EOF
+DISABLE_NETWORK_SERVICE_SUPPORT: $(yaml-quote ${DISABLE_NETWORK_SERVICE_SUPPORT})
+EOF
+    fi
+    if [ -n "${DISABLE_ADMISSION_PLUGINS:-}" ]; then
+      cat >>$file <<EOF
+DISABLE_ADMISSION_PLUGINS: $(yaml-quote ${DISABLE_ADMISSION_PLUGINS})
+EOF
+    fi
     if [ -n "${INITIAL_ETCD_CLUSTER:-}" ]; then
       cat >>$file <<EOF
 INITIAL_ETCD_CLUSTER: $(yaml-quote ${INITIAL_ETCD_CLUSTER})

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -353,8 +353,9 @@ fi
  # pod is associated to certain network, which has its own DNS service.
  # By default, this feature is enabled in the dev cluster started by this script.
 DISABLE_NETWORK_SERVICE_SUPPORT="${DISABLE_NETWORK_SERVICE_SUPPORT:-}"
-
 DISABLE_ADMISSION_PLUGINS=${DISABLE_ADMISSION_PLUGINS:-""}
+ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/testdata/default-flat-network.tmpl"
+
 # check for network service support flags
 if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
   # kubelet enforces per-network DNS ip in pod
@@ -363,8 +364,6 @@ if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
   # tenant controller automatically creates a default network resource for new tenant
   if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
     ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network.json"
-  else
-    ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/testdata/default-flat-network.tmpl"
   fi
 else # when disabled
   # kube-apiserver not to enforce deployment-network validation

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -349,6 +349,28 @@ if [[ ! -z "${NODE_ACCELERATORS}" ]]; then
     fi
 fi
 
+# Arktos specific network and service support is a feature that each
+ # pod is associated to certain network, which has its own DNS service.
+ # By default, this feature is enabled in the dev cluster started by this script.
+DISABLE_NETWORK_SERVICE_SUPPORT="${DISABLE_NETWORK_SERVICE_SUPPORT:-}"
+
+DISABLE_ADMISSION_PLUGINS=${DISABLE_ADMISSION_PLUGINS:-""}
+# check for network service support flags
+if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
+  # kubelet enforces per-network DNS ip in pod
+  FEATURE_GATES="${FEATURE_GATES},MandatoryArktosNetwork=true"
+
+  # tenant controller automatically creates a default network resource for new tenant
+  if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+    ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network.json"
+  else
+    ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/testdata/default-flat-network.tmpl"
+  fi
+else # when disabled
+  # kube-apiserver not to enforce deployment-network validation
+  DISABLE_ADMISSION_PLUGINS="DeploymentNetwork"
+fi
+
 # Optional: Install cluster DNS.
 # Set CLUSTER_DNS_CORE_DNS to 'false' to install kube-dns instead of CoreDNS.
 CLUSTER_DNS_CORE_DNS="${CLUSTER_DNS_CORE_DNS:-true}"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -364,8 +364,9 @@ fi
  # pod is associated to certain network, which has its own DNS service.
  # By default, this feature is enabled in the dev cluster started by this script.
 DISABLE_NETWORK_SERVICE_SUPPORT="${DISABLE_NETWORK_SERVICE_SUPPORT:-}"
-
 DISABLE_ADMISSION_PLUGINS=${DISABLE_ADMISSION_PLUGINS:-""}
+ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/testdata/default-flat-network.tmpl"
+
 # check for network service support flags
 if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
   # kubelet enforces per-network DNS ip in pod
@@ -374,8 +375,6 @@ if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
   # tenant controller automatically creates a default network resource for new tenant
   if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
     ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network.json"
-  else
-    ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/testdata/default-flat-network.tmpl"
   fi
 else # when disabled
   # kube-apiserver not to enforce deployment-network validation

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -360,6 +360,28 @@ if [[ ! -z "${NODE_ACCELERATORS}" ]]; then
     fi
 fi
 
+# Arktos specific network and service support is a feature that each
+ # pod is associated to certain network, which has its own DNS service.
+ # By default, this feature is enabled in the dev cluster started by this script.
+DISABLE_NETWORK_SERVICE_SUPPORT="${DISABLE_NETWORK_SERVICE_SUPPORT:-}"
+
+DISABLE_ADMISSION_PLUGINS=${DISABLE_ADMISSION_PLUGINS:-""}
+# check for network service support flags
+if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
+  # kubelet enforces per-network DNS ip in pod
+  FEATURE_GATES="${FEATURE_GATES},MandatoryArktosNetwork=true"
+
+  # tenant controller automatically creates a default network resource for new tenant
+  if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+    ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network.json"
+  else
+    ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/testdata/default-flat-network.tmpl"
+  fi
+else # when disabled
+  # kube-apiserver not to enforce deployment-network validation
+  DISABLE_ADMISSION_PLUGINS="DeploymentNetwork"
+fi
+
 # Optional: Install cluster DNS.
 # Set CLUSTER_DNS_CORE_DNS to 'false' to install kube-dns instead of CoreDNS.
 CLUSTER_DNS_CORE_DNS="${CLUSTER_DNS_CORE_DNS:-true}"

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -2358,9 +2358,9 @@ function start-kube-controller-manager {
   if [[ -n "${RUN_CONTROLLERS:-}" ]]; then
     params+=" --controllers=${RUN_CONTROLLERS}"
   fi
-  if [[ -s "${KUBE_HOME}/network.tmpl" && -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
-    params+=" --default-network-template-path=${KUBE_HOME}/network.tmpl"
-   fi
+  if [[ -s ${DEFAULT_NETWORK_TEMPLATE} && -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
+    params+=" --default-network-template-path=$DEFAULT_NETWORK_TEMPLATE"
+  fi
 
   if [[ "${ARKTOS_SCALEOUT_SERVER_TYPE:-}" == "rp" ]]; then
     echo "DBG:Set tenant-server-kubeconfig parameters:  ${TENANT_SERVER_KUBECONFIGS}"
@@ -3388,10 +3388,15 @@ EOF
 }
 
 function create-default-network-template-volume-mount {
-  if [[ -s "${KUBE_HOME}/network.tmpl" ]]; then
-    DEFAULT_NETWORK_TEMPLATE_PATH_VOLUME="{\"name\": \"defaulttemplate\",\"hostPath\": {\"path\": \"${KUBE_HOME}/network.tmpl\", \"type\": \"File\"}},"
-    DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT="{\"name\": \"defaulttemplate\",\"mountPath\": \"${KUBE_HOME}/network.tmpl\", \"readOnly\": false},"
+  if [[ -z "${DEFAULT_NETWORK_TEMPLATE:-}" ]]; then
+    echo "DEFAULT_NETWORK_TEMPLATE is not set"
+    exit 1
   fi
+
+  DEFAULT_NETWORK_TEMPLATE_PATH_VOLUME="{\"name\": \"defaulttemplate\",\"hostPath\": {\"path\": \"${DEFAULT_NETWORK_TEMPLATE}\", \"type\": \"File\"}},"
+  DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT="{\"name\": \"defaulttemplate\",\"mountPath\": \"${DEFAULT_NETWORK_TEMPLATE}\", \"readOnly\": false},"
+
+  cat > ${DEFAULT_NETWORK_TEMPLATE} < ${KUBE_HOME}/network.tmpl
 }
 
 function wait-till-apiserver-ready() {

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -2358,7 +2358,7 @@ function start-kube-controller-manager {
   if [[ -n "${RUN_CONTROLLERS:-}" ]]; then
     params+=" --controllers=${RUN_CONTROLLERS}"
   fi
-  if [[ -n "${KUBE_HOME}/network.tmpl" -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
+  if [[ -n "${KUBE_HOME}/network.tmpl" && -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
     params+=" --default-network-template-path=${KUBE_HOME}/network.tmpl"
    fi
 

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -3388,10 +3388,8 @@ EOF
 }
 
 function create-default-network-template-volume-mount {
-  if [[ -n "${KUBE_HOME}/network.tmpl" ]]; then
     DEFAULT_NETWORK_TEMPLATE_PATH_VOLUME="{\"name\": \"defaulttemplate\",\"hostPath\": {\"path\": \"${KUBE_HOME}/network.tmpl\", \"type\": \"File\"}},"
     DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT="{\"name\": \"defaulttemplate\",\"mountPath\": \"${KUBE_HOME}/network.tmpl\", \"readOnly\": false},"
-  fi
 }
 
 function wait-till-apiserver-ready() {

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -2358,10 +2358,9 @@ function start-kube-controller-manager {
   if [[ -n "${RUN_CONTROLLERS:-}" ]]; then
     params+=" --controllers=${RUN_CONTROLLERS}"
   fi
-
-  if [[ -n "${DEFAULT_NETWORK_TEMPLATE:-}" && -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
-    params+=" --default-network-template-path=$DEFAULT_NETWORK_TEMPLATE"
-  fi
+  if [[ -n "${KUBE_HOME}/network.tmpl" -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
+    params+=" --default-network-template-path=${KUBE_HOME}/network.tmpl"
+   fi
 
   if [[ "${ARKTOS_SCALEOUT_SERVER_TYPE:-}" == "rp" ]]; then
     echo "DBG:Set tenant-server-kubeconfig parameters:  ${TENANT_SERVER_KUBECONFIGS}"
@@ -3389,15 +3388,10 @@ EOF
 }
 
 function create-default-network-template-volume-mount {
-  if [[ -z "${DEFAULT_NETWORK_TEMPLATE:-}" ]]; then
-    echo "DEFAULT_NETWORK_TEMPLATE is not set"
-    exit 1
+  if [[ -n "${KUBE_HOME}/network.tmpl" ]]; then
+    DEFAULT_NETWORK_TEMPLATE_PATH_VOLUME="{\"name\": \"defaulttemplate\",\"hostPath\": {\"path\": \"${KUBE_HOME}/network.tmpl\", \"type\": \"File\"}},"
+    DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT="{\"name\": \"defaulttemplate\",\"mountPath\": \"${KUBE_HOME}/network.tmpl\", \"readOnly\": false},"
   fi
-
-  DEFAULT_NETWORK_TEMPLATE_PATH_VOLUME="{\"name\": \"defaulttemplate\",\"hostPath\": {\"path\": \"${DEFAULT_NETWORK_TEMPLATE}\", \"type\": \"File\"}},"
-  DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT="{\"name\": \"defaulttemplate\",\"mountPath\": \"${DEFAULT_NETWORK_TEMPLATE}\", \"readOnly\": false},"
-
-  cat > ${DEFAULT_NETWORK_TEMPLATE} < ${KUBE_HOME}/network.tmpl
 }
 
 function wait-till-apiserver-ready() {

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -3359,7 +3359,7 @@ function override-pv-recycler {
     exit 1
   fi
 
-  PV_RECYCLER_VOLUME="{\"name\": \"pv-recycler-mount\",\"hostPath\": {\"path\": \"${PV_RECYCLER_OVERRIDE_TEMPLATE}\", \"type\": \"FileOrCreate\"}},"
+  PV_RECYCLER_VOLUME="{\"name\": \"pv-recycler-mount\",\"hostPath\": {\"path\": \"${PV_RECYCLER_OVERRIDE_TEMPLATE}\", \"type\": \"File\"}},"
   PV_RECYCLER_MOUNT="{\"name\": \"pv-recycler-mount\",\"mountPath\": \"${PV_RECYCLER_OVERRIDE_TEMPLATE}\", \"readOnly\": true},"
 
   cat > ${PV_RECYCLER_OVERRIDE_TEMPLATE} <<EOF

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -2358,7 +2358,7 @@ function start-kube-controller-manager {
   if [[ -n "${RUN_CONTROLLERS:-}" ]]; then
     params+=" --controllers=${RUN_CONTROLLERS}"
   fi
-  if [[ -n "${KUBE_HOME}/network.tmpl" && -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
+  if [[ -s "${KUBE_HOME}/network.tmpl" && -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
     params+=" --default-network-template-path=${KUBE_HOME}/network.tmpl"
    fi
 
@@ -3359,7 +3359,7 @@ function override-pv-recycler {
     exit 1
   fi
 
-  PV_RECYCLER_VOLUME="{\"name\": \"pv-recycler-mount\",\"hostPath\": {\"path\": \"${PV_RECYCLER_OVERRIDE_TEMPLATE}\", \"type\": \"File\"}},"
+  PV_RECYCLER_VOLUME="{\"name\": \"pv-recycler-mount\",\"hostPath\": {\"path\": \"${PV_RECYCLER_OVERRIDE_TEMPLATE}\", \"type\": \"FileOrCreate\"}},"
   PV_RECYCLER_MOUNT="{\"name\": \"pv-recycler-mount\",\"mountPath\": \"${PV_RECYCLER_OVERRIDE_TEMPLATE}\", \"readOnly\": true},"
 
   cat > ${PV_RECYCLER_OVERRIDE_TEMPLATE} <<EOF
@@ -3388,8 +3388,10 @@ EOF
 }
 
 function create-default-network-template-volume-mount {
+  if [[ -s "${KUBE_HOME}/network.tmpl" ]]; then
     DEFAULT_NETWORK_TEMPLATE_PATH_VOLUME="{\"name\": \"defaulttemplate\",\"hostPath\": {\"path\": \"${KUBE_HOME}/network.tmpl\", \"type\": \"File\"}},"
     DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT="{\"name\": \"defaulttemplate\",\"mountPath\": \"${KUBE_HOME}/network.tmpl\", \"readOnly\": false},"
+  fi
 }
 
 function wait-till-apiserver-ready() {

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -2359,7 +2359,7 @@ function start-kube-controller-manager {
     params+=" --controllers=${RUN_CONTROLLERS}"
   fi
 
-  if [[ -n "${DEFAULT_NETWORK_TEMPLATE:-}" -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
+  if [[ -n "${DEFAULT_NETWORK_TEMPLATE:-}" && -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
     params+=" --default-network-template-path=$DEFAULT_NETWORK_TEMPLATE"
   fi
 
@@ -2390,8 +2390,8 @@ function start-kube-controller-manager {
   sed -i -e "s@{{additional_cloud_config_volume}}@@g" "${src_file}"
   sed -i -e "s@{{pv_recycler_mount}}@${PV_RECYCLER_MOUNT}@g" "${src_file}"
   sed -i -e "s@{{pv_recycler_volume}}@${PV_RECYCLER_VOLUME}@g" "${src_file}"
-  sed -i -e "s@{{default_network_template_path_mount}}@${DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT}@g" "${src_file}"
-  sed -i -e "s@{{default_network_template_path_volume}}@${DEFAULT_NETWORK_TEMPLATE_PATH_VOLUME}@g" "${src_file}"
+  sed -i -e "s@{{defaulttemplate_hostpath_mount}}@${DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT}@g" "${src_file}"
+  sed -i -e "s@{{defaulttemplate_hostpath}}@${DEFAULT_NETWORK_TEMPLATE_PATH_VOLUME}@g" "${src_file}"
   sed -i -e "s@{{flexvolume_hostpath_mount}}@${FLEXVOLUME_HOSTPATH_MOUNT}@g" "${src_file}"
   sed -i -e "s@{{flexvolume_hostpath}}@${FLEXVOLUME_HOSTPATH_VOLUME}@g" "${src_file}"
   sed -i -e "s@{{cpurequest}}@${KUBE_CONTROLLER_MANAGER_CPU_REQUEST}@g" "${src_file}"
@@ -3394,8 +3394,8 @@ function create-default-network-template-volume-mount {
     exit 1
   fi
 
-  DEFAULT_NETWORK_TEMPLATE_PATH_VOLUME="{\"name\": \"default_network_template_path_mount\",\"hostPath\": {\"path\": \"${DEFAULT_NETWORK_TEMPLATE}\", \"type\": \"FileOrCreate\"}},"
-  DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT="{\"name\": \"default_network_template_path_mount\",\"mountPath\": \"${DEFAULT_NETWORK_TEMPLATE}\", \"readOnly\": true},"
+  DEFAULT_NETWORK_TEMPLATE_PATH_VOLUME="{\"name\": \"defaulttemplate\",\"hostPath\": {\"path\": \"${DEFAULT_NETWORK_TEMPLATE}\", \"type\": \"File\"}},"
+  DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT="{\"name\": \"defaulttemplate\",\"mountPath\": \"${DEFAULT_NETWORK_TEMPLATE}\", \"readOnly\": false},"
 
   cat > ${DEFAULT_NETWORK_TEMPLATE} < ${KUBE_HOME}/network.tmpl
 }

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -51,6 +51,7 @@ function main() {
   KUBE_HOME="/home/kubernetes"
   CONTAINERIZED_MOUNTER_HOME="${KUBE_HOME}/containerized_mounter"
   PV_RECYCLER_OVERRIDE_TEMPLATE="${KUBE_HOME}/kube-manifests/kubernetes/pv-recycler-template.yaml"
+  DEFAULT_NETWORK_TEMPLATE="${KUBE_HOME}/kube-manifests/kubernetes/default-network.tmpl"
 
   if [[ ! -e "${KUBE_HOME}/kube-env" ]]; then
     echo "The ${KUBE_HOME}/kube-env file does not exist!! Terminate cluster initialization."
@@ -92,6 +93,7 @@ function main() {
     create-master-etcd-auth
     create-master-etcd-apiserver-auth
     override-pv-recycler
+    create-default-network-template-volume-mount
     gke-master-start
     if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]] && [[ "${SCALEOUT_CLUSTER:-false}" == "false" ]]; then
       create-kubeproxy-user-kubeconfig

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -51,6 +51,7 @@ function main() {
   KUBE_HOME="/home/kubernetes"
   CONTAINERIZED_MOUNTER_HOME="${KUBE_HOME}/containerized_mounter"
   PV_RECYCLER_OVERRIDE_TEMPLATE="${KUBE_HOME}/kube-manifests/kubernetes/pv-recycler-template.yaml"
+  DEFAULT_NETWORK_TEMPLATE="${KUBE_HOME}/kube-manifests/kubernetes/default-network.tmpl"
 
   if [[ ! -e "${KUBE_HOME}/kube-env" ]]; then
     echo "The ${KUBE_HOME}/kube-env file does not exist!! Terminate cluster initialization."

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -51,7 +51,6 @@ function main() {
   KUBE_HOME="/home/kubernetes"
   CONTAINERIZED_MOUNTER_HOME="${KUBE_HOME}/containerized_mounter"
   PV_RECYCLER_OVERRIDE_TEMPLATE="${KUBE_HOME}/kube-manifests/kubernetes/pv-recycler-template.yaml"
-  DEFAULT_NETWORK_TEMPLATE="${KUBE_HOME}/kube-manifests/kubernetes/default-network.tmpl"
 
   if [[ ! -e "${KUBE_HOME}/kube-env" ]]; then
     echo "The ${KUBE_HOME}/kube-env file does not exist!! Terminate cluster initialization."

--- a/cluster/gce/gci/master-helper.sh
+++ b/cluster/gce/gci/master-helper.sh
@@ -85,6 +85,7 @@ function replicate-master-instance() {
   get-metadata "${existing_master_zone}" "${existing_master_name}" kube-master-certs > "${KUBE_TEMP}/kube-master-certs.yaml"
   get-metadata "${existing_master_zone}" "${existing_master_name}" cluster-location > "${KUBE_TEMP}/cluster-location.txt"
   get-metadata "${existing_master_zone}" "${existing_master_name}" controllerconfig > "${KUBE_TEMP}/controllerconfig.json"
+  get-metadata "${existing_master_zone}" "${existing_master_name}" networktemplate > "${KUBE_TEMP}/network.tmpl"
 
   create-master-instance-internal "${REPLICA_NAME}"
 }
@@ -135,6 +136,7 @@ function create-master-instance-internal() {
   metadata="${metadata},kube-master-certs=${KUBE_TEMP}/kube-master-certs.yaml"
   metadata="${metadata},cluster-location=${KUBE_TEMP}/cluster-location.txt"
   metadata="${metadata},controllerconfig=${KUBE_TEMP}/controllerconfig.json"
+  metadata="${metadata},networktemplate=${KUBE_TEMP}/network.tmpl"
   metadata="${metadata},${MASTER_EXTRA_METADATA}"
 
   local disk="name=${master_name}-pd"

--- a/cluster/gce/gci/scaleoutserver-helper.sh
+++ b/cluster/gce/gci/scaleoutserver-helper.sh
@@ -160,6 +160,7 @@ function create-scaleoutserver-instance-internal() {
   metadata="${metadata},kube-master-certs=${KUBE_TEMP}/kube-master-certs.yaml"
   metadata="${metadata},cluster-location=${KUBE_TEMP}/cluster-location.txt"
   metadata="${metadata},controllerconfig=${KUBE_TEMP}/controllerconfig.json"
+  metadata="${metadata},networktemplate=${KUBE_TEMP}/network.tmpl"
   metadata="${metadata},${MASTER_EXTRA_METADATA}"
 
   local disk="name=${server_name}-pd"

--- a/cluster/gce/manifests/kube-controller-manager.manifest
+++ b/cluster/gce/manifests/kube-controller-manager.manifest
@@ -43,7 +43,6 @@
         {{cloud_config_mount}}
         {{additional_cloud_config_mount}}
         {{pv_recycler_mount}}
-        {{default_network_template_path_mount}}
         { "name": "srvkube",
         "mountPath": "/etc/srv/kubernetes",
         "readOnly": true},
@@ -51,6 +50,7 @@
         { "name": "logfile",
         "mountPath": "/var/log/kube-controller-manager.log",
         "readOnly": false},
+        {{defaulttemplate_hostpath_mount}}
         { "name": "etcssl",
         "mountPath": "/etc/ssl",
         "readOnly": true},
@@ -73,7 +73,6 @@
   {{cloud_config_volume}}
   {{additional_cloud_config_volume}}
   {{pv_recycler_volume}}
-  {{default_network_template_path_volume}}
   { "name": "srvkube",
     "hostPath": {
         "path": "/etc/srv/kubernetes"}
@@ -84,6 +83,7 @@
         "path": "/var/log/kube-controller-manager.log",
         "type": "FileOrCreate"}
   },
+  {{defaulttemplate_hostpath}}
   { "name": "etcssl",
     "hostPath": {
         "path": "/etc/ssl"}

--- a/cluster/gce/manifests/kube-controller-manager.manifest
+++ b/cluster/gce/manifests/kube-controller-manager.manifest
@@ -43,6 +43,7 @@
         {{cloud_config_mount}}
         {{additional_cloud_config_mount}}
         {{pv_recycler_mount}}
+        {{default_network_template_path_mount}}
         { "name": "srvkube",
         "mountPath": "/etc/srv/kubernetes",
         "readOnly": true},
@@ -72,6 +73,7 @@
   {{cloud_config_volume}}
   {{additional_cloud_config_volume}}
   {{pv_recycler_volume}}
+  {{default_network_template_path_volume}}
   { "name": "srvkube",
     "hostPath": {
         "path": "/etc/srv/kubernetes"}

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -22,7 +22,7 @@
 readonly GCE_MAX_LOCAL_SSD=8
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
-source "${KUBE_ROOT}/cluster/gce/${KUBE_CONFIG_FILE-"config-default.sh"}"
+source "${KUBE_ROOT}/cluster/gce/${KUBE_CONFIG_FILE:-"config-default.sh"}"
 source "${KUBE_ROOT}/cluster/common.sh"
 source "${KUBE_ROOT}/hack/lib/util.sh"
 source "${KUBE_ROOT}/hack/lib/etcd.sh"
@@ -665,7 +665,9 @@ fi
 # copy controller config into a temporary file.
 # Assumed vars
 function write-network-template {
-  if [[ -n "${ARKTOS_NETWORK_TEMPLATE:-}" ]]; then
+  ARKTOS_NETWORK_TEMPLATE="${ARKTOS_NETWORK_TEMPLATE:-}"
+
+  if [[ -s ${ARKTOS_NETWORK_TEMPLATE} ]]; then
     cp "${ARKTOS_NETWORK_TEMPLATE}" "${KUBE_TEMP}/network.tmpl"
   fi
 }

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -665,9 +665,7 @@ fi
 # copy controller config into a temporary file.
 # Assumed vars
 function write-network-template {
-  ARKTOS_NETWORK_TEMPLATE="${ARKTOS_NETWORK_TEMPLATE:-}"
-
-  if [[ -n ${ARKTOS_NETWORK_TEMPLATE} ]]; then
+  if [[ -n "${ARKTOS_NETWORK_TEMPLATE:-}" ]]; then
     cp "${ARKTOS_NETWORK_TEMPLATE}" "${KUBE_TEMP}/network.tmpl"
   fi
 }

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -662,6 +662,28 @@ EOF
 fi
 }
 
+# copy controller config into a temporary file.
+# Assumed vars
+function write-network-template {
+  ARKTOS_NETWORK_TEMPLATE="${ARKTOS_NETWORK_TEMPLATE:-}"
+
+  if [[ ! -z ${ARKTOS_NETWORK_TEMPLATE} && -n ${ARKTOS_NETWORK_TEMPLATE} ]]; then
+  #if [[ -f ${ARKTOS_NETWORK_TEMPLATE} ]]; then
+    cp "${ARKTOS_NETWORK_TEMPLATE}" "${KUBE_TEMP}/network.tmpl"
+  else
+    cat <<EOF >${KUBE_TEMP}/network.tmpl
+{
+    "metadata": {
+        "name": "default"
+    },
+    "spec": {
+        "type": "flat"
+    }
+}
+EOF
+fi
+}
+
 # Writes the cluster name into a temporary file.
 # Assumed vars
 #   CLUSTER_NAME
@@ -1599,6 +1621,16 @@ EOF
     if [ -n "${SCHEDULER_TEST_LOG_LEVEL:-}" ]; then
       cat >>$file <<EOF
 SCHEDULER_TEST_LOG_LEVEL: $(yaml-quote ${SCHEDULER_TEST_LOG_LEVEL})
+EOF
+    fi
+    if [ -n "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]; then
+      cat >>$file <<EOF
+DISABLE_NETWORK_SERVICE_SUPPORT: $(yaml-quote ${DISABLE_NETWORK_SERVICE_SUPPORT})
+EOF
+    fi
+    if [ -n "${DISABLE_ADMISSION_PLUGINS:-}" ]; then
+      cat >>$file <<EOF
+DISABLE_ADMISSION_PLUGINS: $(yaml-quote ${DISABLE_ADMISSION_PLUGINS})
 EOF
     fi
     if [ -n "${INITIAL_ETCD_CLUSTER:-}" ]; then
@@ -2611,6 +2643,7 @@ function kube-up() {
     write-cluster-location
     write-cluster-name
     write-controller-config
+    write-network-template
     create-autoscaler-config
     if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
       echo "DBG: Generating shared CA certificates"
@@ -2706,6 +2739,8 @@ function kube-up() {
       check-cluster
       validate-cluster-status
       create-node-port
+      # create arktos network crd for scale-up
+      "${KUBE_ROOT}/cluster/kubectl.sh" --kubeconfig="$HOME/.kube/config" apply -f "${KUBE_ROOT}/pkg/controller/artifacts/crd-network.yaml"
     fi
   fi
 }

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -667,8 +667,7 @@ fi
 function write-network-template {
   ARKTOS_NETWORK_TEMPLATE="${ARKTOS_NETWORK_TEMPLATE:-}"
 
-  if [[ ! -z ${ARKTOS_NETWORK_TEMPLATE} && -n ${ARKTOS_NETWORK_TEMPLATE} ]]; then
-  #if [[ -f ${ARKTOS_NETWORK_TEMPLATE} ]]; then
+  if [[ -n ${ARKTOS_NETWORK_TEMPLATE} ]]; then
     cp "${ARKTOS_NETWORK_TEMPLATE}" "${KUBE_TEMP}/network.tmpl"
   else
     cat <<EOF >${KUBE_TEMP}/network.tmpl

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -669,18 +669,7 @@ function write-network-template {
 
   if [[ -n ${ARKTOS_NETWORK_TEMPLATE} ]]; then
     cp "${ARKTOS_NETWORK_TEMPLATE}" "${KUBE_TEMP}/network.tmpl"
-  else
-    cat <<EOF >${KUBE_TEMP}/network.tmpl
-{
-    "metadata": {
-        "name": "default"
-    },
-    "spec": {
-        "type": "flat"
-    }
-}
-EOF
-fi
+  fi
 }
 
 # Writes the cluster name into a temporary file.
@@ -2738,6 +2727,8 @@ function kube-up() {
       check-cluster
       validate-cluster-status
       create-node-port
+      # create arktos network crd for scale-up
+      "${KUBE_ROOT}/cluster/kubectl.sh" --kubeconfig="$HOME/.kube/config" apply -f "${KUBE_ROOT}/pkg/controller/artifacts/crd-network.yaml"
     fi
   fi
 }

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2738,8 +2738,6 @@ function kube-up() {
       check-cluster
       validate-cluster-status
       create-node-port
-      # create arktos network crd for scale-up
-      "${KUBE_ROOT}/cluster/kubectl.sh" --kubeconfig="$HOME/.kube/config" apply -f "${KUBE_ROOT}/pkg/controller/artifacts/crd-network.yaml"
     fi
   fi
 }

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -218,14 +218,14 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 			rbacv1helpers.NewRule("get", "list", "delete", "deletecollection").Groups("*").Resources("*").RuleOrDie(),
 		},
 	})
-	/* This is a too braod authorization - need to revisit. For now, just disable since this controller is not used
 	addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "mizar-service-controller"},
 		Rules: []rbacv1.PolicyRule{
-			rbacv1helpers.NewRule("*").Groups("*").Resources("*").RuleOrDie(),
-			eventsRule(),
+			rbacv1helpers.NewRule("get", "list", "update", "watch").Groups(legacyGroup).Resources("services").RuleOrDie(),
+			rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("endpoints").RuleOrDie(),
+			rbacv1helpers.NewRule("get").Groups("arktos.futurewei.com").Resources("networks").RuleOrDie(),
 		},
-	})*/
+	})
 	addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "node-controller"},
 		Rules: []rbacv1.PolicyRule{

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/BUILD
@@ -46,5 +46,5 @@ go_test(
         "types_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library"],
+    deps = ["//vendor/k8s.io/klog:go_default_library"],
 )

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/flavors.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/flavors.go
@@ -21,6 +21,8 @@ import "fmt"
 var flavors = map[string]FlavorType{}
 var flavorList = []*FlavorType{}
 
+var ERROR_FLAVOR_NOT_FOUND = fmt.Errorf("flavor not found")
+
 // slim down version of the openstack flavor data structure
 type FlavorType struct {
 	Id          int
@@ -54,7 +56,7 @@ func GetFalvor(name string) (*FlavorType, error) {
 		return &flavor, nil
 	}
 
-	return nil, fmt.Errorf("flavor %s, not found", name)
+	return nil, ERROR_FLAVOR_NOT_FOUND
 }
 
 func ListFalvors() []*FlavorType {

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/images.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/images.go
@@ -20,6 +20,7 @@ import "fmt"
 
 var images = map[string]ImageType{}
 var imageList = []*ImageType{}
+var ERROR_IMAGE_NOT_FOUND = fmt.Errorf("image not found")
 
 // Arktos doesn't have its own image registry
 // this is simulate the read-only image service to get test images for VM
@@ -50,7 +51,7 @@ func GetImage(name string) (*ImageType, error) {
 		return &image, nil
 	}
 
-	return nil, fmt.Errorf("image %s, not found", name)
+	return nil, ERROR_IMAGE_NOT_FOUND
 }
 
 func ListImages() []*ImageType {

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/openstackutils.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/openstackutils.go
@@ -26,7 +26,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/apis/apps"
@@ -39,6 +38,7 @@ const (
 	RESTORE  = "restore"
 )
 
+var ERROR_UNKNOWN_ACTION = fmt.Errorf("unknown action")
 var supportedActions = []string{REBOOT, SNAPSHOT, RESTORE}
 
 // init function initialize the VM flavor and image cache
@@ -51,180 +51,6 @@ func init() {
 
 	il := ListImages()
 	klog.V(6).Infof("built-in images: %v", il)
-}
-
-type Network struct {
-	Uuid     string `json:"uuid"`
-	Port     string `json:"port"`
-	Fixed_ip string `json:"fixed_ip"`
-}
-
-type MetadataType struct {
-	key   string
-	value string
-}
-
-type SecurityGroup struct {
-	name string
-}
-
-type LinkType struct {
-	Link string
-	Rel  string
-}
-
-type ServerType struct {
-	Name            string          `json:"name"`
-	ImageRef        string          `json:"imageRef"`
-	Flavor          string          `json:"flavorRef"`
-	Networks        []Network       `json:"networks"`
-	Security_groups []SecurityGroup `json:"security_groups"`
-	Key_name        string          `json:"key_name"`
-	Metadata        MetadataType    `json:"metadata"`
-	User_data       string          `json:"user_data"`
-}
-
-// VM creation request in Openstack
-// non-zero possitive Min or max count indicates batch creation, even if it is one
-// Return_Reservation_Id indicates response behavior, true to return the reservationID ( replicset name in Arktos )
-// So that the client can list the servers associated with this replicaset
-type OpenstackServerRequest struct {
-	Server                ServerType `json:"server"`
-	Min_count             int        `json:"min_count"`
-	Max_count             int        `json:"max_count"`
-	Return_Reservation_Id bool       `json:"return_reservation_id"`
-}
-
-// VM creation response in Openstack
-type OpenstackResponse struct {
-	Id              string
-	Links           []LinkType
-	Security_groups []SecurityGroup
-}
-
-func (o *OpenstackResponse) GetObjectKind() schema.ObjectKind {
-	return schema.OpenstackObjectKind
-}
-
-func (o *OpenstackResponse) DeepCopyObject() runtime.Object {
-	return o
-}
-
-type OpenstackServerListRequest struct {
-	Reservation_Id string `json:"reservation_id"`
-}
-
-// VM list response
-type OpenstackServerListResponse struct {
-	Servers []OpenstackResponse
-}
-
-func (o *OpenstackServerListResponse) GetObjectKind() schema.ObjectKind {
-	return schema.OpenstackObjectKind
-}
-
-func (o *OpenstackServerListResponse) DeepCopyObject() runtime.Object {
-	return o
-}
-
-// VM Batch creation response in Openstack
-type OpenstackBatchResponse struct {
-	Reservation_Id string `json:"reservation_id"`
-}
-
-func (o *OpenstackBatchResponse) GetObjectKind() schema.ObjectKind {
-	return schema.OpenstackObjectKind
-}
-
-func (o *OpenstackBatchResponse) DeepCopyObject() runtime.Object {
-	return o
-}
-
-type ArktosRebootParams struct {
-	DelayInSeconds int `json:"delayInSeconds"`
-}
-
-// Reboot action support
-//
-type ArktosReboot struct {
-	ApiVersion   string             `json:"apiVersion"`
-	Kind         string             `json:"kind"`
-	Operation    string             `json:"operation"`
-	RebootParams ArktosRebootParams `json:"rebootParams"`
-}
-
-// Snapshot action support
-//
-type ArktosSnapshotParams struct {
-	SnapshotName string `json:"snapshotName"`
-}
-type ArktosSnapshot struct {
-	ApiVersion     string               `json:"apiVersion"`
-	Kind           string               `json:"kind"`
-	Operation      string               `json:"operation"`
-	SnapshotParams ArktosSnapshotParams `json:"snapshotParams"`
-}
-
-// Openstack createImage action match to the Arktos snapshot action
-type OpenstackCreateImage struct {
-	Name     string
-	Metadata MetadataType
-}
-
-type OpenstackCreateImageRequest struct {
-	Snapshot OpenstackCreateImage
-}
-
-// snapshot creation response in Openstack
-type OpenstackCreateImageResponse struct {
-	ImageId string
-}
-
-func (o *OpenstackCreateImageResponse) GetObjectKind() schema.ObjectKind {
-	return schema.OpenstackObjectKind
-}
-
-func (o *OpenstackCreateImageResponse) DeepCopyObject() runtime.Object {
-	return o
-}
-
-// Restore action support
-//
-type ArktosRestoreParams struct {
-	SnapshotID string `json:"snapshotID"`
-}
-type ArktosRestore struct {
-	ApiVersion    string              `json:"apiVersion"`
-	Kind          string              `json:"kind"`
-	Operation     string              `json:"operation"`
-	RestoreParams ArktosRestoreParams `json:"restoreParams"`
-}
-
-// Openstack rebuild action match to the Arktos restore action
-// Openstack rebuild struct has much optional field which are not applicable to Arktos restore action
-// slim down to key info
-type OpenstackRebuild struct {
-	ImageRef string
-	Metadata MetadataType
-}
-
-type OpenstackRebuildRequest struct {
-	Restore OpenstackRebuild
-}
-
-// rebuild response in Openstack
-type OpenstackRebuildResponse struct {
-	ServerId  string
-	ImageId   string
-	CreatedAt string
-}
-
-func (o *OpenstackRebuildResponse) GetObjectKind() schema.ObjectKind {
-	return schema.OpenstackObjectKind
-}
-
-func (o *OpenstackRebuildResponse) DeepCopyObject() runtime.Object {
-	return o
 }
 
 // Convert Openstack request to kubernetes pod request body
@@ -293,7 +119,7 @@ func ConvertActionFromOpenstackRequest(body []byte) ([]byte, error) {
 		obj := ArktosRestore{"v1", "CustomAction", op, ArktosRestoreParams{o.Restore.ImageRef}}
 		return json.Marshal(obj)
 	default:
-		return nil, fmt.Errorf("unsupported action: %s", op)
+		return nil, ERROR_UNKNOWN_ACTION
 	}
 }
 
@@ -383,7 +209,7 @@ func GetNamespaceFromRequest(r *http.Request) string {
 	return metav1.NamespaceSystem
 }
 
-// the suffix of URL path is the action of the VM
+// The suffix of URL path is the action of the VM
 // Arktos only supports reboot, stp[, start, snapshot, restore for the current release
 func IsActionRequest(path string) bool {
 	return strings.HasSuffix(path, "action")

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/openstackutils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/openstackutils_test.go
@@ -18,30 +18,36 @@ package openstack
 
 import (
 	"bytes"
+	"k8s.io/klog"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/util/json"
 )
 
-//TODO: fix UT
-func TestConvertToOpenstackRequest(t *testing.T) {
+var outputStr1 = `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"testvm","tenant":"system","namespace":"kube-system","creationTimestamp":null,"annotations":{"VirtletCPUModel":"host-model"}},"spec":{"virtualMachine":{"name":"testvm","image":"download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img","resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"1","memory":"512Mi"}},"imagePullPolicy":"IfNotPresent","keyPairName":"foobar","publicKey":"ssh-rsa AAA"}}}`
+
+func TestConvertServerFromOpenstackRequest(t *testing.T) {
 	tests := []struct {
 		name           string
 		input          string
-		expectedOutput OpenstackServerRequest
-
-		expectedError error
+		expectedOutput []byte
+		expectedError  error
 	}{
 		{
-			name:  "all valid, basic test",
-			input: `{"server":{"name":"testvm","imageRef":"6db08272-a856-49da-8909-7c4c73ab0bac","flavorRef":"m1.tiny"}}`,
-			expectedOutput: OpenstackServerRequest{
-				Server: ServerType{Name: "testvm",
-					ImageRef: "6db08272-a856-49da-8909-7c4c73ab0bac",
-					Flavor:   "mi.tiny",
-				},
-			},
-			expectedError: nil,
+			name:           "all valid, basic test",
+			input:          `{"server":{"name":"testvm","imageRef":"cirros-0.5.1","flavorRef":"m1.tiny"}}`,
+			expectedOutput: []byte(outputStr1),
+			expectedError:  nil,
+		},
+		{
+			name:           "Non-existing flavor",
+			input:          `{"server":{"name":"testvm","imageRef":"cirros-0.5.1","flavorRef":"NotExistFlavor"}}`,
+			expectedOutput: nil,
+			expectedError:  ERROR_FLAVOR_NOT_FOUND,
+		},
+		{
+			name:           "Non-existing image",
+			input:          `{"server":{"name":"testvm","imageRef":"NotExistImage","flavorRef":"m1.tiny"}}`,
+			expectedOutput: nil,
+			expectedError:  ERROR_IMAGE_NOT_FOUND,
 		},
 	}
 
@@ -52,13 +58,55 @@ func TestConvertToOpenstackRequest(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expectedBytes, err := json.Marshal(test.expectedOutput)
+		if bytes.Compare(actualBytes, test.expectedOutput) != 0 {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestConvertActionFromOpenstackRequest(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedOutput []byte
+		expectedError  error
+	}{
+		{
+			name:           "all valid, basic reboot action",
+			input:          `{"reboot":{"type":"HARD"}}`,
+			expectedOutput: []byte(`{"apiVersion":"v1","kind":"CustomAction","operation":"reboot","rebootParams":{"delayInSeconds":10}}`),
+			expectedError:  nil,
+		},
+		{
+			name:           "all valid, basic snapshot action",
+			input:          `{"snapshot":{"name":"foobar","metadata":{"meta_var":"meta_val"}}}`,
+			expectedOutput: []byte(`{"apiVersion":"v1","kind":"CustomAction","operation":"snapshot","snapshotParams":{"snapshotName":"foobar"}}`),
+			expectedError:  nil,
+		},
+		{
+			name:           "all valid, basic rebuild action",
+			input:          `{"restore":{"ImageRef":"foobar","metadata":{"meta_var":"meta_val"}}}`,
+			expectedOutput: []byte(`{"apiVersion":"v1","kind":"CustomAction","operation":"restore","restoreParams":{"snapshotID":"foobar"}}`),
+			expectedError:  nil,
+		},
+		{
+			name:           "Non-existing flavor",
+			input:          `{"not-exist":{"type":"HARD"}}`,
+			expectedOutput: nil,
+			expectedError:  ERROR_UNKNOWN_ACTION,
+		},
+	}
+
+	for _, test := range tests {
+		actualBytes, err := ConvertActionFromOpenstackRequest([]byte(test.input))
 
 		if err != test.expectedError {
 			t.Fatal(err)
 		}
 
-		if bytes.Compare(actualBytes, expectedBytes) != 0 {
+		klog.Infof("output: %s", string(actualBytes))
+
+		if bytes.Compare(actualBytes, test.expectedOutput) != 0 {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind feature


**What this PR does / why we need it**:
The PR is to ensure to automatically create the network object (flat or mizar) of "default"  for system tenant when scale out 1 x 1 cluster or scale-up cluster of KUBE-UP environment.

If network support is not desired, setting env var DISABLE_NETWORK_SERVICE_SUPPORT will disable this feature.
 

**Which issue(s) this PR fixes**:
Fixes # 1279

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
TEST:
1. For mizar to start kube-up cluster:
start cluster:
```
export KUBEMARK_NUM_NODES=100 NUM_NODES=1 SCALEOUT_CLUSTER=true SCALEOUT_TP_COUNT=1 SCALEOUT_RP_COUNT=1 RUN_PREFIX=carltenant-012222 NETWORK_PROVIDER=mizar
```
```
export MASTER_DISK_SIZE=500GB MASTER_ROOT_DISK_SIZE=500GB KUBE_GCE_ZONE=us-west2-b MASTER_SIZE=n1-highmem-32 NODE_SIZE=n1-highmem-16 NODE_DISK_SIZE=500GB GOPATH=$HOME/go KUBE_GCE_ENABLE_IP_ALIASES=true KUBE_GCE_PRIVATE_CLUSTER=true CREATE_CUSTOM_NETWORK=true KUBE_GCE_INSTANCE_PREFIX=${RUN_PREFIX} KUBE_GCE_NETWORK=${RUN_PREFIX} ENABLE_KCM_LEADER_ELECT=false ENABLE_SCHEDULER_LEADER_ELECT=false ETCD_QUOTA_BACKEND_BYTES=8589934592 SHARE_PARTITIONSERVER=false LOGROTATE_FILES_MAX_COUNT=200 LOGROTATE_MAX_SIZE=200M KUBE_ENABLE_APISERVER_INSECURE_PORT=true KUBE_ENABLE_PROMETHEUS_DEBUG=true KUBE_ENABLE_PPROF_DEBUG=true TEST_CLUSTER_LOG_LEVEL=--v=2 HOLLOW_KUBELET_TEST_LOG_LEVEL=--v=2 GCE_REGION=us-west2-b
```
```
make quick-release; ./cluster/kube-up.sh
```
```
kubectl get network
```
```
NAME      TYPE    VPC                      PHASE   DNS
default   mizar   system-default-network 
```

Shutdown cluster:
```
./cluster/kube-down.sh
```
2. For flat network to start kube-up cluster:
start cluster:
```
export KUBEMARK_NUM_NODES=100 NUM_NODES=1 SCALEOUT_CLUSTER=true SCALEOUT_TP_COUNT=1 SCALEOUT_RP_COUNT=1 RUN_PREFIX=carltenant-012222
```
```
export MASTER_DISK_SIZE=500GB MASTER_ROOT_DISK_SIZE=500GB KUBE_GCE_ZONE=us-west2-b MASTER_SIZE=n1-highmem-32 NODE_SIZE=n1-highmem-16 NODE_DISK_SIZE=500GB GOPATH=$HOME/go KUBE_GCE_ENABLE_IP_ALIASES=true KUBE_GCE_PRIVATE_CLUSTER=true CREATE_CUSTOM_NETWORK=true KUBE_GCE_INSTANCE_PREFIX=${RUN_PREFIX} KUBE_GCE_NETWORK=${RUN_PREFIX} ENABLE_KCM_LEADER_ELECT=false ENABLE_SCHEDULER_LEADER_ELECT=false ETCD_QUOTA_BACKEND_BYTES=8589934592 SHARE_PARTITIONSERVER=false LOGROTATE_FILES_MAX_COUNT=200 LOGROTATE_MAX_SIZE=200M KUBE_ENABLE_APISERVER_INSECURE_PORT=true KUBE_ENABLE_PROMETHEUS_DEBUG=true KUBE_ENABLE_PPROF_DEBUG=true TEST_CLUSTER_LOG_LEVEL=--v=2 HOLLOW_KUBELET_TEST_LOG_LEVEL=--v=2 GCE_REGION=us-west2-b
```
```
make quick-release; ./cluster/kube-up.sh
```
```
kubectl get network
```
```
NAME      TYPE    VPC                      PHASE   DNS
default   flat 
```

Shutdown cluster:
```
./cluster/kube-down.sh
```