### PR TITLE
arktos network controller arg --resource-name-salt  set valid value in kube-up scale-out cluster

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -161,7 +161,7 @@ function main() {
     else
       if [[ "${ARKTOS_SCALEOUT_SERVER_TYPE:-}" == "tp" ]]; then
         if [[ -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
-          start-arktos-network-controller ${KUBERNETES_MASTER_NAME}
+          start-arktos-network-controller ${CLUSTER_NAME}
         fi
         start-cluster-networking   ####start cluster networking if not using default kubenet
       fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR sets --resource-name-salt arg value which does not violate DNS naming check.

Current value is of form of TP server ip, which could not pass the DNS name validation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1318

**Special notes for your reviewer**:
tested on 1tp+1rpx1worker cluster
```
$ kubectl get rs -n kube-system | grep coredns-default
coredns-default-hwc-kubeup-test-tp-1-7456994c79   3444567537333564004   1         1         0       28m
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
