### PR TITLE
[kube-up][scale-out]Automatically create default mizar vpc and subnet for tenants 

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -942,9 +942,9 @@ EOF
 DISABLE_NETWORK_SERVICE_SUPPORT: $(yaml-quote ${DISABLE_NETWORK_SERVICE_SUPPORT})
 EOF
     fi
-    if [ -n "${DISABLE_ADMISSION_PLUGINS:-}" ]; then
+    if [ -n "${NETWORK_PROVIDER:-}" ]; then
       cat >>$file <<EOF
-DISABLE_ADMISSION_PLUGINS: $(yaml-quote ${DISABLE_ADMISSION_PLUGINS})
+NETWORK_PROVIDER: $(yaml-quote ${NETWORK_PROVIDER})
 EOF
     fi
     if [ -n "${INITIAL_ETCD_CLUSTER:-}" ]; then

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -942,9 +942,9 @@ EOF
 DISABLE_NETWORK_SERVICE_SUPPORT: $(yaml-quote ${DISABLE_NETWORK_SERVICE_SUPPORT})
 EOF
     fi
-    if [ -n "${NETWORK_PROVIDER:-}" ]; then
+    if [ -n "${DISABLE_ADMISSION_PLUGINS:-}" ]; then
       cat >>$file <<EOF
-NETWORK_PROVIDER: $(yaml-quote ${NETWORK_PROVIDER})
+DISABLE_ADMISSION_PLUGINS: $(yaml-quote ${DISABLE_ADMISSION_PLUGINS})
 EOF
     fi
     if [ -n "${INITIAL_ETCD_CLUSTER:-}" ]; then

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -354,8 +354,9 @@ fi
  # pod is associated to certain network, which has its own DNS service.
  # By default, this feature is enabled in the dev cluster started by this script.
 DISABLE_NETWORK_SERVICE_SUPPORT="${DISABLE_NETWORK_SERVICE_SUPPORT:-}"
-DISABLE_ADMISSION_PLUGINS=${DISABLE_ADMISSION_PLUGINS:-""}
 ARKTOS_NETWORK_TEMPLATE="${ARKTOS_NETWORK_TEMPLATE:-}"
+VPC_NETWORK_TEMPLATE="${VPC_NETWORK_TEMPLATE:-}"
+SUBNET_NETWORK_TEMPLATE="${SUBNET_NETWORK_TEMPLATE:-}"
 
 # check for network service support flags
 if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
@@ -365,12 +366,11 @@ if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
   # tenant controller automatically creates a default network resource for new tenant
   if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
     ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network.json"
+    VPC_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network_vpc_template.json"
+    SUBNET_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network_subnet_template.json"
   else
     ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/testdata/default-flat-network.tmpl"
   fi
-else # when disabled
-  # kube-apiserver not to enforce deployment-network validation
-  DISABLE_ADMISSION_PLUGINS="DeploymentNetwork"
 fi
 
 # Optional: Install cluster DNS.

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -354,9 +354,8 @@ fi
  # pod is associated to certain network, which has its own DNS service.
  # By default, this feature is enabled in the dev cluster started by this script.
 DISABLE_NETWORK_SERVICE_SUPPORT="${DISABLE_NETWORK_SERVICE_SUPPORT:-}"
+DISABLE_ADMISSION_PLUGINS=${DISABLE_ADMISSION_PLUGINS:-""}
 ARKTOS_NETWORK_TEMPLATE="${ARKTOS_NETWORK_TEMPLATE:-}"
-VPC_NETWORK_TEMPLATE="${VPC_NETWORK_TEMPLATE:-}"
-SUBNET_NETWORK_TEMPLATE="${SUBNET_NETWORK_TEMPLATE:-}"
 
 # check for network service support flags
 if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
@@ -366,11 +365,21 @@ if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
   # tenant controller automatically creates a default network resource for new tenant
   if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
     ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network.json"
-    VPC_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network_vpc_template.json"
-    SUBNET_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network_subnet_template.json"
   else
     ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/testdata/default-flat-network.tmpl"
   fi
+else # when disabled
+  # kube-apiserver not to enforce deployment-network validation
+  DISABLE_ADMISSION_PLUGINS="DeploymentNetwork"
+fi
+
+# When NETWORK_PROVIDER is set to mizar, the template files of default 
+# vpc and subnets are provided here
+VPC_NETWORK_TEMPLATE="${VPC_NETWORK_TEMPLATE:-}"
+SUBNET_NETWORK_TEMPLATE="${SUBNET_NETWORK_TEMPLATE:-}"
+if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+  VPC_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network_vpc_template.json"
+  SUBNET_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network_subnet_template.json"
 fi
 
 # Optional: Install cluster DNS.

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -365,8 +365,9 @@ fi
  # pod is associated to certain network, which has its own DNS service.
  # By default, this feature is enabled in the dev cluster started by this script.
 DISABLE_NETWORK_SERVICE_SUPPORT="${DISABLE_NETWORK_SERVICE_SUPPORT:-}"
-DISABLE_ADMISSION_PLUGINS=${DISABLE_ADMISSION_PLUGINS:-""}
 ARKTOS_NETWORK_TEMPLATE="${ARKTOS_NETWORK_TEMPLATE:-}"
+VPC_NETWORK_TEMPLATE="${VPC_NETWORK_TEMPLATE:-}"
+SUBNET_NETWORK_TEMPLATE="${SUBNET_NETWORK_TEMPLATE:-}"
 
 # check for network service support flags
 if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
@@ -376,12 +377,11 @@ if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
   # tenant controller automatically creates a default network resource for new tenant
   if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
     ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network.json"
+    VPC_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network_vpc_template.json"
+    SUBNET_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network_subnet_template.json"
   else
     ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/testdata/default-flat-network.tmpl"
   fi
-else # when disabled
-  # kube-apiserver not to enforce deployment-network validation
-  DISABLE_ADMISSION_PLUGINS="DeploymentNetwork"
 fi
 
 # Optional: Install cluster DNS.

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -365,9 +365,8 @@ fi
  # pod is associated to certain network, which has its own DNS service.
  # By default, this feature is enabled in the dev cluster started by this script.
 DISABLE_NETWORK_SERVICE_SUPPORT="${DISABLE_NETWORK_SERVICE_SUPPORT:-}"
+DISABLE_ADMISSION_PLUGINS=${DISABLE_ADMISSION_PLUGINS:-""}
 ARKTOS_NETWORK_TEMPLATE="${ARKTOS_NETWORK_TEMPLATE:-}"
-VPC_NETWORK_TEMPLATE="${VPC_NETWORK_TEMPLATE:-}"
-SUBNET_NETWORK_TEMPLATE="${SUBNET_NETWORK_TEMPLATE:-}"
 
 # check for network service support flags
 if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
@@ -377,11 +376,21 @@ if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
   # tenant controller automatically creates a default network resource for new tenant
   if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
     ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network.json"
-    VPC_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network_vpc_template.json"
-    SUBNET_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network_subnet_template.json"
   else
     ARKTOS_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/testdata/default-flat-network.tmpl"
   fi
+else # when disabled
+  # kube-apiserver not to enforce deployment-network validation
+  DISABLE_ADMISSION_PLUGINS="DeploymentNetwork"
+fi
+
+# When NETWORK_PROVIDER is set to mizar, the template files of default
+# vpc and subnets are provided here
+VPC_NETWORK_TEMPLATE="${VPC_NETWORK_TEMPLATE:-}"
+SUBNET_NETWORK_TEMPLATE="${SUBNET_NETWORK_TEMPLATE:-}"
+if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+  VPC_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network_vpc_template.json"
+  SUBNET_NETWORK_TEMPLATE="${KUBE_ROOT}/hack/runtime/default_mizar_network_subnet_template.json"
 fi
 
 # Optional: Install cluster DNS.

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -1805,9 +1805,6 @@ function start-kube-apiserver {
   if [[ -n "${ENABLE_GARBAGE_COLLECTOR:-}" ]]; then
     params+=" --enable-garbage-collector=${ENABLE_GARBAGE_COLLECTOR}"
   fi
-  if [[ -n "${DISABLE_ADMISSION_PLUGINS:-}" ]]; then
-    params+=" --disable-admission-plugins=${DISABLE_ADMISSION_PLUGINS}"
-  fi
 
   if [[ -n "${NUM_NODES:-}" ]]; then
     local max_request_inflight="-1"
@@ -2358,7 +2355,7 @@ function start-kube-controller-manager {
   if [[ -n "${RUN_CONTROLLERS:-}" ]]; then
     params+=" --controllers=${RUN_CONTROLLERS}"
   fi
-  if [[ -s ${DEFAULT_NETWORK_TEMPLATE} && -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
+  if [[ -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" && -s ${DEFAULT_NETWORK_TEMPLATE} ]]; then
     params+=" --default-network-template-path=$DEFAULT_NETWORK_TEMPLATE"
   fi
 
@@ -2389,11 +2386,37 @@ function start-kube-controller-manager {
   sed -i -e "s@{{additional_cloud_config_volume}}@@g" "${src_file}"
   sed -i -e "s@{{pv_recycler_mount}}@${PV_RECYCLER_MOUNT}@g" "${src_file}"
   sed -i -e "s@{{pv_recycler_volume}}@${PV_RECYCLER_VOLUME}@g" "${src_file}"
-  sed -i -e "s@{{defaulttemplate_hostpath_mount}}@${DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT}@g" "${src_file}"
-  sed -i -e "s@{{defaulttemplate_hostpath}}@${DEFAULT_NETWORK_TEMPLATE_PATH_VOLUME}@g" "${src_file}"
   sed -i -e "s@{{flexvolume_hostpath_mount}}@${FLEXVOLUME_HOSTPATH_MOUNT}@g" "${src_file}"
   sed -i -e "s@{{flexvolume_hostpath}}@${FLEXVOLUME_HOSTPATH_VOLUME}@g" "${src_file}"
   sed -i -e "s@{{cpurequest}}@${KUBE_CONTROLLER_MANAGER_CPU_REQUEST}@g" "${src_file}"
+
+  if [[ -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
+    sed -i -e "s@{{defaulttemplate_hostpath_mount}}@${DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT}@g" "${src_file}"
+    sed -i -e "s@{{defaulttemplate_hostpath}}@${DEFAULT_NETWORK_TEMPLATE_PATH_VOLUME}@g" "${src_file}"
+
+    if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+      sed -i -e "s@{{defaultvpctemplate_hostpath_mount}}@${DEFAULT_VPC_TEMPLATE_PATH_MOUNT}@g" "${src_file}"
+      sed -i -e "s@{{defaultvpctemplate_hostpath}}@${DEFAULT_VPC_TEMPLATE_PATH_VOLUME}@g" "${src_file}"
+
+      sed -i -e "s@{{defaultsubnettemplate_hostpath_mount}}@${DEFAULT_SUBNET_TEMPLATE_PATH_MOUNT}@g" "${src_file}"
+      sed -i -e "s@{{defaultsubnettemplate_hostpath}}@${DEFAULT_SUBNET_TEMPLATE_PATH_VOLUME}@g" "${src_file}"
+    else
+      sed -i -e "/{{defaultvpctemplate_hostpath}}/d" "${src_file}"
+      sed -i -e "/{{defaultvpctemplate_hostpath_mount}}/d" "${src_file}"
+
+      sed -i -e "/{{defaultsubnettemplate_hostpath}}/d" "${src_file}"
+      sed -i -e "/{{defaultsubnettemplate_hostpath_mount}}/d" "${src_file}"
+    fi
+  else
+    sed -i -e "/{{defaulttemplate_hostpath}}/d" "${src_file}"
+    sed -i -e "/{{defaulttemplate_hostpath_mount}}/d" "${src_file}"
+
+    sed -i -e "/{{defaultvpctemplate_hostpath}}/d" "${src_file}"
+    sed -i -e "/{{defaultvpctemplate_hostpath_mount}}/d" "${src_file}"
+
+    sed -i -e "/{{defaultsubnettemplate_hostpath}}/d" "${src_file}"
+    sed -i -e "/{{defaultsubnettemplate_hostpath_mount}}/d" "${src_file}"
+  fi
 
   cp "${src_file}" /etc/kubernetes/manifests
 }
@@ -3461,6 +3484,23 @@ function create-default-network-template-volume-mount {
   DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT="{\"name\": \"defaulttemplate\",\"mountPath\": \"${DEFAULT_NETWORK_TEMPLATE}\", \"readOnly\": false},"
 
   cat > ${DEFAULT_NETWORK_TEMPLATE} < ${KUBE_HOME}/network.tmpl
+
+  if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+    if [[ -z "${DEFAULT_VPC_TEMPLATE_PATH:-}" || -z "${DEFAULT_SUBNET_TEMPLATE_PATH:-}" ]]; then
+      echo "DEFAULT_VPC_TEMPLATE_PATH or DEFAULT_SUBNET_TEMPLATE_PATH is not set"
+      exit 1
+    fi
+
+    DEFAULT_VPC_TEMPLATE_PATH_VOLUME="{\"name\": \"defaultvpctemplate\",\"hostPath\": {\"path\": \"${DEFAULT_VPC_TEMPLATE_PATH}\", \"type\": \"File\"}},"
+    DEFAULT_VPC_TEMPLATE_PATH_MOUNT="{\"name\": \"defaultvpctemplate\",\"mountPath\": \"${DEFAULT_VPC_TEMPLATE_PATH}\", \"readOnly\": false},"
+
+    DEFAULT_SUBNET_TEMPLATE_PATH_VOLUME="{\"name\": \"defaultsubnettemplate\",\"hostPath\": {\"path\": \"${DEFAULT_SUBNET_TEMPLATE_PATH}\", \"type\": \"File\"}},"
+    DEFAULT_SUBNET_TEMPLATE_PATH_MOUNT="{\"name\": \"defaultsubnettemplate\",\"mountPath\": \"${DEFAULT_SUBNET_TEMPLATE_PATH}\", \"readOnly\": false},"
+
+    mkdir -p "${DEFAULT_PATH}"
+    cat > ${DEFAULT_VPC_TEMPLATE_PATH} < ${KUBE_HOME}/vpc.tmpl
+    cat > ${DEFAULT_SUBNET_TEMPLATE_PATH} < ${KUBE_HOME}/subnet.tmpl
+  fi
 }
 
 function wait-till-apiserver-ready() {

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -2390,32 +2390,28 @@ function start-kube-controller-manager {
   sed -i -e "s@{{flexvolume_hostpath}}@${FLEXVOLUME_HOSTPATH_VOLUME}@g" "${src_file}"
   sed -i -e "s@{{cpurequest}}@${KUBE_CONTROLLER_MANAGER_CPU_REQUEST}@g" "${src_file}"
 
+  # For default arktos network controller
   if [[ -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
     sed -i -e "s@{{defaulttemplate_hostpath_mount}}@${DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT}@g" "${src_file}"
     sed -i -e "s@{{defaulttemplate_hostpath}}@${DEFAULT_NETWORK_TEMPLATE_PATH_VOLUME}@g" "${src_file}"
+  else
+    sed -i -e "/{{defaulttemplate_hostpath}}/d" "${src_file}"
+    sed -i -e "/{{defaulttemplate_hostpath_mount}}/d" "${src_file}"
+  fi
 
-    if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+  # For mizar default vpc and subnet
+  if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
       sed -i -e "s@{{defaultvpctemplate_hostpath_mount}}@${DEFAULT_VPC_TEMPLATE_PATH_MOUNT}@g" "${src_file}"
       sed -i -e "s@{{defaultvpctemplate_hostpath}}@${DEFAULT_VPC_TEMPLATE_PATH_VOLUME}@g" "${src_file}"
 
       sed -i -e "s@{{defaultsubnettemplate_hostpath_mount}}@${DEFAULT_SUBNET_TEMPLATE_PATH_MOUNT}@g" "${src_file}"
       sed -i -e "s@{{defaultsubnettemplate_hostpath}}@${DEFAULT_SUBNET_TEMPLATE_PATH_VOLUME}@g" "${src_file}"
-    else
+  else
       sed -i -e "/{{defaultvpctemplate_hostpath}}/d" "${src_file}"
       sed -i -e "/{{defaultvpctemplate_hostpath_mount}}/d" "${src_file}"
 
       sed -i -e "/{{defaultsubnettemplate_hostpath}}/d" "${src_file}"
       sed -i -e "/{{defaultsubnettemplate_hostpath_mount}}/d" "${src_file}"
-    fi
-  else
-    sed -i -e "/{{defaulttemplate_hostpath}}/d" "${src_file}"
-    sed -i -e "/{{defaulttemplate_hostpath_mount}}/d" "${src_file}"
-
-    sed -i -e "/{{defaultvpctemplate_hostpath}}/d" "${src_file}"
-    sed -i -e "/{{defaultvpctemplate_hostpath_mount}}/d" "${src_file}"
-
-    sed -i -e "/{{defaultsubnettemplate_hostpath}}/d" "${src_file}"
-    sed -i -e "/{{defaultsubnettemplate_hostpath_mount}}/d" "${src_file}"
   fi
 
   cp "${src_file}" /etc/kubernetes/manifests
@@ -3484,7 +3480,9 @@ function create-default-network-template-volume-mount {
   DEFAULT_NETWORK_TEMPLATE_PATH_MOUNT="{\"name\": \"defaulttemplate\",\"mountPath\": \"${DEFAULT_NETWORK_TEMPLATE}\", \"readOnly\": false},"
 
   cat > ${DEFAULT_NETWORK_TEMPLATE} < ${KUBE_HOME}/network.tmpl
+}
 
+function create-default-vpc-subnet-template-volume-mount {
   if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
     if [[ -z "${DEFAULT_VPC_TEMPLATE_PATH:-}" || -z "${DEFAULT_SUBNET_TEMPLATE_PATH:-}" ]]; then
       echo "DEFAULT_VPC_TEMPLATE_PATH or DEFAULT_SUBNET_TEMPLATE_PATH is not set"

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -53,6 +53,9 @@ function main() {
   CONTAINERIZED_MOUNTER_HOME="${KUBE_HOME}/containerized_mounter"
   PV_RECYCLER_OVERRIDE_TEMPLATE="${KUBE_HOME}/kube-manifests/kubernetes/pv-recycler-template.yaml"
   DEFAULT_NETWORK_TEMPLATE="${KUBE_HOME}/kube-manifests/kubernetes/default-network.tmpl"
+  DEFAULT_PATH="/hack/runtime"
+  DEFAULT_VPC_TEMPLATE_PATH="${DEFAULT_PATH}/default_mizar_network_vpc_template.json"
+  DEFAULT_SUBNET_TEMPLATE_PATH="${DEFAULT_PATH}/default_mizar_network_subnet_template.json"
 
   if [[ ! -e "${KUBE_HOME}/kube-env" ]]; then
     echo "The ${KUBE_HOME}/kube-env file does not exist!! Terminate cluster initialization."
@@ -94,7 +97,9 @@ function main() {
     create-master-etcd-auth
     create-master-etcd-apiserver-auth
     override-pv-recycler
-    create-default-network-template-volume-mount
+    if [[ -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
+      create-default-network-template-volume-mount
+    fi
     gke-master-start
     if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]] && [[ "${SCALEOUT_CLUSTER:-false}" == "false" ]]; then
       create-kubeproxy-user-kubeconfig

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -103,6 +103,7 @@ function main() {
     gke-master-start
     if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]] && [[ "${SCALEOUT_CLUSTER:-false}" == "false" ]]; then
       create-kubeproxy-user-kubeconfig
+      create-default-vpc-subnet-template-volume-mount
     fi
   else
     create-node-pki

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -238,53 +238,21 @@ function download-controller-config {
   )
 }
 
-function download-network-template {
+function download-template-file {
   local -r dest="$1"
-  echo "Downloading network template file, if it exists"
+  local -r object="$2"
+  local -r objecttemplate="$3"
+  echo "Downloading $object template file, if it exists"
   # Fetch kubelet config file from GCE metadata server.
   (
     umask 077
-    local -r tmp_network_template="/tmp/network.tmpl"
+    local -r tmp_template="/tmp/${object}.tmpl"
     if curl --fail --retry 5 --retry-delay 3 ${CURL_RETRY_CONNREFUSED} --silent --show-error \
         -H "X-Google-Metadata-Request: True" \
-        -o "${tmp_network_template}" \
-        http://metadata.google.internal/computeMetadata/v1/instance/attributes/networktemplate; then
+        -o "${tmp_template}" \
+        http://metadata.google.internal/computeMetadata/v1/instance/attributes/${objecttemplate}; then
       # only write to the final location if curl succeeds
-      mv ${tmp_network_template} ${dest}
-    fi
-  )
-}
-
-function download-vpc-template {
-  local -r vpc="$1"
-  echo "Downloading vpc template file, if it exists"
-  # Fetch kubelet config file from GCE metadata server.
-  (
-    umask 077
-    local -r tmp_vpc_template="/tmp/vpc.tmpl"
-    if curl --fail --retry 5 --retry-delay 3 ${CURL_RETRY_CONNREFUSED} --silent --show-error \
-        -H "X-Google-Metadata-Request: True" \
-        -o "${tmp_vpc_template}" \
-        http://metadata.google.internal/computeMetadata/v1/instance/attributes/vpctemplate; then
-      # only write to the final location if curl succeeds
-      mv ${tmp_vpc_template} ${vpc}
-    fi
-  )
-}
-
-function download-subnet-template {
-  local -r subnet="$1"
-  echo "Downloading subnet template file, if it exists"
-  # Fetch kubelet config file from GCE metadata server.
-  (
-    umask 077
-    local -r tmp_subnet_template="/tmp/subnet.tmpl"
-    if curl --fail --retry 5 --retry-delay 3 ${CURL_RETRY_CONNREFUSED} --silent --show-error \
-        -H "X-Google-Metadata-Request: True" \
-        -o "${tmp_subnet_template}" \
-        http://metadata.google.internal/computeMetadata/v1/instance/attributes/subnettemplate; then
-      # only write to the final location if curl succeeds
-      mv ${tmp_subnet_template} ${subnet}
+      mv ${tmp_template} ${dest}
     fi
   )
 }
@@ -993,17 +961,14 @@ if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
   if [[ "${OS_ID}" =~ "ubuntu".* ]] && [[ "${OS_VER}" =~ "18.04".* ]]; then
     ensure-mizar-kernel-and-ifname
   fi
+  download-template-file "${KUBE_HOME}/vpc.tmpl" "vpc" "vpctemplate"
+  download-template-file "${KUBE_HOME}/subnet.tmpl" "subnet" "subnettemplate"
 fi
 
 download-kubelet-config "${KUBE_HOME}/kubelet-config.yaml"
 download-controller-config "${KUBE_HOME}/controllerconfig.json"
 if [[ -z "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]]; then
-  download-network-template "${KUBE_HOME}/network.tmpl"
-
-  if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
-    download-vpc-template "${KUBE_HOME}/vpc.tmpl"
-    download-subnet-template "${KUBE_HOME}/subnet.tmpl"
-  fi
+  download-template-file "${KUBE_HOME}/network.tmpl" "network" "networktemplate"
 fi
 download-apiserver-config "${KUBE_HOME}/apiserver.config"
 

--- a/cluster/gce/gci/master-helper.sh
+++ b/cluster/gce/gci/master-helper.sh
@@ -142,7 +142,7 @@ function create-master-instance-internal() {
     metadata="${metadata},networktemplate=${KUBE_TEMP}/network.tmpl"
   fi
 
-  if [[ -z "${DISABLE_NETWORK_SERVICE_SUPPORT}" && "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+  if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
     if [[ -s ${KUBE_TEMP}/vpc.tmpl && -s ${KUBE_TEMP}/subnet.tmpl ]]; then
       metadata="${metadata},vpctemplate=${KUBE_TEMP}/vpc.tmpl"
       metadata="${metadata},subnettemplate=${KUBE_TEMP}/subnet.tmpl"

--- a/cluster/gce/gci/scaleoutserver-helper.sh
+++ b/cluster/gce/gci/scaleoutserver-helper.sh
@@ -160,9 +160,17 @@ function create-scaleoutserver-instance-internal() {
   metadata="${metadata},kube-master-certs=${KUBE_TEMP}/kube-master-certs.yaml"
   metadata="${metadata},cluster-location=${KUBE_TEMP}/cluster-location.txt"
   metadata="${metadata},controllerconfig=${KUBE_TEMP}/controllerconfig.json"
-  if [[ -s ${KUBE_TEMP}/network.tmpl ]]; then
+  if [[ -z "${DISABLE_NETWORK_SERVICE_SUPPORT}" && -s ${KUBE_TEMP}/network.tmpl ]]; then
     metadata="${metadata},networktemplate=${KUBE_TEMP}/network.tmpl"
   fi
+
+  if [[ -z "${DISABLE_NETWORK_SERVICE_SUPPORT}" && "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+    if [[ -s ${KUBE_TEMP}/vpc.tmpl && -s ${KUBE_TEMP}/subnet.tmpl ]]; then
+      metadata="${metadata},vpctemplate=${KUBE_TEMP}/vpc.tmpl"
+      metadata="${metadata},subnettemplate=${KUBE_TEMP}/subnet.tmpl"
+    fi
+  fi
+
   metadata="${metadata},${MASTER_EXTRA_METADATA}"
 
   local disk="name=${server_name}-pd"

--- a/cluster/gce/gci/scaleoutserver-helper.sh
+++ b/cluster/gce/gci/scaleoutserver-helper.sh
@@ -164,7 +164,7 @@ function create-scaleoutserver-instance-internal() {
     metadata="${metadata},networktemplate=${KUBE_TEMP}/network.tmpl"
   fi
 
-  if [[ -z "${DISABLE_NETWORK_SERVICE_SUPPORT}" && "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+  if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
     if [[ -s ${KUBE_TEMP}/vpc.tmpl && -s ${KUBE_TEMP}/subnet.tmpl ]]; then
       metadata="${metadata},vpctemplate=${KUBE_TEMP}/vpc.tmpl"
       metadata="${metadata},subnettemplate=${KUBE_TEMP}/subnet.tmpl"

--- a/cluster/gce/manifests/kube-controller-manager.manifest
+++ b/cluster/gce/manifests/kube-controller-manager.manifest
@@ -51,6 +51,8 @@
         "mountPath": "/var/log/kube-controller-manager.log",
         "readOnly": false},
         {{defaulttemplate_hostpath_mount}}
+        {{defaultvpctemplate_hostpath_mount}}
+        {{defaultsubnettemplate_hostpath_mount}}
         { "name": "etcssl",
         "mountPath": "/etc/ssl",
         "readOnly": true},
@@ -84,6 +86,8 @@
         "type": "FileOrCreate"}
   },
   {{defaulttemplate_hostpath}}
+  {{defaultvpctemplate_hostpath}}
+  {{defaultsubnettemplate_hostpath}}
   { "name": "etcssl",
     "hostPath": {
         "path": "/etc/ssl"}

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -670,6 +670,15 @@ function write-network-template {
   fi
 }
 
+function write-vpc-subnet-template {
+  if [[ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} && "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+    if [[ -s ${VPC_NETWORK_TEMPLATE} && -s ${SUBNET_NETWORK_TEMPLATE} ]]; then
+      cp "${VPC_NETWORK_TEMPLATE}" "${KUBE_TEMP}/vpc.tmpl"
+      cp "${SUBNET_NETWORK_TEMPLATE}" "${KUBE_TEMP}/subnet.tmpl"
+    fi
+  fi
+}
+
 # Writes the cluster name into a temporary file.
 # Assumed vars
 #   CLUSTER_NAME
@@ -1617,11 +1626,6 @@ EOF
     if [ -n "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]; then
       cat >>$file <<EOF
 DISABLE_NETWORK_SERVICE_SUPPORT: $(yaml-quote ${DISABLE_NETWORK_SERVICE_SUPPORT})
-EOF
-    fi
-    if [ -n "${DISABLE_ADMISSION_PLUGINS:-}" ]; then
-      cat >>$file <<EOF
-DISABLE_ADMISSION_PLUGINS: $(yaml-quote ${DISABLE_ADMISSION_PLUGINS})
 EOF
     fi
     if [ -n "${INITIAL_ETCD_CLUSTER:-}" ]; then
@@ -2635,6 +2639,7 @@ function kube-up() {
     write-cluster-name
     write-controller-config
     write-network-template
+    write-vpc-subnet-template
     create-autoscaler-config
     if [[ "${SCALEOUT_CLUSTER:-false}" == "true" ]]; then
       echo "DBG: Generating shared CA certificates"

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -671,7 +671,7 @@ function write-network-template {
 }
 
 function write-vpc-subnet-template {
-  if [[ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} && "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+  if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
     if [[ -s ${VPC_NETWORK_TEMPLATE} && -s ${SUBNET_NETWORK_TEMPLATE} ]]; then
       cp "${VPC_NETWORK_TEMPLATE}" "${KUBE_TEMP}/vpc.tmpl"
       cp "${SUBNET_NETWORK_TEMPLATE}" "${KUBE_TEMP}/subnet.tmpl"
@@ -1626,6 +1626,11 @@ EOF
     if [ -n "${DISABLE_NETWORK_SERVICE_SUPPORT:-}" ]; then
       cat >>$file <<EOF
 DISABLE_NETWORK_SERVICE_SUPPORT: $(yaml-quote ${DISABLE_NETWORK_SERVICE_SUPPORT})
+EOF
+    fi
+    if [ -n "${DISABLE_ADMISSION_PLUGINS:-}" ]; then
+      cat >>$file <<EOF
+DISABLE_ADMISSION_PLUGINS: $(yaml-quote ${DISABLE_ADMISSION_PLUGINS})
 EOF
     fi
     if [ -n "${INITIAL_ETCD_CLUSTER:-}" ]; then

--- a/cmd/BUILD
+++ b/cmd/BUILD
@@ -35,7 +35,6 @@ filegroup(
         "//cmd/linkcheck:all-srcs",
         "//cmd/preferredimports:all-srcs",
         "//cmd/workload-controller-manager:all-srcs",
-        "//cmd/arktos-network-controller:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/cmd/kube-controller-manager/app/mizarcontrollers.go
+++ b/cmd/kube-controller-manager/app/mizarcontrollers.go
@@ -22,8 +22,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
-	//"time"
 
 	arktos "k8s.io/arktos-ext/pkg/generated/clientset/versioned"
 	"k8s.io/arktos-ext/pkg/generated/informers/externalversions"
@@ -189,11 +187,6 @@ func startArktosNetworkController(ctx *ControllerContext, networkInformerFactory
 	currentDir, err := os.Getwd()
 	if err != nil {
 		klog.Errorf("Get current directory (%s) in error (%v).", currentDir, err)
-		return nil, false, err
-	}
-
-	if !strings.HasSuffix(currentDir, arktosName) {
-		klog.Errorf("Current directory (%s) is not in Arktos Home directory with error (%v).", currentDir, err)
 		return nil, false, err
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup
/kind feature


**What this PR does / why we need it**:
The PR is to enable the feature - automatically create the default mizar VPC and Subnets objects for all tenants including system tenant and non-system tenants after scale out 1 x 1 cluster or scale-up cluster of KUBE-UP environment starts.

System tenant: 
``` 
vpc - system-default-network 
subnet - system-default-network-subnet
```

Non-system tenant: 
```
vpc - {{tenant name}}-default-network
subnet - {{tenant name}}-default-network-subnet 
```

If network support is not desired, setting environment variable DISABLE_NETWORK_SERVICE_SUPPORT to true will disable this feature; in the meantime, if NETWORK_PROVIDER is set to 'mizar', the vpc 'vpc0' and subnet 'net0' are still automatically created,

**Which issue(s) this PR fixes**:
Fixes #1322 

To simplify the code review, the issue #1326 will be fixed by another PR 1331.

**Special notes for your reviewer**:
This PR is the follow-up of the PR1310 and PR1298.

The POC test environment also contains mizar PR1320.

**Does this PR introduce a user-facing change?**:

The following 8 cases in kubeup environment are tested without new issues.
1x1 scale-out cluster with mizar and DISABLE_NETWORK_SERVICE_SUPPORT is unset
1x1 scale-out cluster with flat and DISABLE_NETWORK_SERVICE_SUPPORT is unset
scale-up cluster with mizar and DISABLE_NETWORK_SERVICE_SUPPORT is unset
scale-up cluster with flat and DISABLE_NETWORK_SERVICE_SUPPORT is unset

1x1 scale-out cluster with mizar and DISABLE_NETWORK_SERVICE_SUPPORT=true
1x1 scale-out cluster with flat and DISABLE_NETWORK_SERVICE_SUPPORT=true
scale-up cluster with mizar and DISABLE_NETWORK_SERVICE_SUPPORT=true
scale-up cluster with flat and DISABLE_NETWORK_SERVICE_SUPPORT=true

Additional case in local dev environment is tested without new issue because there are minor code changes in cmd/kube-controller-manager/app/mizarcontrollers.go. 

make clean; CNIPLUGIN=mizar ./hack/arktos-up.sh

