### PR TITLE
Slight refactor and essential UT

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/BUILD
@@ -46,5 +46,5 @@ go_test(
         "types_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library"],
+    deps = ["//vendor/k8s.io/klog:go_default_library"],
 )

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/flavors.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/flavors.go
@@ -21,6 +21,7 @@ import "fmt"
 var flavors = map[string]FlavorType{}
 var flavorList = []*FlavorType{}
 
+var ERROR_FLAVOR_NOT_FOUND = fmt.Errorf("flavor not found")
 // slim down version of the openstack flavor data structure
 type FlavorType struct {
 	Id          int
@@ -54,7 +55,7 @@ func GetFalvor(name string) (*FlavorType, error) {
 		return &flavor, nil
 	}
 
-	return nil, fmt.Errorf("flavor %s, not found", name)
+	return nil, ERROR_FLAVOR_NOT_FOUND
 }
 
 func ListFalvors() []*FlavorType {

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/flavors.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/flavors.go
@@ -22,6 +22,7 @@ var flavors = map[string]FlavorType{}
 var flavorList = []*FlavorType{}
 
 var ERROR_FLAVOR_NOT_FOUND = fmt.Errorf("flavor not found")
+
 // slim down version of the openstack flavor data structure
 type FlavorType struct {
 	Id          int

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/images.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/images.go
@@ -20,6 +20,7 @@ import "fmt"
 
 var images = map[string]ImageType{}
 var imageList = []*ImageType{}
+var ERROR_IMAGE_NOT_FOUND = fmt.Errorf("image not found")
 
 // Arktos doesn't have its own image registry
 // this is simulate the read-only image service to get test images for VM
@@ -50,7 +51,7 @@ func GetImage(name string) (*ImageType, error) {
 		return &image, nil
 	}
 
-	return nil, fmt.Errorf("image %s, not found", name)
+	return nil, ERROR_IMAGE_NOT_FOUND
 }
 
 func ListImages() []*ImageType {

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/openstackutils.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/openstackutils.go
@@ -26,7 +26,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/apis/apps"
@@ -39,6 +38,7 @@ const (
 	RESTORE  = "restore"
 )
 
+var ERROR_UNKNOWN_ACTION = fmt.Errorf("unknown action")
 var supportedActions = []string{REBOOT, SNAPSHOT, RESTORE}
 
 // init function initialize the VM flavor and image cache
@@ -51,180 +51,6 @@ func init() {
 
 	il := ListImages()
 	klog.V(6).Infof("built-in images: %v", il)
-}
-
-type Network struct {
-	Uuid     string `json:"uuid"`
-	Port     string `json:"port"`
-	Fixed_ip string `json:"fixed_ip"`
-}
-
-type MetadataType struct {
-	key   string
-	value string
-}
-
-type SecurityGroup struct {
-	name string
-}
-
-type LinkType struct {
-	Link string
-	Rel  string
-}
-
-type ServerType struct {
-	Name            string          `json:"name"`
-	ImageRef        string          `json:"imageRef"`
-	Flavor          string          `json:"flavorRef"`
-	Networks        []Network       `json:"networks"`
-	Security_groups []SecurityGroup `json:"security_groups"`
-	Key_name        string          `json:"key_name"`
-	Metadata        MetadataType    `json:"metadata"`
-	User_data       string          `json:"user_data"`
-}
-
-// VM creation request in Openstack
-// non-zero possitive Min or max count indicates batch creation, even if it is one
-// Return_Reservation_Id indicates response behavior, true to return the reservationID ( replicset name in Arktos )
-// So that the client can list the servers associated with this replicaset
-type OpenstackServerRequest struct {
-	Server                ServerType `json:"server"`
-	Min_count             int        `json:"min_count"`
-	Max_count             int        `json:"max_count"`
-	Return_Reservation_Id bool       `json:"return_reservation_id"`
-}
-
-// VM creation response in Openstack
-type OpenstackResponse struct {
-	Id              string
-	Links           []LinkType
-	Security_groups []SecurityGroup
-}
-
-func (o *OpenstackResponse) GetObjectKind() schema.ObjectKind {
-	return schema.OpenstackObjectKind
-}
-
-func (o *OpenstackResponse) DeepCopyObject() runtime.Object {
-	return o
-}
-
-type OpenstackServerListRequest struct {
-	Reservation_Id string `json:"reservation_id"`
-}
-
-// VM list response
-type OpenstackServerListResponse struct {
-	Servers []OpenstackResponse
-}
-
-func (o *OpenstackServerListResponse) GetObjectKind() schema.ObjectKind {
-	return schema.OpenstackObjectKind
-}
-
-func (o *OpenstackServerListResponse) DeepCopyObject() runtime.Object {
-	return o
-}
-
-// VM Batch creation response in Openstack
-type OpenstackBatchResponse struct {
-	Reservation_Id string `json:"reservation_id"`
-}
-
-func (o *OpenstackBatchResponse) GetObjectKind() schema.ObjectKind {
-	return schema.OpenstackObjectKind
-}
-
-func (o *OpenstackBatchResponse) DeepCopyObject() runtime.Object {
-	return o
-}
-
-type ArktosRebootParams struct {
-	DelayInSeconds int `json:"delayInSeconds"`
-}
-
-// Reboot action support
-//
-type ArktosReboot struct {
-	ApiVersion   string             `json:"apiVersion"`
-	Kind         string             `json:"kind"`
-	Operation    string             `json:"operation"`
-	RebootParams ArktosRebootParams `json:"rebootParams"`
-}
-
-// Snapshot action support
-//
-type ArktosSnapshotParams struct {
-	SnapshotName string `json:"snapshotName"`
-}
-type ArktosSnapshot struct {
-	ApiVersion     string               `json:"apiVersion"`
-	Kind           string               `json:"kind"`
-	Operation      string               `json:"operation"`
-	SnapshotParams ArktosSnapshotParams `json:"snapshotParams"`
-}
-
-// Openstack createImage action match to the Arktos snapshot action
-type OpenstackCreateImage struct {
-	Name     string
-	Metadata MetadataType
-}
-
-type OpenstackCreateImageRequest struct {
-	Snapshot OpenstackCreateImage
-}
-
-// snapshot creation response in Openstack
-type OpenstackCreateImageResponse struct {
-	ImageId string
-}
-
-func (o *OpenstackCreateImageResponse) GetObjectKind() schema.ObjectKind {
-	return schema.OpenstackObjectKind
-}
-
-func (o *OpenstackCreateImageResponse) DeepCopyObject() runtime.Object {
-	return o
-}
-
-// Restore action support
-//
-type ArktosRestoreParams struct {
-	SnapshotID string `json:"snapshotID"`
-}
-type ArktosRestore struct {
-	ApiVersion    string              `json:"apiVersion"`
-	Kind          string              `json:"kind"`
-	Operation     string              `json:"operation"`
-	RestoreParams ArktosRestoreParams `json:"restoreParams"`
-}
-
-// Openstack rebuild action match to the Arktos restore action
-// Openstack rebuild struct has much optional field which are not applicable to Arktos restore action
-// slim down to key info
-type OpenstackRebuild struct {
-	ImageRef string
-	Metadata MetadataType
-}
-
-type OpenstackRebuildRequest struct {
-	Restore OpenstackRebuild
-}
-
-// rebuild response in Openstack
-type OpenstackRebuildResponse struct {
-	ServerId  string
-	ImageId   string
-	CreatedAt string
-}
-
-func (o *OpenstackRebuildResponse) GetObjectKind() schema.ObjectKind {
-	return schema.OpenstackObjectKind
-}
-
-func (o *OpenstackRebuildResponse) DeepCopyObject() runtime.Object {
-	return o
 }
 
 // Convert Openstack request to kubernetes pod request body
@@ -293,7 +119,7 @@ func ConvertActionFromOpenstackRequest(body []byte) ([]byte, error) {
 		obj := ArktosRestore{"v1", "CustomAction", op, ArktosRestoreParams{o.Restore.ImageRef}}
 		return json.Marshal(obj)
 	default:
-		return nil, fmt.Errorf("unsupported action: %s", op)
+		return nil, ERROR_UNKNOWN_ACTION
 	}
 }
 
@@ -383,7 +209,7 @@ func GetNamespaceFromRequest(r *http.Request) string {
 	return metav1.NamespaceSystem
 }
 
-// the suffix of URL path is the action of the VM
+// The suffix of URL path is the action of the VM
 // Arktos only supports reboot, stp[, start, snapshot, restore for the current release
 func IsActionRequest(path string) bool {
 	return strings.HasSuffix(path, "action")

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/openstackutils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/openstackutils_test.go
@@ -29,25 +29,25 @@ func TestConvertServerFromOpenstackRequest(t *testing.T) {
 		name           string
 		input          string
 		expectedOutput []byte
-		expectedError error
+		expectedError  error
 	}{
 		{
-			name:  "all valid, basic test",
-			input: `{"server":{"name":"testvm","imageRef":"cirros-0.5.1","flavorRef":"m1.tiny"}}`,
+			name:           "all valid, basic test",
+			input:          `{"server":{"name":"testvm","imageRef":"cirros-0.5.1","flavorRef":"m1.tiny"}}`,
 			expectedOutput: []byte(outputStr1),
-			expectedError: nil,
+			expectedError:  nil,
 		},
 		{
-			name:  "Non-existing flavor",
-			input: `{"server":{"name":"testvm","imageRef":"cirros-0.5.1","flavorRef":"NotExistFlavor"}}`,
+			name:           "Non-existing flavor",
+			input:          `{"server":{"name":"testvm","imageRef":"cirros-0.5.1","flavorRef":"NotExistFlavor"}}`,
 			expectedOutput: nil,
-			expectedError: ERROR_FLAVOR_NOT_FOUND,
+			expectedError:  ERROR_FLAVOR_NOT_FOUND,
 		},
 		{
-			name:  "Non-existing image",
-			input: `{"server":{"name":"testvm","imageRef":"NotExistImage","flavorRef":"m1.tiny"}}`,
+			name:           "Non-existing image",
+			input:          `{"server":{"name":"testvm","imageRef":"NotExistImage","flavorRef":"m1.tiny"}}`,
 			expectedOutput: nil,
-			expectedError: ERROR_IMAGE_NOT_FOUND,
+			expectedError:  ERROR_IMAGE_NOT_FOUND,
 		},
 	}
 
@@ -69,31 +69,31 @@ func TestConvertActionFromOpenstackRequest(t *testing.T) {
 		name           string
 		input          string
 		expectedOutput []byte
-		expectedError error
+		expectedError  error
 	}{
 		{
-			name:  "all valid, basic reboot action",
-			input: `{"reboot":{"type":"HARD"}}`,
+			name:           "all valid, basic reboot action",
+			input:          `{"reboot":{"type":"HARD"}}`,
 			expectedOutput: []byte(`{"apiVersion":"v1","kind":"CustomAction","operation":"reboot","rebootParams":{"delayInSeconds":10}}`),
-			expectedError: nil,
+			expectedError:  nil,
 		},
 		{
-			name:  "all valid, basic snapshot action",
-			input: `{"snapshot":{"name":"foobar","metadata":{"meta_var":"meta_val"}}}`,
+			name:           "all valid, basic snapshot action",
+			input:          `{"snapshot":{"name":"foobar","metadata":{"meta_var":"meta_val"}}}`,
 			expectedOutput: []byte(`{"apiVersion":"v1","kind":"CustomAction","operation":"snapshot","snapshotParams":{"snapshotName":"foobar"}}`),
-			expectedError: nil,
+			expectedError:  nil,
 		},
 		{
-			name:  "all valid, basic rebuild action",
-			input: `{"restore":{"ImageRef":"foobar","metadata":{"meta_var":"meta_val"}}}`,
+			name:           "all valid, basic rebuild action",
+			input:          `{"restore":{"ImageRef":"foobar","metadata":{"meta_var":"meta_val"}}}`,
 			expectedOutput: []byte(`{"apiVersion":"v1","kind":"CustomAction","operation":"restore","restoreParams":{"snapshotID":"foobar"}}`),
-			expectedError: nil,
+			expectedError:  nil,
 		},
 		{
-			name:  "Non-existing flavor",
-			input: `{"not-exist":{"type":"HARD"}}`,
+			name:           "Non-existing flavor",
+			input:          `{"not-exist":{"type":"HARD"}}`,
 			expectedOutput: nil,
-			expectedError: ERROR_UNKNOWN_ACTION,
+			expectedError:  ERROR_UNKNOWN_ACTION,
 		},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/types_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/types_test.go
@@ -22,52 +22,20 @@ import (
 )
 
 type input struct {
+	replicas   int
 	serverName string
 	imageRef   string
 	vcpu       int
 	memInMi    int
 }
 
-var expectedJson1 = `
-{
-   "apiVersion":"v1",
-   "kind":"Pod",
-   "MetaData":{
-      "name":"testvm",
-      "tenant":"system",
-      "namespace":"kube-system",
-      "creationTimestamp":null,
-      "annotations":{
-         "VirtletCPUModel":"host-model"
-      }
-   },
-   "spec":{
-      "virtualMachine":{
-         "name":"testvm",
-         "image":"m1.tiny",
-         "resources":{
-            "limits":{
-               "cpu":"1",
-               "memory":"512Mi"
-            },
-            "requests":{
-               "cpu":"1",
-               "memory":"512Mi"
-            }
-         },
-         "keyPairName":"foobar",
-         "publicKey":"ssh-rsa AAA"
-      }
-   }
-}`
+var expectedJson1 = `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"testvm","tenant":"system","namespace":"kube-system","creationTimestamp":null,"annotations":{"VirtletCPUModel":"host-model"}},"spec":{"virtualMachine":{"name":"testvm","image":"m1.tiny","resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"1","memory":"512Mi"}},"imagePullPolicy":"IfNotPresent","keyPairName":"foobar","publicKey":"ssh-rsa AAA"}}}`
 
-//TODO: fix UT
-func TestGetRequestBody(t *testing.T) {
+func TestConstructVmPodRequestBody(t *testing.T) {
 	tests := []struct {
 		name               string
 		input              input
 		expectedJsonString string
-
 		expectedError error
 	}{
 		{
@@ -80,6 +48,35 @@ func TestGetRequestBody(t *testing.T) {
 
 	for _, test := range tests {
 		b, err := constructVmPodRequestBody(test.input.serverName, test.input.imageRef, test.input.vcpu, test.input.memInMi)
+
+		if err != test.expectedError {
+			t.Fatal(err)
+		}
+
+		if strings.Compare(string(b), test.expectedJsonString) != 0 {
+			t.Fatal(err)
+		}
+	}
+}
+
+var expectedJson2 = `{"apiVersion":"apps/v1","kind":"ReplicaSet","metadata":{"name":"testvm","tenant":"system","namespace":"kube-system","creationTimestamp":null},"spec":{"replicas":3,"selector":{"matchLabels":{"ln":"testvm"}},"template":{"metadata":{"creationTimestamp":null,"labels":{"ln":"testvm"},"annotations":{"VirtletCPUModel":"host-model"}},"spec":{"virtualMachine":{"name":"testvm","image":"m1.tiny","resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"1","memory":"512Mi"}},"imagePullPolicy":"IfNotPresent","keyPairName":"foobar","publicKey":"ssh-rsa AAA"}}}}}`
+func TestConstructReplicasetRequestBody(t *testing.T) {
+	tests := []struct {
+		name               string
+		input              input
+		expectedJsonString string
+		expectedError error
+	}{
+		{
+			name:               "basic valid test",
+			input:              input{replicas: 3,  serverName: "testvm", imageRef: "m1.tiny", vcpu: 1, memInMi: 512},
+			expectedJsonString: expectedJson2,
+			expectedError:      nil,
+		},
+	}
+
+	for _, test := range tests {
+		b, err := constructReplicasetRequestBody(test.input.replicas, test.input.serverName, test.input.imageRef, test.input.vcpu, test.input.memInMi)
 
 		if err != test.expectedError {
 			t.Fatal(err)

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/types_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/types_test.go
@@ -36,7 +36,7 @@ func TestConstructVmPodRequestBody(t *testing.T) {
 		name               string
 		input              input
 		expectedJsonString string
-		expectedError error
+		expectedError      error
 	}{
 		{
 			name:               "basic valid test",
@@ -60,16 +60,17 @@ func TestConstructVmPodRequestBody(t *testing.T) {
 }
 
 var expectedJson2 = `{"apiVersion":"apps/v1","kind":"ReplicaSet","metadata":{"name":"testvm","tenant":"system","namespace":"kube-system","creationTimestamp":null},"spec":{"replicas":3,"selector":{"matchLabels":{"ln":"testvm"}},"template":{"metadata":{"creationTimestamp":null,"labels":{"ln":"testvm"},"annotations":{"VirtletCPUModel":"host-model"}},"spec":{"virtualMachine":{"name":"testvm","image":"m1.tiny","resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"1","memory":"512Mi"}},"imagePullPolicy":"IfNotPresent","keyPairName":"foobar","publicKey":"ssh-rsa AAA"}}}}}`
+
 func TestConstructReplicasetRequestBody(t *testing.T) {
 	tests := []struct {
 		name               string
 		input              input
 		expectedJsonString string
-		expectedError error
+		expectedError      error
 	}{
 		{
 			name:               "basic valid test",
-			input:              input{replicas: 3,  serverName: "testvm", imageRef: "m1.tiny", vcpu: 1, memInMi: 512},
+			input:              input{replicas: 3, serverName: "testvm", imageRef: "m1.tiny", vcpu: 1, memInMi: 512},
 			expectedJsonString: expectedJson2,
 			expectedError:      nil,
 		},


### PR DESCRIPTION
This will be first quality effort for 130. slight refactor types and utils files and essential UT test fixes. all new UTs are passing now.

Local testing:
```
yunwens-mbp:kubernetes yunwenbai$ bazel test //staging/src/k8s.io/apiserver/pkg/util/openstack/...
INFO: Analyzed 4 targets (0 packages loaded, 0 targets configured).
INFO: Found 3 targets and 1 test target...
INFO: Elapsed time: 0.297s, Critical Path: 0.03s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
//staging/src/k8s.io/apiserver/pkg/util/openstack:go_default_test (cached) PASSED in 0.3s

Executed 0 out of 1 test: 1 test passes.
INFO: Build completed successfully, 1 total action
yunwens-mbp:kubernetes yunwenbai$ bazel test //staging/src/k8s.io/apiserver/pkg/util/...
INFO: Analyzed 33 targets (0 packages loaded, 0 targets configured).
INFO: Found 27 targets and 6 test targets...
INFO: Elapsed time: 6.114s, Critical Path: 5.71s
INFO: 30 processes: 30 darwin-sandbox.
INFO: Build completed successfully, 35 total actions
//staging/src/k8s.io/apiserver/pkg/util/openstack:go_default_test (cached) PASSED in 0.3s
//staging/src/k8s.io/apiserver/pkg/util/proxy:go_default_test   (cached) PASSED in 0.3s
//staging/src/k8s.io/apiserver/pkg/util/flushwriter:go_default_test      PASSED in 0.3s
//staging/src/k8s.io/apiserver/pkg/util/openapi:go_default_test          PASSED in 0.4s
//staging/src/k8s.io/apiserver/pkg/util/webhook:go_default_test          PASSED in 2.1s
//staging/src/k8s.io/apiserver/pkg/util/wsstream:go_default_test         PASSED in 0.4s

Executed 4 out of 6 tests: 6 tests pass.
INFO: Build completed successfully, 35 total actions
yunwens-mbp:kubernetes yunwenbai$ 
```