### PR TITLE
fix kubectl missing error for scale-out

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -3421,33 +3421,33 @@ function start-mizar-scaleout {
     TP_MASTER_NAME="${TPSERVER_NAME[$tp_num]}"
     # Place mizar crds yaml
     cp "${src_dir}/mizar-crds.yaml" ${dst_dir}
-    src_file="${dst_dir}/mizar-crds.yaml"
-    kubectl --kubeconfig=${tp_kubeconfig} apply -f "${src_file}"
+    dst_file="${dst_dir}/mizar-crds.yaml"
+    ${KUBE_ROOT}/cluster/kubectl.sh --kubeconfig=${tp_kubeconfig} apply -f "${dst_file}"
 
     if [[ "${tp_num}" == "1" ]]; then
       # Place mizar daemon yaml.
       cp "${src_dir}/mizar-daemon.yaml" "${dst_dir}"
-      src_file="${dst_dir}/mizar-daemon.yaml"
-      sed -i -e "s@{{network_provider_version}}@${NETWORK_PROVIDER_VERSION}@g" "${src_file}"
-      kubectl --kubeconfig=${tp_kubeconfig}  apply -f "${src_file}"
+      dst_file="${dst_dir}/mizar-daemon.yaml"
+      sed -i -e "s@{{network_provider_version}}@${NETWORK_PROVIDER_VERSION}@g" "${dst_file}"
+      ${KUBE_ROOT}/cluster/kubectl.sh --kubeconfig=${tp_kubeconfig}  apply -f "${dst_file}"
     fi
 
     # Place mizar daemon yaml on TP master.
     cp "${src_dir}/mizar-daemon-tpmaster.yaml" "${dst_dir}"
-    src_file="${dst_dir}/mizar-daemon-tpmaster.yaml"
-    sed -i -e "s@{{network_provider_version}}@${NETWORK_PROVIDER_VERSION}@g" "${src_file}"
-    sed -i -e "s@{{tp_master_name}}@${TP_MASTER_NAME}@g" "${src_file}"
-    kubectl --kubeconfig=${tp_kubeconfig}  apply -f "${src_file}"
+    dst_file="${dst_dir}/mizar-daemon-tpmaster.yaml"
+    sed -i -e "s@{{network_provider_version}}@${NETWORK_PROVIDER_VERSION}@g" "${dst_file}"
+    sed -i -e "s@{{tp_master_name}}@${TP_MASTER_NAME}@g" "${dst_file}"
+    ${KUBE_ROOT}/cluster/kubectl.sh --kubeconfig=${tp_kubeconfig}  apply -f "${dst_file}"
 
-    kubectl --kubeconfig=${tp_kubeconfig} create configmap system-source --namespace=kube-system --from-literal=name=arktos --from-literal=company=futurewei
+    ${KUBE_ROOT}/cluster/kubectl.sh --kubeconfig=${tp_kubeconfig} create configmap system-source --namespace=kube-system --from-literal=name=arktos --from-literal=company=futurewei
 
     # Place mizar operator yaml.
     cp "${src_dir}/mizar-operator.yaml" "${dst_dir}"
-    src_file="${dst_dir}/mizar-operator.yaml"
-    sed -i -e "s@{{network_provider_version}}@${NETWORK_PROVIDER_VERSION}@g" "${src_file}"
-    sed -i -e "s@{{tp_master_name}}@${TP_MASTER_NAME}@g" "${src_file}"
-    sed -i -e "s@{{cluster_vpc_vni_id}}@${CLUSTER_VPC_VNI_ID}@g" "${src_file}"
-    kubectl --kubeconfig=${tp_kubeconfig} apply -f "${src_file}"
+    dst_file="${dst_dir}/mizar-operator.yaml"
+    sed -i -e "s@{{network_provider_version}}@${NETWORK_PROVIDER_VERSION}@g" "${dst_file}"
+    sed -i -e "s@{{tp_master_name}}@${TP_MASTER_NAME}@g" "${dst_file}"
+    sed -i -e "s@{{cluster_vpc_vni_id}}@${CLUSTER_VPC_VNI_ID}@g" "${dst_file}"
+    ${KUBE_ROOT}/cluster/kubectl.sh --kubeconfig=${tp_kubeconfig} apply -f "${dst_file}"
     rm -r "${dst_dir}"
   done
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:
replace kubectl with ${KUBE_ROOT}/cluster/kubectl.sh when start-mizar-scaleout

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1369 

**Special notes for your reviewer**:
Tested on clean ubuntu 20.04: started scale-out 1x1 with mizar
```
$ kubectl --version
kubectl: command not found
```

```
$ ./cluster/kubectl.sh get pods -AT -owide --kubeconfig=/home/sonyali/go/src/arktos/cluster/kubeconfig.tp-1 | grep mizar
system   default       mizar-daemon-7d9b8bfd48-x8zj6                               6140887095703380146   1/1     Running             0          32m   10.40.0.2   sonyaubuntu1-021822-tp-1-master              <none>           <none>
system   default       mizar-daemon-fccrb                                          2186085137071605070   1/1     Running             0          32m   10.40.0.3   sonyaubuntu1-021822-rp-1-master              <none>           <none>
system   default       mizar-daemon-h5slr                                          2620821491582687911   1/1     Running             0          32m   10.40.0.4   sonyaubuntu1-021822-rp-1-minion-group-gx45   <none>           <none>
system   default       mizar-daemon-jlvp6                                          2418309849680788888   1/1     Running             0          32m   10.40.0.5   sonyaubuntu1-021822-rp-1-minion-group-69xf   <none>           <none>
system   default       mizar-operator-8cf5d795b-4wszh                              9041018273459331292   1/1     Running             0          32m   10.40.0.2   sonyaubuntu1-021822-tp-1-master              <none>           <none>
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
