### PR TITLE
Add TP master into mizar droplets

### DIFF
--- a/cmd/kube-controller-manager/app/mizarcontrollers.go
+++ b/cmd/kube-controller-manager/app/mizarcontrollers.go
@@ -97,6 +97,7 @@ func startMizarNodeController(ctx *ControllerContext, grpcHost string, grpcAdapt
 	klog.V(2).Infof("Starting %v", controllerName)
 
 	go controllers.NewMizarNodeController(
+		ctx.InformerFactory.Core().V1().Nodes(),
 		ctx.ResourceProviderNodeInformers,
 		ctx.ClientBuilder.ClientOrDie(controllerName),
 		grpcHost,

--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -691,6 +691,7 @@ if [ "${IS_RESOURCE_PARTITION}" != "true" ]; then
     echo "Creating mizar crds ......."
     cp "${KUBE_ROOT}/third_party/mizar/mizar-crds.yaml" mizar-crds.yaml
     ${KUBECTL} apply -f mizar-crds.yaml
+    rm mizar-crds.yaml
 
     if [[ "${IS_SECONDARY_TP}" == "false" ]]; then
       # Deploying mizar daemonset
@@ -698,6 +699,7 @@ if [ "${IS_RESOURCE_PARTITION}" != "true" ]; then
       cp "${KUBE_ROOT}/third_party/mizar/mizar-daemon.yaml" mizar-daemon.yaml
       sed -i -e "s@{{network_provider_version}}@${MIZAR_VERSION}@g" mizar-daemon.yaml
       ${KUBECTL} apply -f mizar-daemon.yaml
+      rm mizar-daemon.yaml
     fi
 
     # Place mizar operator
@@ -708,6 +710,7 @@ if [ "${IS_RESOURCE_PARTITION}" != "true" ]; then
     sed -i -e "s@{{tp_master_name}}@${API_HOST}@g" mizar-operator.yaml
     sed -i -e "s@{{cluster_vpc_vni_id}}@${CLUSTER_VPC_VNI_ID}@g" mizar-operator.yaml
     ${KUBECTL} apply -f mizar-operator.yaml
+    rm mizar-operator.yaml
   fi
 
   ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" create configmap -n kube-system virtlet-image-translations --from-file ${VIRTLET_DEPLOYMENT_FILES_DIR}/images.yaml

--- a/hack/arktos-up-scale-out-poc.sh
+++ b/hack/arktos-up-scale-out-poc.sh
@@ -702,6 +702,14 @@ if [ "${IS_RESOURCE_PARTITION}" != "true" ]; then
       rm mizar-daemon.yaml
     fi
 
+    # Deploying mizar daemon to tp master
+    echo "Deploying mizar daemon to TP master ......."
+    cp "${KUBE_ROOT}/third_party/mizar/mizar-daemon-tpmaster.yaml" mizar-daemon-tpmaster.yaml
+    sed -i -e "s@{{network_provider_version}}@${MIZAR_VERSION}@g" mizar-daemon-tpmaster.yaml
+    sed -i -e "s@{{tp_master_name}}@${API_HOST}@g" mizar-daemon-tpmaster.yaml
+    ${KUBECTL} apply -f mizar-daemon-tpmaster.yaml
+    rm mizar-daemon-tpmaster.yaml
+
     # Place mizar operator
     echo "Starting mizar operator......."
     CLUSTER_VPC_VNI_ID="${RANDOM}"

--- a/third_party/mizar/mizar-daemon-tpmaster.yaml
+++ b/third_party/mizar/mizar-daemon-tpmaster.yaml
@@ -1,0 +1,47 @@
+# Daemonset to deploy Mizar node agents
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mizar-daemon
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      job: mizar-daemon
+  template:
+    metadata:
+      labels:
+        job: mizar-daemon
+    spec:
+      tolerations:
+        # The daemon shall run on the master node
+        - effect: NoSchedule
+          operator: Exists
+      nodeName: "{{tp_master_name}}"
+      terminationGracePeriodSeconds: 5
+      serviceAccountName: mizar-operator
+      hostNetwork: true
+      hostPID: true
+      initContainers:
+      - name: node-init
+        image: mizarnet/mizar:{{network_provider_version}}
+        command: [./node-init.sh]
+        securityContext:
+        # Start mizar daemon static pod
+          privileged: true
+        volumeMounts:
+        - name: mizar
+          mountPath: /home
+      containers:
+      - name: mizar-daemon
+        image: mizarnet/dropletd:{{network_provider_version}}
+        env:
+        - name: FEATUREGATE_BWQOS
+          value: 'false'
+        securityContext:
+          privileged: true
+      volumes:
+      - name: mizar
+        hostPath:
+          path: /var
+          type: Directory


### PR DESCRIPTION
1. Deploy daemon to TP master.
2. Add TP master node(s) into mizar droplets

Currently test passed in 1x1 local dev env. But 2x2 test is missing mizar eps for hosts. Will need mizar team to take a look.

In 1x1 scaleout, if kube-dns and coredns pod can be created successfully (Issue https://github.com/CentaurusInfra/arktos/issues/1357 tracks the pod creation issue), mizar host endpoints can be created, kube-dns&coredns pods runs w/o crashing, service endpoints filled in correctly)
