### PR TITLE
Filter Openstack request related VMs in list and basic error handling 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/BUILD
@@ -56,6 +56,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/flushwriter:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/openstack:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/wsstream:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"sync"
 
+	"k8s.io/apiserver/pkg/util/openstack"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -255,6 +256,15 @@ func WriteObjectNegotiated(s runtime.NegotiatedSerializer, restrictions negotiat
 func ErrorNegotiated(err error, s runtime.NegotiatedSerializer, gv schema.GroupVersion, w http.ResponseWriter, req *http.Request) int {
 	status := ErrorToAPIStatus(err)
 	code := int(status.Code)
+
+	if openstack.IsOpenstackRequest(req) {
+
+		//TODO:Identify more Arktos specfic terms to replace if needed
+		t := openstack.Openstack_error{Message: strings.ReplaceAll(status.Message, "pod", "server"), ErrorCode: code, Reason: string(status.Reason)}
+		WriteRawJSON(code, t, w)
+		return code
+	}
+
 	// when writing an error, check to see if the status indicates a retry after period
 	if status.Details != nil && status.Details.RetryAfterSeconds > 0 {
 		delay := strconv.Itoa(int(status.Details.RetryAfterSeconds))

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/apiserver/pkg/util/openstack"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -39,6 +38,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/flushwriter"
+	"k8s.io/apiserver/pkg/util/openstack"
 	"k8s.io/apiserver/pkg/util/wsstream"
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/openstack.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/openstack.go
@@ -224,7 +224,9 @@ func (o Openstack) serverHandler(resp http.ResponseWriter, req *http.Request) {
 			return
 		}
 		if rev_id != "" {
-			redirectUrl += fmt.Sprintf("?labelSelector=ln=%s", rev_id)
+			redirectUrl += fmt.Sprintf("?labelSelector=%s=true,ln=%s", openstack.OPENSTACK_API, rev_id)
+		} else {
+			redirectUrl += fmt.Sprintf("?labelSelector=%s=true", openstack.OPENSTACK_API)
 		}
 
 	case http.MethodDelete:

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/types.go
@@ -30,9 +30,16 @@ import (
 
 const (
 	LABEL_SELECTOR_NAME = "ln"
+	OPENSTACK_API = "openstsckApi"
 )
 
 var cpuModelAnnotation = map[string]string{"VirtletCPUModel": "host-model"}
+
+type Openstack_error struct {
+	Message string `json:"message"`
+	ErrorCode int `json:"errorcode"`
+	Reason string `json:"reason"`
+}
 
 type Network struct {
 	Uuid     string `json:"uuid"`
@@ -243,7 +250,7 @@ func constructReplicasetRequestBody(replicas int, server ServerType, imageRef st
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: cpuModelAnnotation,
-				Labels:      map[string]string{LABEL_SELECTOR_NAME: server.Name},
+				Labels:      map[string]string{LABEL_SELECTOR_NAME: server.Name, OPENSTACK_API:"true"},
 			},
 			Spec: v1.PodSpec{
 				VirtualMachine: constructVMSpec(server, imageRef, vcpu, memInMi),
@@ -277,6 +284,7 @@ func constructVmPodRequestBody(server ServerType, imageRef string, vcpu, memInMi
 		Namespace:   metav1.NamespaceSystem,
 		Tenant:      metav1.TenantSystem,
 		Annotations: cpuModelAnnotation,
+		Labels: map[string]string{OPENSTACK_API:"true"},
 	}
 
 	t.Spec = v1.PodSpec{

--- a/staging/src/k8s.io/apiserver/pkg/util/openstack/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/openstack/types.go
@@ -30,15 +30,15 @@ import (
 
 const (
 	LABEL_SELECTOR_NAME = "ln"
-	OPENSTACK_API = "openstsckApi"
+	OPENSTACK_API       = "openstsckApi"
 )
 
 var cpuModelAnnotation = map[string]string{"VirtletCPUModel": "host-model"}
 
 type Openstack_error struct {
-	Message string `json:"message"`
-	ErrorCode int `json:"errorcode"`
-	Reason string `json:"reason"`
+	Message   string `json:"message"`
+	ErrorCode int    `json:"errorcode"`
+	Reason    string `json:"reason"`
 }
 
 type Network struct {
@@ -250,7 +250,7 @@ func constructReplicasetRequestBody(replicas int, server ServerType, imageRef st
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: cpuModelAnnotation,
-				Labels:      map[string]string{LABEL_SELECTOR_NAME: server.Name, OPENSTACK_API:"true"},
+				Labels:      map[string]string{LABEL_SELECTOR_NAME: server.Name, OPENSTACK_API: "true"},
 			},
 			Spec: v1.PodSpec{
 				VirtualMachine: constructVMSpec(server, imageRef, vcpu, memInMi),
@@ -284,7 +284,7 @@ func constructVmPodRequestBody(server ServerType, imageRef string, vcpu, memInMi
 		Namespace:   metav1.NamespaceSystem,
 		Tenant:      metav1.TenantSystem,
 		Annotations: cpuModelAnnotation,
-		Labels: map[string]string{OPENSTACK_API:"true"},
+		Labels:      map[string]string{OPENSTACK_API: "true"},
 	}
 
 	t.Spec = v1.PodSpec{

--- a/test/e2e/arktos/testvm-batch.json
+++ b/test/e2e/arktos/testvm-batch.json
@@ -7,7 +7,8 @@
       {
         "uuid":"2608d099-c5cb-45c9-a85e-c7daba9f95bf"
       }
-    ]
+    ],
+    "key_name": "ssh-rsa AAAA"
   },
   "min_count":3,
   "max_count":3,


### PR DESCRIPTION
local test:
```
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# curl -L -k -XGET -H "Content-Type: application/json" -H "User-Agent: kubectl/v0.9.0 (linux/amd64) kubernetes/$Format" -H "Accept: application/json" -H "openstack: true" 'http://localhost:8080/servers' -d @test/e2e/arktos/testvm-list.json -v | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /servers HTTP/1.1
> Host: localhost:8080
> Content-Type: application/json
> User-Agent: kubectl/v0.9.0 (linux/amd64) kubernetes/
> Accept: application/json
> openstack: true
> Content-Length: 29
> 
} [29 bytes data]
* upload completely sent off: 29 out of 29 bytes
< HTTP/1.1 307 Temporary Redirect
< Cache-Control: no-cache, private
< Content-Type: text/html; charset=utf-8
< Location: /api/v1/tenants/system/namespaces/kube-system/pods?labelSelector=openstsckApi=true,ln=testvm
< Date: Mon, 31 Jan 2022 17:15:32 GMT
< Content-Length: 128
< 
* Ignoring the response-body
{ [128 bytes data]
100   157  100   128  100    29   125k  29000 --:--:-- --:--:-- --:--:--  153k
* Connection #0 to host localhost left intact
* Issue another request to this URL: 'http://localhost:8080/api/v1/tenants/system/namespaces/kube-system/pods?labelSelector=openstsckApi=true,ln=testvm'
* Found bundle for host localhost: 0x559d82c98ae0 [can pipeline]
* Re-using existing connection! (#0) with host localhost
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /api/v1/tenants/system/namespaces/kube-system/pods?labelSelector=openstsckApi=true,ln=testvm HTTP/1.1
> Host: localhost:8080
> Content-Type: application/json
> User-Agent: kubectl/v0.9.0 (linux/amd64) kubernetes/
> Accept: application/json
> openstack: true
> Content-Length: 29
> 
} [29 bytes data]
* upload completely sent off: 29 out of 29 bytes
< HTTP/1.1 200 OK
< Cache-Control: no-cache, private
< Content-Type: application/json
< Date: Mon, 31 Jan 2022 17:15:32 GMT
< Content-Length: 15
< 
{ [15 bytes data]
100    44  100    15  100    29   3750   7250 --:--:-- --:--:-- --:--:-- 11000
* Connection #0 to host localhost left intact
{
  "Servers": []
}
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# curl -L -k -XPOST -H "Content-Type: application/json" -H "User-Agent: kubectl/v0.9.0 (linux/amd64) kubernetes/$Format" -H "Accept: application/json" -H "openstack: true" 'http://localhost:8080/servers' -d @test/e2e/arktos/testvm-batch.json -v | jq
Note: Unnecessary use of -X or --request, POST is already inferred.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /servers HTTP/1.1
> Host: localhost:8080
> Content-Type: application/json
> User-Agent: kubectl/v0.9.0 (linux/amd64) kubernetes/
> Accept: application/json
> openstack: true
> Content-Length: 275
> 
} [275 bytes data]
* upload completely sent off: 275 out of 275 bytes
< HTTP/1.1 307 Temporary Redirect
< Cache-Control: no-cache, private
< Location: /apis/apps/v1/tenants/system/namespaces/kube-system/replicasets
< Date: Mon, 31 Jan 2022 17:15:57 GMT
< Content-Length: 0
< 
100   275    0     0  100   275      0   268k --:--:-- --:--:-- --:--:--  268k
* Connection #0 to host localhost left intact
* Issue another request to this URL: 'http://localhost:8080/apis/apps/v1/tenants/system/namespaces/kube-system/replicasets'
* Found bundle for host localhost: 0x565178e53980 [can pipeline]
* Re-using existing connection! (#0) with host localhost
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /apis/apps/v1/tenants/system/namespaces/kube-system/replicasets HTTP/1.1
> Host: localhost:8080
> Content-Type: application/json
> User-Agent: kubectl/v0.9.0 (linux/amd64) kubernetes/
> Accept: application/json
> openstack: true
> Content-Length: 275
> 
} [275 bytes data]
* upload completely sent off: 275 out of 275 bytes
< HTTP/1.1 201 Created
< Cache-Control: no-cache, private
< Content-Type: application/json
< Date: Mon, 31 Jan 2022 17:15:57 GMT
< Content-Length: 28
< 
{ [28 bytes data]
100   303  100    28  100   275   4666  45833 --:--:-- --:--:-- --:--:-- 50499
* Connection #0 to host localhost left intact
{
  "reservation_id": "testvm"
}
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# curl -L -k -XGET -H "Content-Type: application/json" -H "User-Agent: kubectl/v0.9.0 (linux/amd64) kubernetes/$Format" -H "Accept: application/json" -H "openstack: true" 'http://localhost:8080/servers' -d @test/e2e/arktos/testvm-list.json -v | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /servers HTTP/1.1
> Host: localhost:8080
> Content-Type: application/json
> User-Agent: kubectl/v0.9.0 (linux/amd64) kubernetes/
> Accept: application/json
> openstack: true
> Content-Length: 29
> 
} [29 bytes data]
* upload completely sent off: 29 out of 29 bytes
< HTTP/1.1 307 Temporary Redirect
< Cache-Control: no-cache, private
< Content-Type: text/html; charset=utf-8
< Location: /api/v1/tenants/system/namespaces/kube-system/pods?labelSelector=openstsckApi=true,ln=testvm
< Date: Mon, 31 Jan 2022 17:16:01 GMT
< Content-Length: 128
< 
* Ignoring the response-body
{ [128 bytes data]
100   157  100   128  100    29   1855    420 --:--:-- --:--:-- --:--:--  2275
* Connection #0 to host localhost left intact
* Issue another request to this URL: 'http://localhost:8080/api/v1/tenants/system/namespaces/kube-system/pods?labelSelector=openstsckApi=true,ln=testvm'
* Found bundle for host localhost: 0x55ca7b932ae0 [can pipeline]
* Re-using existing connection! (#0) with host localhost
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /api/v1/tenants/system/namespaces/kube-system/pods?labelSelector=openstsckApi=true,ln=testvm HTTP/1.1
> Host: localhost:8080
> Content-Type: application/json
> User-Agent: kubectl/v0.9.0 (linux/amd64) kubernetes/
> Accept: application/json
> openstack: true
> Content-Length: 29
> 
} [29 bytes data]
* upload completely sent off: 29 out of 29 bytes
< HTTP/1.1 200 OK
< Cache-Control: no-cache, private
< Content-Type: application/json
< Date: Mon, 31 Jan 2022 17:16:01 GMT
< Content-Length: 386
< 
{ [386 bytes data]
100   415  100   386  100    29   4825    362 --:--:-- --:--:-- --:--:--  5187
* Connection #0 to host localhost left intact
{
  "Servers": [
    {
      "Id": "testvm-mqq8f",
      "Links": [
        {
          "Link": "/api/v1/namespaces/kube-system/pods/testvm-mqq8f",
          "Rel": ""
        }
      ],
      "Security_groups": null
    },
    {
      "Id": "testvm-th59p",
      "Links": [
        {
          "Link": "/api/v1/namespaces/kube-system/pods/testvm-th59p",
          "Rel": ""
        }
      ],
      "Security_groups": null
    },
    {
      "Id": "testvm-wzbm9",
      "Links": [
        {
          "Link": "/api/v1/namespaces/kube-system/pods/testvm-wzbm9",
          "Rel": ""
        }
      ],
      "Security_groups": null
    }
  ]
}
root@ip-172-31-10-115:/work/src/k8s.io/kubernetes# curl -L -k -H "Content-Type: application/json" -H "User-Agent: kubectl/v0.9.0 (linux/amd64) kubernetes/$Format" -H "Accept: application/json" -H "openstack: true" 'http://localhost:8080/servers/abc' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   122  100   122    0     0  24400      0 --:--:-- --:--:-- --:--:-- 24400
100    88  100    88    0     0   3034      0 --:--:-- --:--:-- --:--:--  3034
{
  "message": "servers \"abc\" not found",
  "errorcode": 404,
  "reason": "NotFound"
}

```
