### PR TITLE
mizar preliminary installation not to install binary

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -426,15 +426,9 @@ EOF
 }
 
 function install-mizar-cni-bin {
-  if [[ "${NETWORK_PROVIDER_VERSION}" == "dev" ]]; then
-    wget https://github.com/CentaurusInfra/mizar/releases/download/v0.9/mizarcni -O ${KUBE_BIN}/mizarcni
-  else
-    wget https://github.com/CentaurusInfra/mizar/releases/download/v${NETWORK_PROVIDER_VERSION}/mizarcni -O ${KUBE_BIN}/mizarcni
-  fi
-  chmod +x ${KUBE_BIN}/mizarcni
-  #BUGBUG: This is a hack around arktos runtime hardcoding of CNI bin dir
+  # create folder only here
+  # mizar will be installed via daemonset or other means later
   mkdir -p /opt/cni/bin
-  cp -f ${KUBE_BIN}/mizarcni /opt/cni/bin/
 }
 
 function download-mizar-cni-yaml {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR is part of fixes to #1357. The more important fix is from mizar:dev side. This PR only solves the kube-up scale-out preliminary step related issue.

As the preliminary step, it does not download mizar cni binary and have it installed. Instead, it only ensures the cni binary folder is there. The full-fledged mizar installation will be done by daemonset or other means.

With this change, kubelet will not invoke the possibly polluted cni binary before the proper mizar parts are there.
 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1357 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
