### PR TITLE
Wait mizar ready when starting up local cluster

### DIFF
--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -711,13 +711,11 @@ echo "Arktos Setup done."
 #echo "Kata Setup done."
 #echo "*******************************************"
 
-print_success
-
-if [ IS_RESOURCE_PARTITION == "true" and "${CNIPLUGIN}" == "mizar" ]; then
-  echo "*******************************************"
+if [ "${CNIPLUGIN}" == "mizar" ] && [ "${IS_RESOURCE_PARTITION}" == "false" ]; then
   kube::common::wait-until-mizar-ready
-  echo "Tenant Partition is ready. Press Ctrl-C to shut it down."
 fi
+
+print_success
 
 if [[ "${ENABLE_DAEMON}" = false ]]; then
   while true; do sleep 1; healthcheck; done

--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -713,6 +713,12 @@ echo "Arktos Setup done."
 
 print_success
 
+if [ IS_RESOURCE_PARTITION == "true" and "${CNIPLUGIN}" == "mizar" ]; then
+  echo "*******************************************"
+  kube::common::wait-until-mizar-ready
+  echo "Tenant Partition is ready. Press Ctrl-C to shut it down."
+fi
+
 if [[ "${ENABLE_DAEMON}" = false ]]; then
   while true; do sleep 1; healthcheck; done
 fi

--- a/hack/arktos-up.sh
+++ b/hack/arktos-up.sh
@@ -613,7 +613,7 @@ print_success
 if [ "${CNIPLUGIN}" == "mizar" ]; then
   echo "*******************************************"
   kube::common::wait-until-mizar-ready
-  echo "Local Kubernetes cluster is running with Mizar. Press Ctrl-C to shut it down."
+  echo "Local Kubernetes cluster is ready. Press Ctrl-C to shut it down."
 fi
 
 if [[ "${ENABLE_DAEMON}" = false ]]; then

--- a/hack/arktos-up.sh
+++ b/hack/arktos-up.sh
@@ -608,13 +608,11 @@ KUBECTL=${KUBECTL} "${KUBE_ROOT}"/hack/install-kata.sh
 echo "Kata Setup done."
 echo "*******************************************"
 
-print_success
-
 if [ "${CNIPLUGIN}" == "mizar" ]; then
-  echo "*******************************************"
   kube::common::wait-until-mizar-ready
-  echo "Local Kubernetes cluster is ready. Press Ctrl-C to shut it down."
 fi
+
+print_success
 
 if [[ "${ENABLE_DAEMON}" = false ]]; then
   while true; do sleep 1; healthcheck; done

--- a/hack/arktos-up.sh
+++ b/hack/arktos-up.sh
@@ -610,6 +610,12 @@ echo "*******************************************"
 
 print_success
 
+if [ "${CNIPLUGIN}" == "mizar" ]; then
+  echo "*******************************************"
+  kube::common::wait-until-mizar-ready
+  echo "Local Kubernetes cluster is running with Mizar. Press Ctrl-C to shut it down."
+fi
+
 if [[ "${ENABLE_DAEMON}" = false ]]; then
   while true; do sleep 1; healthcheck; done
 fi

--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -878,17 +878,22 @@ function kube::common::generate_kubeproxy_certs {
 
 function kube::common::wait-until-mizar-ready {
     echo "Waiting for Mizar CRDs to reach 'Provisioned' state ..."
-    until ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" get vpcs | grep Provisioned; do
+    until ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" get vpcs 2> /dev/null | grep Provisioned > /dev/null; do
+        echo -n .
         sleep 5
     done
-    until ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" get dividers | grep Provisioned; do
+    until ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" get dividers 2> /dev/null | grep Provisioned > /dev/null; do
+        echo -n .
         sleep 5
     done
-    until ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" get bouncers | grep Provisioned; do
+    until ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" get bouncers 2> /dev/null | grep Provisioned > /dev/null; do
+        echo -n .
         sleep 5
     done
-    until ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" get subnets | grep Provisioned; do
+    until ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" get subnets 2> /dev/null | grep Provisioned > /dev/null; do
+        echo -n .
         sleep 5
     done
+    echo
     echo "Mizar is ready."
 }

--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -877,7 +877,7 @@ function kube::common::generate_kubeproxy_certs {
 }
 
 function kube::common::wait-until-mizar-ready {
-    echo "Waiting for Mizar CRDs to reach 'Provisioned' state ..."
+    echo "Waiting for Mizar CRDs to reach 'Provisioned' state"
     until ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" get vpcs 2> /dev/null | grep Provisioned > /dev/null; do
         echo -n .
         sleep 5

--- a/hack/lib/common.sh
+++ b/hack/lib/common.sh
@@ -876,4 +876,19 @@ function kube::common::generate_kubeproxy_certs {
     fi
 }
 
-
+function kube::common::wait-until-mizar-ready {
+    echo "Waiting for Mizar CRDs to reach 'Provisioned' state ..."
+    until ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" get vpcs | grep Provisioned; do
+        sleep 5
+    done
+    until ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" get dividers | grep Provisioned; do
+        sleep 5
+    done
+    until ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" get bouncers | grep Provisioned; do
+        sleep 5
+    done
+    until ${KUBECTL} --kubeconfig "${CERT_DIR}/admin.kubeconfig" get subnets | grep Provisioned; do
+        sleep 5
+    done
+    echo "Mizar is ready."
+}


### PR DESCRIPTION
When starting up arktos cluster, if cni plugin is Mizar, there need some time for Mizar to be in "Provisioned" state which indicate Mizar is ready.
This pr is to add a waiting until Mizar is ready.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind feature

**Special notes for your reviewer**:
1. For the newly added func kube::common::wait-until-mizar-ready, it's copied from existing code in cluster/gce/ubuntu/configure-helper-common.sh line 3291 function wait-until-mizar-ready. 
I was considering using the same func there but from its location it's not proper to use it. 
I'm opening to suggestion from reviewer on how the functions shall be organized.
2. We need to do the same thing for arktos-up-scale-out-poc.sh. I want to do it after item 1 is decided.

**Does this PR introduce a user-facing change?**:
NONE