### PR TITLE
Make local scale out have same architecture as kube up

### DIFF
--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -638,12 +638,8 @@ if [[ "${START_MODE}" != "nokubelet" ]]; then
         KUBELET_LOG=""
         ;;
       Linux)
-    	if [ "${IS_RESOURCE_PARTITION}" == "true" ]; then
-	   KUBELET_LOG=/tmp/kubelet.log
-           kube::common::start_kubelet
-	else
-           KUBELET_LOG=""
-    	fi
+	       KUBELET_LOG=/tmp/kubelet.log
+         kube::common::start_kubelet
         ;;
       *)
         print_color "Unsupported host OS.  Must be Linux or Mac OS X, kubelet aborted."

--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -617,9 +617,7 @@ if [[ "${START_MODE}" != "kubeletonly" ]]; then
     start_cloud_controller_manager
   fi
   if [[ "${START_MODE}" != "nokubeproxy" ]]; then
-    if [ "${IS_RESOURCE_PARTITION}" == "true" ]; then
-       kube::common::start_kubeproxy
-    fi
+    kube::common::start_kubeproxy
   fi
   if [ "${IS_RESOURCE_PARTITION}" != "true" ]; then
      kube::common::start_kubescheduler

--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -640,8 +640,8 @@ if [[ "${START_MODE}" != "nokubelet" ]]; then
         KUBELET_LOG=""
         ;;
       Linux)
-	       KUBELET_LOG=/tmp/kubelet.log
-         kube::common::start_kubelet
+        KUBELET_LOG=/tmp/kubelet.log
+        kube::common::start_kubelet
         ;;
       *)
         print_color "Unsupported host OS.  Must be Linux or Mac OS X, kubelet aborted."


### PR DESCRIPTION
Features:
. Deploy mizar operator on tp master
. Start kube-proxy and kubelet on TP master
. Use mizar templates saved in third-party folder
. Do not start daemonset from non primary TP

Test done:
1. Verified kube proxy and kubelet running on tp master only connects to tp master
2. Verified previous start up setting can start 1x1 scale out cluster

Instruction to start non primary TP:
```
export IS_SECONDARY_TP=true
```