### PR TITLE
[Arktos-Mizar-Integration][ScaleOut]For starting mizar-operator pod on scale-out TP servers successfully

### DIFF
--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -702,6 +702,9 @@ if [ "${IS_RESOURCE_PARTITION}" != "true" ]; then
 
     # Place mizar operator
     echo "Starting mizar operator......."
+    if [ ! -d "${MIZAR_OPERATOR_HOST_PATH}"  ]; then
+      sudo mkdir -p ${MIZAR_OPERATOR_HOST_PATH}
+    fi
     CLUSTER_VPC_VNI_ID="${RANDOM}"
     cp "${KUBE_ROOT}/third_party/mizar/mizar-operator.yaml" mizar-operator.yaml
     sed -i -e "s@{{network_provider_version}}@${MIZAR_VERSION}@g" mizar-operator.yaml

--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -702,6 +702,8 @@ if [ "${IS_RESOURCE_PARTITION}" != "true" ]; then
 
     # Place mizar operator
     echo "Starting mizar operator......."
+    # # For starting mizar-operator pods on scale-out TP servers successfully on Ubuntu 20.04
+    MIZAR_OPERATOR_HOST_PATH=${MIZAR_OPERATOR_HOST_PATH:-"/etc/kubernetes"}
     if [ ! -d "${MIZAR_OPERATOR_HOST_PATH}"  ]; then
       sudo mkdir -p ${MIZAR_OPERATOR_HOST_PATH}
     fi

--- a/hack/lib/common-var-init.sh
+++ b/hack/lib/common-var-init.sh
@@ -236,10 +236,6 @@ nameserver ${UPSTREAM_DNS_IP}
 EOF
   fi
 fi
-#
-# For starting mizar-operator pods on scale-out TP servers successfully on Ubuntu 20.04
-#
-MIZAR_OPERATOR_HOST_PATH=${MIZAR_OPERATOR_HOST_PATH:-"/etc/kubernetes"}
 
 # --------------------------------------------------------------------------------------------
 # End of 2nd Common environment variables used in arktos-up.sh& arktos-apiserver-partition.sh

--- a/hack/lib/common-var-init.sh
+++ b/hack/lib/common-var-init.sh
@@ -236,6 +236,10 @@ nameserver ${UPSTREAM_DNS_IP}
 EOF
   fi
 fi
+#
+# For starting mizar-operator pods on scale-out TP servers successfully on Ubuntu 20.04
+#
+MIZAR_OPERATOR_HOST_PATH=${MIZAR_OPERATOR_HOST_PATH:-"/etc/kubernetes"}
 
 # --------------------------------------------------------------------------------------------
 # End of 2nd Common environment variables used in arktos-up.sh& arktos-apiserver-partition.sh


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR is to ensure the directory /etc/kubernetes will be automatically created on scale-out TP servers if the directory is not existing as default. This will ensure to start mizar-operator pod on scale-out TP servers successfully.

**Which issue(s) this PR fixes**:
Fixes # N/A

**Special notes for your reviewer**:
This PR depends on PR #1362.

**Does this PR introduce a user-facing change?**:
Test is done in local scale-out 1 x 1 running on Ubuntu20.04.
