### PR TITLE
ServerType update to fit Openstack required and key optional configs.

### DIFF
--- a/pkg/controller/mizar/mizar-pod-controller.go
+++ b/pkg/controller/mizar/mizar-pod-controller.go
@@ -232,7 +232,7 @@ func (c *MizarPodController) handle(keyWithEventType KeyWithEventType) error {
 			klog.Warningf("The arktos network %s is not Ready.", network.Name)
 			// put key back into queue
 			go func() {
-				time.Sleep(100 * time.Millisecond)	// avoid busy waiting
+				time.Sleep(100 * time.Millisecond) // avoid busy waiting
 				if eventType == EventType_Create {
 					c.createObj(obj)
 				} else { // Update

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/openstack.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/openstack.go
@@ -43,8 +43,12 @@ const (
 
 type Openstack struct{}
 
-// the url path is /servers/{vmId}
+// the url path is /servers/{vmId} OR /servers/{vmId}/{action}
 func getElementFromPath(path string) string {
+	elements := strings.Split(path, "/")
+	if len(elements) < 3 {
+		return ""
+	}
 	return strings.Split(path, "/")[2]
 }
 
@@ -186,12 +190,21 @@ func (o Openstack) serverHandler(resp http.ResponseWriter, req *http.Request) {
 
 	tenant := openstack.GetTenantFromRequest(req)
 	namespace := openstack.GetNamespaceFromRequest(req)
-
+	vmId := getElementFromPath(req.URL.Path)
 	redirectUrl := ""
 
+	// For now, just check if it is empty string, which indicate badRequest
+	validateVmName := func(name string) {
+		if name == "" {
+			resp.WriteHeader(http.StatusBadRequest)
+			return
+		}
+	}
+
 	if openstack.IsActionRequest(req.URL.Path) {
+		validateVmName(vmId)
 		redirectUrl = fmt.Sprintf(POD_URL_TEMPLATE, tenant, namespace)
-		redirectUrl += "/" + getElementFromPath(req.URL.Path) + "/action"
+		redirectUrl += "/" + vmId + "/action"
 		o.actionHandler(resp, req, redirectUrl)
 		return
 	}
@@ -200,7 +213,8 @@ func (o Openstack) serverHandler(resp http.ResponseWriter, req *http.Request) {
 	case http.MethodGet:
 		redirectUrl = fmt.Sprintf(POD_URL_TEMPLATE, tenant, namespace)
 		if isGetDetail(req.URL.Path) {
-			redirectUrl += "/" + getElementFromPath(req.URL.Path)
+			validateVmName(vmId)
+			redirectUrl += "/" + vmId
 		}
 
 		rev_id, err := getReservationIdFromListRequest(req)
@@ -213,8 +227,9 @@ func (o Openstack) serverHandler(resp http.ResponseWriter, req *http.Request) {
 		}
 
 	case http.MethodDelete:
+		validateVmName(vmId)
 		redirectUrl = fmt.Sprintf(POD_URL_TEMPLATE, tenant, namespace)
-		redirectUrl += "/" + getElementFromPath(req.URL.Path)
+		redirectUrl += "/" + vmId
 	case http.MethodPost:
 		isBatchRequest, err := isBatchCreationRequest(req)
 		if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/openstack.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/openstack.go
@@ -71,7 +71,8 @@ func isBatchCreationRequest(req *http.Request) (bool, error) {
 	err = json.Unmarshal(body, &obj)
 
 	if err != nil {
-		klog.Errorf("error unmarshal request body :%s. error %v", string(body), err)
+		klog.V(6).Infof("Failed unmarshal request body: %s", string(body))
+		klog.Errorf("error unmarshal request: %v", err)
 		return false, err
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/openstack.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/openstack.go
@@ -71,7 +71,7 @@ func isBatchCreationRequest(req *http.Request) (bool, error) {
 	err = json.Unmarshal(body, &obj)
 
 	if err != nil {
-		klog.Errorf("error unmarshal request. error %v", err)
+		klog.Errorf("error unmarshal request body :%s. error %v", string(body), err)
 		return false, err
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/openstackutils.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/openstackutils.go
@@ -81,9 +81,9 @@ func ConvertServerFromOpenstackRequest(body []byte) ([]byte, error) {
 
 	if IsBatchCreationRequest(obj) {
 		replicas := obj.Min_count
-		ret, err = constructReplicasetRequestBody(replicas, obj.Server.Name, image.ImageRef, flavor.Vcpus, flavor.MemoryMb)
+		ret, err = constructReplicasetRequestBody(replicas, obj.Server, image.ImageRef, flavor.Vcpus, flavor.MemoryMb)
 	} else {
-		ret, err = constructVmPodRequestBody(obj.Server.Name, image.ImageRef, flavor.Vcpus, flavor.MemoryMb)
+		ret, err = constructVmPodRequestBody(obj.Server, image.ImageRef, flavor.Vcpus, flavor.MemoryMb)
 	}
 	if err != nil {
 		klog.Errorf("failed to construct request body. error: %v", err)

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/openstackutils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/openstackutils_test.go
@@ -104,7 +104,7 @@ func TestConvertActionFromOpenstackRequest(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		klog.Infof("output: %s", string(actualBytes))
+		klog.V(8).Infof("output: %s", string(actualBytes))
 
 		if bytes.Compare(actualBytes, test.expectedOutput) != 0 {
 			t.Fatal(err)

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/openstackutils_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/openstackutils_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 )
 
-var outputStr1 = `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"testvm","tenant":"system","namespace":"kube-system","creationTimestamp":null,"annotations":{"VirtletCPUModel":"host-model"}},"spec":{"virtualMachine":{"name":"testvm","image":"download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img","resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"1","memory":"512Mi"}},"imagePullPolicy":"IfNotPresent","keyPairName":"foobar","publicKey":"ssh-rsa AAA"}}}`
+var outputStr1 = `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"testvm","tenant":"system","namespace":"kube-system","creationTimestamp":null,"annotations":{"VirtletCPUModel":"host-model"}},"spec":{"virtualMachine":{"name":"testvm","image":"download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img","resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"1","memory":"512Mi"}},"imagePullPolicy":"IfNotPresent"}}}`
 
 func TestConvertServerFromOpenstackRequest(t *testing.T) {
 	tests := []struct {
@@ -58,6 +58,7 @@ func TestConvertServerFromOpenstackRequest(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		klog.Infof("server output: %s", string(actualBytes))
 		if bytes.Compare(actualBytes, test.expectedOutput) != 0 {
 			t.Fatal(err)
 		}
@@ -104,7 +105,7 @@ func TestConvertActionFromOpenstackRequest(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		klog.V(8).Infof("output: %s", string(actualBytes))
+		klog.Infof("output: %s", string(actualBytes))
 
 		if bytes.Compare(actualBytes, test.expectedOutput) != 0 {
 			t.Fatal(err)

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/types.go
@@ -55,23 +55,23 @@ type LinkType struct {
 }
 
 type ServerType struct {
-	Name            string          `json:"name"`
+	Name string `json:"name"`
 	// Boot from image is what currently supported in Arktos-vm-runtime, so this is required
-	ImageRef        string          `json:"imageRef"`
-	Flavor          string          `json:"flavorRef"`
+	ImageRef string `json:"imageRef"`
+	Flavor   string `json:"flavorRef"`
 	// +optional
-	Networks        []Network       `json:"networks"`
+	Networks []Network `json:"networks"`
 	// +optional
 	Security_groups []SecurityGroup `json:"security_groups"`
 	// +optional
-	Key_name        string          `json:"key_name"`
+	Key_name string `json:"key_name"`
 	// +optional
-	Metadata        MetadataType    `json:"metadata"`
+	Metadata MetadataType `json:"metadata"`
 	// +optional
-	User_data       string          `json:"user_data"`
+	User_data string `json:"user_data"`
 	// the compute service host node the server to be created on
 	// +optional
-	Host            string           `json:"host"`
+	Host string `json:"host"`
 }
 
 // VM creation request in Openstack
@@ -299,7 +299,7 @@ func constructVMSpec(server ServerType, imageRef string, vcpu, memInMi int) *v1.
 		ImagePullPolicy: v1.PullIfNotPresent,
 		Name:            server.Name,
 		PublicKey:       server.Key_name,
-		UserData:        server.User_data,
+		UserData:        []byte(server.User_data),
 		Resources: v1.ResourceRequirements{
 			Limits: v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse(strconv.Itoa(vcpu)),

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/types_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/types_test.go
@@ -17,19 +17,20 @@ limitations under the License.
 package openstack
 
 import (
+	"k8s.io/klog"
 	"strings"
 	"testing"
 )
 
 type input struct {
-	replicas   int
-	server     ServerType
-	imageRef   string
-	vcpu       int
-	memInMi    int
+	replicas int
+	server   ServerType
+	imageRef string
+	vcpu     int
+	memInMi  int
 }
 
-var expectedJson1 = `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"testvm","tenant":"system","namespace":"kube-system","creationTimestamp":null,"annotations":{"VirtletCPUModel":"host-model"}},"spec":{"virtualMachine":{"name":"testvm","image":"m1.tiny","resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"1","memory":"512Mi"}},"imagePullPolicy":"IfNotPresent","keyPairName":"foobar","publicKey":"ssh-rsa AAA"}}}`
+var expectedJson1 = `{"apiVersion":"v1","kind":"Pod","metadata":{"name":"testvm","tenant":"system","namespace":"kube-system","creationTimestamp":null,"annotations":{"VirtletCPUModel":"host-model"}},"spec":{"virtualMachine":{"name":"testvm","image":"m1.tiny","resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"1","memory":"512Mi"}},"imagePullPolicy":"IfNotPresent","publicKey":"ssh-rsa AAA"}}}`
 
 func TestConstructVmPodRequestBody(t *testing.T) {
 	tests := []struct {
@@ -40,7 +41,7 @@ func TestConstructVmPodRequestBody(t *testing.T) {
 	}{
 		{
 			name:               "basic valid test",
-			input:              input{server: ServerType{Name: "testvm"}, imageRef: "m1.tiny", vcpu: 1, memInMi: 512},
+			input:              input{server: ServerType{Name: "testvm", Key_name: "ssh-rsa AAA"}, imageRef: "m1.tiny", vcpu: 1, memInMi: 512},
 			expectedJsonString: expectedJson1,
 			expectedError:      nil,
 		},
@@ -53,13 +54,14 @@ func TestConstructVmPodRequestBody(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		klog.Infof("vmPodBody: %s", string(b))
 		if strings.Compare(string(b), test.expectedJsonString) != 0 {
 			t.Fatal(err)
 		}
 	}
 }
 
-var expectedJson2 = `{"apiVersion":"apps/v1","kind":"ReplicaSet","metadata":{"name":"testvm","tenant":"system","namespace":"kube-system","creationTimestamp":null},"spec":{"replicas":3,"selector":{"matchLabels":{"ln":"testvm"}},"template":{"metadata":{"creationTimestamp":null,"labels":{"ln":"testvm"},"annotations":{"VirtletCPUModel":"host-model"}},"spec":{"virtualMachine":{"name":"testvm","image":"m1.tiny","resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"1","memory":"512Mi"}},"imagePullPolicy":"IfNotPresent","keyPairName":"foobar","publicKey":"ssh-rsa AAA"}}}}}`
+var expectedJson2 = `{"apiVersion":"apps/v1","kind":"ReplicaSet","metadata":{"name":"testvm","tenant":"system","namespace":"kube-system","creationTimestamp":null},"spec":{"replicas":3,"selector":{"matchLabels":{"ln":"testvm"}},"template":{"metadata":{"creationTimestamp":null,"labels":{"ln":"testvm"},"annotations":{"VirtletCPUModel":"host-model"}},"spec":{"virtualMachine":{"name":"testvm","image":"m1.tiny","resources":{"limits":{"cpu":"1","memory":"512Mi"},"requests":{"cpu":"1","memory":"512Mi"}},"imagePullPolicy":"IfNotPresent","publicKey":"ssh-rsa AAA"}}}}}`
 
 func TestConstructReplicasetRequestBody(t *testing.T) {
 	tests := []struct {
@@ -70,7 +72,7 @@ func TestConstructReplicasetRequestBody(t *testing.T) {
 	}{
 		{
 			name:               "basic valid test",
-			input:              input{replicas: 3, server: ServerType{Name: "testvm"}, imageRef: "m1.tiny", vcpu: 1, memInMi: 512},
+			input:              input{replicas: 3, server: ServerType{Name: "testvm", Key_name: "ssh-rsa AAA"}, imageRef: "m1.tiny", vcpu: 1, memInMi: 512},
 			expectedJsonString: expectedJson2,
 			expectedError:      nil,
 		},
@@ -83,6 +85,7 @@ func TestConstructReplicasetRequestBody(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		klog.Infof("replicasetBody: %s", string(b))
 		if strings.Compare(string(b), test.expectedJsonString) != 0 {
 			t.Fatal(err)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/types_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/types_test.go
@@ -23,7 +23,7 @@ import (
 
 type input struct {
 	replicas   int
-	serverName string
+	server     ServerType
 	imageRef   string
 	vcpu       int
 	memInMi    int
@@ -40,14 +40,14 @@ func TestConstructVmPodRequestBody(t *testing.T) {
 	}{
 		{
 			name:               "basic valid test",
-			input:              input{serverName: "testvm", imageRef: "m1.tiny", vcpu: 1, memInMi: 512},
+			input:              input{server: ServerType{Name: "testvm"}, imageRef: "m1.tiny", vcpu: 1, memInMi: 512},
 			expectedJsonString: expectedJson1,
 			expectedError:      nil,
 		},
 	}
 
 	for _, test := range tests {
-		b, err := constructVmPodRequestBody(test.input.serverName, test.input.imageRef, test.input.vcpu, test.input.memInMi)
+		b, err := constructVmPodRequestBody(test.input.server, test.input.imageRef, test.input.vcpu, test.input.memInMi)
 
 		if err != test.expectedError {
 			t.Fatal(err)
@@ -70,14 +70,14 @@ func TestConstructReplicasetRequestBody(t *testing.T) {
 	}{
 		{
 			name:               "basic valid test",
-			input:              input{replicas: 3, serverName: "testvm", imageRef: "m1.tiny", vcpu: 1, memInMi: 512},
+			input:              input{replicas: 3, server: ServerType{Name: "testvm"}, imageRef: "m1.tiny", vcpu: 1, memInMi: 512},
 			expectedJsonString: expectedJson2,
 			expectedError:      nil,
 		},
 	}
 
 	for _, test := range tests {
-		b, err := constructReplicasetRequestBody(test.input.replicas, test.input.serverName, test.input.imageRef, test.input.vcpu, test.input.memInMi)
+		b, err := constructReplicasetRequestBody(test.input.replicas, test.input.server, test.input.imageRef, test.input.vcpu, test.input.memInMi)
 
 		if err != test.expectedError {
 			t.Fatal(err)

--- a/test/e2e/arktos/testvm.json
+++ b/test/e2e/arktos/testvm.json
@@ -8,5 +8,15 @@
             "uuid":"2608d099-c5cb-45c9-a85e-c7daba9f95bf"
          }
       ]
+      "security_groups": [
+            {
+                "name": "default"
+            }
+        ],
+      "key_name": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaJEcFDXEK2ZbX0ZLS1EIYFZRbDAcRfuVjpstSc0De8+sV1aiu+dePxdkuDRwqFtCyk6dEZkssjOkBXtri00MECLkir6FcH3kKOJtbJ6vy3uaJc9w1ERo+wyl6SkAh/+JTJkp7QRXj8oylW5E20LsbnA/dIwWzAF51PPwF7A7FtNg9DnwPqMkxFo1Th/buOMKbP5ZA1mmNNtmzbMpMfJATvVyiv3ccsSJKOiyQr6UG+j7sc/7jMVz5Xk34Vd0l8GwcB0334MchHckmqDB142h/NCWTr8oLakDNvkfC1YneAfAO41hDkUbxPtVBG5M/o7P4fxoqiHEX+ZLfRxDtHB53 me@localhost"
+      "metadata" : {
+            "TestKey1" : "TestValue1"
+        },
+        "user_data" : "IyEvYmluL2Jhc2gKL2Jpbi9zdQplY2hvICJJIGFtIGluIHlvdSEiCg=="
    }
 }

--- a/test/e2e/arktos/testvm.json
+++ b/test/e2e/arktos/testvm.json
@@ -7,16 +7,15 @@
          {
             "uuid":"2608d099-c5cb-45c9-a85e-c7daba9f95bf"
          }
-      ]
+      ],
       "security_groups": [
             {
                 "name": "default"
             }
-        ],
-      "key_name": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaJEcFDXEK2ZbX0ZLS1EIYFZRbDAcRfuVjpstSc0De8+sV1aiu+dePxdkuDRwqFtCyk6dEZkssjOkBXtri00MECLkir6FcH3kKOJtbJ6vy3uaJc9w1ERo+wyl6SkAh/+JTJkp7QRXj8oylW5E20LsbnA/dIwWzAF51PPwF7A7FtNg9DnwPqMkxFo1Th/buOMKbP5ZA1mmNNtmzbMpMfJATvVyiv3ccsSJKOiyQr6UG+j7sc/7jMVz5Xk34Vd0l8GwcB0334MchHckmqDB142h/NCWTr8oLakDNvkfC1YneAfAO41hDkUbxPtVBG5M/o7P4fxoqiHEX+ZLfRxDtHB53 me@localhost"
+      ],
+      "key_name": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCaJEcFDXEK2ZbX0ZLS1EIYFZRbDAcRfuVjpstSc0De8+sV1aiu+dePxdkuDRwqFtCyk6dEZkssjOkBXtri00MECLkir6FcH3kKOJtbJ6vy3uaJc9w1ERo+wyl6SkAh/+JTJkp7QRXj8oylW5E20LsbnA/dIwWzAF51PPwF7A7FtNg9DnwPqMkxFo1Th/buOMKbP5ZA1mmNNtmzbMpMfJATvVyiv3ccsSJKOiyQr6UG+j7sc/7jMVz5Xk34Vd0l8GwcB0334MchHckmqDB142h/NCWTr8oLakDNvkfC1YneAfAO41hDkUbxPtVBG5M/o7P4fxoqiHEX+ZLfRxDtHB53 me@localhost",
       "metadata" : {
             "TestKey1" : "TestValue1"
-        },
-        "user_data" : "IyEvYmluL2Jhc2gKL2Jpbi9zdQplY2hvICJJIGFtIGluIHlvdSEiCg=="
+      }
    }
 }


### PR DESCRIPTION
Local testing:
```
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# curl -L -k -XPOST -H "Content-Type: application/json" -H "User-Agent: kubectl/v0.9.0 (linux/amd64) kubernetes/$Format" -H "Accept: application/json" -H "openstack: true" 'http://localhost:8080/servers' -d @test/e2e/arktos/testvm.json -v | jq
Note: Unnecessary use of -X or --request, POST is already inferred.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /servers HTTP/1.1
> Host: localhost:8080
> Content-Type: application/json
> User-Agent: kubectl/v0.9.0 (linux/amd64) kubernetes/
> Accept: application/json
> openstack: true
> Content-Length: 775
> 
} [775 bytes data]
* upload completely sent off: 775 out of 775 bytes
< HTTP/1.1 307 Temporary Redirect
< Cache-Control: no-cache, private
< Location: /api/v1/tenants/system/namespaces/kube-system/pods
< Date: Thu, 27 Jan 2022 18:33:16 GMT
< Content-Length: 0
< 
100   775    0     0  100   775      0   756k --:--:-- --:--:-- --:--:--  756k
* Connection #0 to host localhost left intact
* Issue another request to this URL: 'http://localhost:8080/api/v1/tenants/system/namespaces/kube-system/pods'
* Found bundle for host localhost: 0x56295dd6a8d0 [can pipeline]
* Re-using existing connection! (#0) with host localhost
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /api/v1/tenants/system/namespaces/kube-system/pods HTTP/1.1
> Host: localhost:8080
> Content-Type: application/json
> User-Agent: kubectl/v0.9.0 (linux/amd64) kubernetes/
> Accept: application/json
> openstack: true
> Content-Length: 775
> 
} [775 bytes data]
* upload completely sent off: 775 out of 775 bytes
< HTTP/1.1 201 Created
< Cache-Control: no-cache, private
< Content-Type: application/json
< Date: Thu, 27 Jan 2022 18:33:16 GMT
< Content-Length: 112
< 
{ [112 bytes data]
100   887  100   112  100   775  18666   126k --:--:-- --:--:-- --:--:--  144k
* Connection #0 to host localhost left intact
{
  "Id": "testvm",
  "Links": [
    {
      "Link": "/api/v1/namespaces/kube-system/pods/testvm",
      "Rel": ""
    }
  ],
  "Security_groups": null
}
```