### PR TITLE
Kubeup scaleout mizar support

### DIFF
--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -1367,7 +1367,19 @@ function prepare-log-file {
 function prepare-kube-proxy-manifest-variables {
   local -r src_file=$1;
 
-  local -r kubeconfig="--kubeconfig=/var/lib/kube-proxy/kubeconfig"
+  local kubeconfig="--kubeconfig=/var/lib/kube-proxy/kubeconfig"
+  if [[ "${ARKTOS_SCALEOUT_SERVER_TYPE:-}" == "node" ]]; then
+    echo "DBG:Set tenant-server-kubeconfig parameters:  ${TENANT_SERVER_KUBECONFIGS}"
+    kubeconfig+=" --tenant-server-kubeconfig=${TENANT_SERVER_KUBECONFIGS}"
+  fi
+
+  local proxy_tpconfig_mount=""
+  local proxy_tpconfig_volume=""
+  if [[ "${ARKTOS_SCALEOUT_SERVER_TYPE:-}" == "node" ]]; then
+    proxy_tpconfig_volume="  - hostPath:\n      path: /etc/srv/kubernetes/tp-kubeconfigs\n    name: tp-configs"
+    proxy_tpconfig_mount="    - mountPath: /etc/srv/kubernetes/tp-kubeconfigs\n      name: tp-configs\n      readOnly: true"
+  fi
+
   local kube_docker_registry="k8s.gcr.io"
   if [[ -n "${KUBE_DOCKER_REGISTRY:-}" ]]; then
     kube_docker_registry=${KUBE_DOCKER_REGISTRY}
@@ -1402,6 +1414,8 @@ function prepare-kube-proxy-manifest-variables {
     kube_cache_mutation_detector_env_value="value: \"${ENABLE_CACHE_MUTATION_DETECTOR}\""
   fi
   sed -i -e "s@{{kubeconfig}}@${kubeconfig}@g" ${src_file}
+  sed -i -e "s@{{proxy_tpconfig_mount}}@${proxy_tpconfig_mount}@g" ${src_file}
+  sed -i -e "s@{{proxy_tpconfig_volume}}@${proxy_tpconfig_volume}@g" ${src_file}
   sed -i -e "s@{{pillar\['kube_docker_registry'\]}}@${kube_docker_registry}@g" ${src_file}
   sed -i -e "s@{{pillar\['kube-proxy_docker_tag'\]}}@${kube_proxy_docker_tag}@g" ${src_file}
   sed -i -e "s@{{params}}@${params}@g" ${src_file}

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -124,7 +124,7 @@ function create-dirs {
   if [[ "${KUBERNETES_MASTER:-}" == "false" ]]; then
     mkdir -p /var/lib/kube-proxy
   fi
-  if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]] && [[ "${SCALEOUT_CLUSTER:-false}" == "false" ]]; then
+  if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
     mkdir -p /var/lib/kube-proxy
   fi
 }
@@ -2374,7 +2374,7 @@ function start-kube-controller-manager {
     RUN_CONTROLLERS="serviceaccount,serviceaccount-token,nodelifecycle,nodeipam,ttl,csrsigning,csrapproving,csrcleaner"
   fi
   if [[ "${ARKTOS_SCALEOUT_SERVER_TYPE:-}" == "tp" ]]; then
-    RUN_CONTROLLERS="*,-nodeipam,-nodelifecycle,-mizar-controllers,-network,-ttl"
+    RUN_CONTROLLERS="*,-nodeipam,-nodelifecycle,-ttl"
   fi
   if [[ -n "${RUN_CONTROLLERS:-}" ]]; then
     params+=" --controllers=${RUN_CONTROLLERS}"
@@ -3289,10 +3289,6 @@ function wait-until-mizar-ready {
 }
 
 function start-mizar-scaleup {
-  #Wait for apiserver to setup default namespace
-  until kubectl get ns | grep default; do
-    sleep 5
-  done
   echo "Installing Mizar for scale-up architecture..."
   kubectl create configmap system-source --namespace=kube-system --from-literal=name=arktos --from-literal=company=futurewei
   kubectl create -f "${KUBE_HOME}/mizar/deploy.mizar.yaml"

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -96,7 +96,7 @@ function main() {
     override-pv-recycler
     create-default-network-template-volume-mount
     gke-master-start
-    if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]] && [[ "${SCALEOUT_CLUSTER:-false}" == "false" ]]; then
+    if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
       create-kubeproxy-user-kubeconfig
     fi
   else
@@ -138,7 +138,7 @@ function main() {
 
     start-kube-apiserver
     start-kube-controller-manager
-    if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]] && [[ "${SCALEOUT_CLUSTER:-false}" == "false" ]]; then
+    if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
       start-kube-proxy
     fi
 

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -432,6 +432,9 @@ function install-mizar-cni-bin {
     wget https://github.com/CentaurusInfra/mizar/releases/download/v${NETWORK_PROVIDER_VERSION}/mizarcni -O ${KUBE_BIN}/mizarcni
   fi
   chmod +x ${KUBE_BIN}/mizarcni
+  #BUGBUG: This is a hack around arktos runtime hardcoding of CNI bin dir
+  mkdir -p /opt/cni/bin
+  cp -f ${KUBE_BIN}/mizarcni /opt/cni/bin/
 }
 
 function download-mizar-cni-yaml {
@@ -907,7 +910,6 @@ validate-python
 download-kube-env
 source "${KUBE_HOME}/kube-env"
 
-# This hack is only needed because arktos does not support ubuntu 20.04 with latest kernels
 # When arktos adds support for 20.04 that has 5.11.0 kernel, we don't need to update kernel.
 if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
   OS_ID=$(cat /etc/os-release | grep ^ID= | cut -d= -f2)

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -426,15 +426,9 @@ EOF
 }
 
 function install-mizar-cni-bin {
-  if [[ "${NETWORK_PROVIDER_VERSION}" == "dev" ]]; then
-    wget https://github.com/CentaurusInfra/mizar/releases/download/v0.9/mizarcni -O ${KUBE_BIN}/mizarcni
-  else
-    wget https://github.com/CentaurusInfra/mizar/releases/download/v${NETWORK_PROVIDER_VERSION}/mizarcni -O ${KUBE_BIN}/mizarcni
-  fi
-  chmod +x ${KUBE_BIN}/mizarcni
-  #BUGBUG: This is a hack around arktos runtime hardcoding of CNI bin dir
+  # create folder only here
+  # mizar will be installed via daemonset or other means later
   mkdir -p /opt/cni/bin
-  cp -f ${KUBE_BIN}/mizarcni /opt/cni/bin/
 }
 
 function download-mizar-cni-yaml {

--- a/cluster/gce/manifests/kube-proxy.manifest
+++ b/cluster/gce/manifests/kube-proxy.manifest
@@ -48,6 +48,7 @@ spec:
     - mountPath: /var/lib/kube-proxy/kubeconfig
       name: kubeconfig
       readOnly: false
+{{proxy_tpconfig_mount}}
     - mountPath: /run/xtables.lock
       name: iptableslock
       readOnly: false
@@ -65,6 +66,7 @@ spec:
       path: /var/lib/kube-proxy/kubeconfig
       type: FileOrCreate
     name: kubeconfig
+{{proxy_tpconfig_volume}}
   - hostPath:
       path: /var/log
     name: varlog

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2691,7 +2691,10 @@ function kube-up() {
         validate-cluster-status
         create-node-port
       done
-      restart_tp_scheduler_and_controller
+      restart-tp-scheduler-and-controller
+      if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then 
+        start-mizar-scaleout
+      fi
     else
       export ARKTOS_SCALEOUT_SERVER_TYPE=""
       create-master
@@ -3370,7 +3373,7 @@ function create-rpmaster {
 #       if future design is to let scheduler and controller managers to point to a generic server to get those RP
 #       kubeconfigs, the generic service should generate different ones for them.
 # TODO: remove this restart because all tp/rp ip has been reserved and this config should be ready before tp/rp started
-function restart_tp_scheduler_and_controller {
+function restart-tp-scheduler-and-controller {
   for (( tp_num=1; tp_num<=${SCALEOUT_TP_COUNT}; tp_num++ ))
   do
     tp_vm="${TPSERVER_NAME[$tp_num]}"
@@ -3392,6 +3395,49 @@ function restart_tp_scheduler_and_controller {
     echo "DBG: restart controller manager on TP master: ${tp_vm}"
     cmd="sudo pkill -f kube-controller-manager"
     gcloud compute ssh --ssh-flag="-o LogLevel=quiet" --ssh-flag="-o ConnectTimeout=30" --project "${PROJECT}" --zone="${ZONE}" "${tp_vm}" --command "${cmd}"
+  done
+}
+
+function start-mizar-scaleout {
+  echo "Installing Mizar for scale-out architecture..."
+  local -r src_dir="${KUBE_ROOT}/third_party/mizar"
+  local -r dst_dir="/tmp/mizar"
+  for (( tp_num=1; tp_num<=${SCALEOUT_TP_COUNT}; tp_num++ ))
+  do
+    mkdir -p ${dst_dir}
+    tp_kubeconfig="${RESOURCE_DIRECTORY}/kubeconfig${KUBEMARK_PREFIX}.tp-${tp_num}"
+    CLUSTER_VPC_VNI_ID="$tp_num"
+    TP_MASTER_NAME="${TPSERVER_NAME[$tp_num]}"
+    # Place mizar crds yaml
+    cp "${src_dir}/mizar-crds.yaml" ${dst_dir}
+    dst_file="${dst_dir}/mizar-crds.yaml"
+    ${KUBE_ROOT}/cluster/kubectl.sh --kubeconfig=${tp_kubeconfig} apply -f "${dst_file}"
+
+    if [[ "${tp_num}" == "1" ]]; then
+      # Place mizar daemon yaml.
+      cp "${src_dir}/mizar-daemon.yaml" "${dst_dir}"
+      dst_file="${dst_dir}/mizar-daemon.yaml"
+      sed -i -e "s@{{network_provider_version}}@${NETWORK_PROVIDER_VERSION}@g" "${dst_file}"
+      ${KUBE_ROOT}/cluster/kubectl.sh --kubeconfig=${tp_kubeconfig}  apply -f "${dst_file}"
+    fi
+
+    # Place mizar daemon yaml on TP master.
+    cp "${src_dir}/mizar-daemon-tpmaster.yaml" "${dst_dir}"
+    dst_file="${dst_dir}/mizar-daemon-tpmaster.yaml"
+    sed -i -e "s@{{network_provider_version}}@${NETWORK_PROVIDER_VERSION}@g" "${dst_file}"
+    sed -i -e "s@{{tp_master_name}}@${TP_MASTER_NAME}@g" "${dst_file}"
+    ${KUBE_ROOT}/cluster/kubectl.sh --kubeconfig=${tp_kubeconfig}  apply -f "${dst_file}"
+
+    ${KUBE_ROOT}/cluster/kubectl.sh --kubeconfig=${tp_kubeconfig} create configmap system-source --namespace=kube-system --from-literal=name=arktos --from-literal=company=futurewei
+
+    # Place mizar operator yaml.
+    cp "${src_dir}/mizar-operator.yaml" "${dst_dir}"
+    dst_file="${dst_dir}/mizar-operator.yaml"
+    sed -i -e "s@{{network_provider_version}}@${NETWORK_PROVIDER_VERSION}@g" "${dst_file}"
+    sed -i -e "s@{{tp_master_name}}@${TP_MASTER_NAME}@g" "${dst_file}"
+    sed -i -e "s@{{cluster_vpc_vni_id}}@${CLUSTER_VPC_VNI_ID}@g" "${dst_file}"
+    ${KUBE_ROOT}/cluster/kubectl.sh --kubeconfig=${tp_kubeconfig} apply -f "${dst_file}"
+    rm -r "${dst_dir}"
   done
 }
 

--- a/third_party/mizar/mizar-crds.yaml
+++ b/third_party/mizar/mizar-crds.yaml
@@ -1,0 +1,468 @@
+# mizar CRD bouncers.mizar.com
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bouncers.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Bouncer
+    plural: bouncers
+    singular: bouncer
+    shortNames:
+      - bncr
+      - bncrs
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: vpc
+          type: string
+          priority: 0
+          jsonPath: .spec.vpc
+          description: The VPC of the divider
+        - name: net
+          type: string
+          priority: 0
+          jsonPath: .spec.net
+          description: The Network of the bouncer
+        - name: Ip
+          type: string
+          priority: 0
+          jsonPath: .spec.ip
+          description: The IP of the droplet
+        - name: Mac
+          type: string
+          priority: 0
+          jsonPath: .spec.mac
+          description: The mac address of the divider's droplet
+        - name: Droplet
+          type: string
+          priority: 0
+          jsonPath: .spec.droplet
+          description: The name of the droplet resource
+        - name: Status
+          type: string
+          priority: 0
+          jsonPath: .spec.status
+          description: The Current Status of the divider
+        - name: CreateTime
+          type: string
+          priority: 0
+          jsonPath: .spec.createtime
+          description: Time the object is created
+        - name: ProvisionDelay
+          type: string
+          priority: 0
+          jsonPath: .spec.provisiondelay
+          description: Time to provision an object from creation
+---
+# mizar CRD dividers.mizar.com
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: dividers.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Divider
+    plural: dividers
+    singular: divider
+    shortNames:
+      - divd
+      - divds
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: vpc
+          type: string
+          priority: 0
+          jsonPath: .spec.vpc
+          description: The VPC of the divider
+        - name: Ip
+          type: string
+          priority: 0
+          jsonPath: .spec.ip
+          description: The IP of the divider's droplet
+        - name: Mac
+          type: string
+          priority: 0
+          jsonPath: .spec.mac
+          description: The mac address of the divider's droplet
+        - name: Droplet
+          type: string
+          priority: 0
+          jsonPath: .spec.droplet
+          description: The name of the droplet resource
+        - name: Status
+          type: string
+          priority: 0
+          jsonPath: .spec.status
+          description: The Current Status of the divider
+        - name: CreateTime
+          type: string
+          priority: 0
+          jsonPath: .spec.createtime
+          description: Time the object is created
+        - name: ProvisionDelay
+          type: string
+          priority: 0
+          jsonPath: .spec.provisiondelay
+          description: Time to provision an object from creation
+---
+# mizar CRD droplets.mizar.com
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: droplets.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Droplet
+    plural: droplets
+    singular: droplet
+    shortNames:
+      - drp
+      - drps
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Mac
+          type: string
+          priority: 0
+          jsonPath: .spec.mac
+          description: The mac address of the endpoint
+        - name: Ip
+          type: string
+          priority: 0
+          jsonPath: .spec.ip
+          description: The IP of the endpoint
+        - name: Status
+          type: string
+          priority: 0
+          jsonPath: .spec.status
+          description: The Current Status of the droplet
+        - name: Interface
+          type: string
+          priority: 0
+          jsonPath: .spec.itf
+          description: The main interface of the droplet
+        - name: CreateTime
+          type: string
+          priority: 0
+          jsonPath: .spec.createtime
+          description: Time the object is created
+        - name: ProvisionDelay
+          type: string
+          priority: 0
+          jsonPath: .spec.provisiondelay
+          description: Time to provision an object from creation
+---
+# mizar CRD endpoints.mizar.com
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: endpoints.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Endpoint
+    plural: endpoints
+    singular: endpoint
+    shortNames:
+      - ep
+      - eps
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          priority: 0
+          jsonPath: .spec.type
+          description: The type of the endpoint
+        - name: Mac
+          type: string
+          priority: 0
+          jsonPath: .spec.mac
+          description: The mac address of the endpoint
+        - name: Ip
+          type: string
+          priority: 0
+          jsonPath: .spec.ip
+          description: The IP of the endpoint
+        - name: Gw
+          type: string
+          priority: 0
+          jsonPath: .spec.gw
+          description: The GW of the endpoint
+        - name: Prefix
+          type: string
+          priority: 0
+          jsonPath: .spec.prefix
+          description: The network prefix of the endpoint
+        - name: Status
+          type: string
+          priority: 0
+          jsonPath: .spec.status
+          description: The Current Provisioning Status of the endpoint
+        - name: Network
+          type: string
+          priority: 0
+          jsonPath: .spec.net
+          description: The network of the endpoint
+        - name: Vpc
+          type: string
+          priority: 0
+          jsonPath: .spec.vpc
+          description: The vpc of the endpoint
+        - name: Vni
+          type: string
+          priority: 0
+          jsonPath: .spec.vni
+          description: The VNI of the VPC
+        - name: Droplet
+          type: string
+          priority: 0
+          jsonPath: .spec.droplet
+          description: The droplet hosting the endpoint
+        - name: Interface
+          type: string
+          priority: 0
+          jsonPath: .spec.itf
+          description: The interface name of the endpoint
+        - name: Veth
+          type: string
+          priority: 0
+          jsonPath: .spec.veth
+          description: The veth peer interface name of the endpoint
+        - name: Netns
+          type: string
+          priority: 0
+          jsonPath: .spec.netns
+          description: The netns of the endpoint
+        - name: HostIp
+          type: string
+          priority: 0
+          jsonPath: .spec.hostip
+          description: The Host IP of the endpoint
+        - name: HostMac
+          type: string
+          priority: 0
+          jsonPath: .spec.hostmac
+          description: The Host MAC of the endpoint
+        - name: CreateTime
+          type: string
+          priority: 0
+          jsonPath: .spec.createtime
+          description: Time the object is created
+        - name: ProvisionDelay
+          type: string
+          priority: 0
+          jsonPath: .spec.provisiondelay
+          description: Time to provision an object from creation
+        - name: CniDelay
+          type: string
+          priority: 0
+          jsonPath: .spec.cnidelay
+          description: Time to setup endpoint on droplet
+        - name: Pod
+          type: string
+          priority: 0
+          jsonPath: .spec.pod
+          description: The pod associated with the endpoint
+---
+# mizar CRD subnets.mizar.com
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: subnets.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Subnet
+    plural: subnets
+    singular: subnet
+    shortNames:
+      - subnet
+      - subnets
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Ip
+          type: string
+          priority: 0
+          jsonPath: .spec.ip
+          description: The IP of the NET CIDR block
+        - name: Prefix
+          type: string
+          priority: 0
+          jsonPath: .spec.prefix
+          description: The prefix of the NET CIDR block
+        - name: Vni
+          type: string
+          priority: 0
+          jsonPath: .spec.vni
+          description: The VNI of the VPC
+        - name: Vpc
+          type: string
+          priority: 0
+          jsonPath: .spec.vpc
+          description: The name of the VPC
+        - name: Status
+          type: string
+          priority: 0
+          jsonPath: .spec.status
+          description: The Current Provisioning Status of the net
+        - name: Bouncers
+          type: integer
+          priority: 0
+          jsonPath: .spec.bouncers
+          description: The number of bouncers of the Net
+        - name: CreateTime
+          type: string
+          priority: 0
+          jsonPath: .spec.createtime
+          description: Time the object is created
+        - name: ProvisionDelay
+          type: string
+          priority: 0
+          jsonPath: .spec.provisiondelay
+          description: Time to provision an object from creation
+---
+# mizar CRD vpcs.mizar.com
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: vpcs.mizar.com
+spec:
+  scope: Namespaced
+  group: mizar.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    kind: Vpc
+    plural: vpcs
+    singular: vpc
+    shortNames:
+      - vpc
+      - vpcs
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Ip
+          type: string
+          priority: 0
+          jsonPath: .spec.ip
+          description: The IP of the VPC CIDR block
+        - name: Prefix
+          type: string
+          priority: 0
+          jsonPath: .spec.prefix
+          description: The prefix of the VPC CIDR block
+        - name: Vni
+          type: string
+          priority: 0
+          jsonPath: .spec.vni
+          description: The VNI of the VPC
+        - name: Dividers
+          type: integer
+          priority: 0
+          jsonPath: .spec.dividers
+          description: The number of dividers of the VPC
+        - name: Status
+          type: string
+          priority: 0
+          jsonPath: .spec.status
+          description: The Current Provisioning Status of the net
+        - name: CreateTime
+          type: string
+          priority: 0
+          jsonPath: .spec.createtime
+          description: Time the object is created
+        - name: ProvisionDelay
+          type: string
+          priority: 0
+          jsonPath: .spec.provisiondelay
+          description: Time to provision an object from creation
+---
+# mizar service account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mizar-operator
+---
+# mizar cluster role binding
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mizar-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: mizar-operator
+    namespace: default

--- a/third_party/mizar/mizar-daemon-tpmaster.yaml
+++ b/third_party/mizar/mizar-daemon-tpmaster.yaml
@@ -1,0 +1,47 @@
+# Daemonset to deploy Mizar node agents
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mizar-daemon
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      job: mizar-daemon
+  template:
+    metadata:
+      labels:
+        job: mizar-daemon
+    spec:
+      tolerations:
+        # The daemon shall run on the master node
+        - effect: NoSchedule
+          operator: Exists
+      nodeName: "{{tp_master_name}}"
+      terminationGracePeriodSeconds: 5
+      serviceAccountName: mizar-operator
+      hostNetwork: true
+      hostPID: true
+      initContainers:
+      - name: node-init
+        image: mizarnet/mizar:{{network_provider_version}}
+        command: [./node-init.sh]
+        securityContext:
+        # Start mizar daemon static pod
+          privileged: true
+        volumeMounts:
+        - name: mizar
+          mountPath: /home
+      containers:
+      - name: mizar-daemon
+        image: mizarnet/dropletd:{{network_provider_version}}
+        env:
+        - name: FEATUREGATE_BWQOS
+          value: 'false'
+        securityContext:
+          privileged: true
+      volumes:
+      - name: mizar
+        hostPath:
+          path: /var
+          type: Directory

--- a/third_party/mizar/mizar-daemon.yaml
+++ b/third_party/mizar/mizar-daemon.yaml
@@ -1,0 +1,46 @@
+# Daemonset to deploy Mizar node agents
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: mizar-daemon
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      job: mizar-daemon
+  template:
+    metadata:
+      labels:
+        job: mizar-daemon
+    spec:
+      tolerations:
+        # The daemon shall run on the master node
+        - effect: NoSchedule
+          operator: Exists
+      terminationGracePeriodSeconds: 5
+      serviceAccountName: mizar-operator
+      hostNetwork: true
+      hostPID: true
+      initContainers:
+      - name: node-init
+        image: mizarnet/mizar:{{network_provider_version}}
+        command: [./node-init.sh]
+        securityContext:
+        # Start mizar daemon static pod
+          privileged: true
+        volumeMounts:
+        - name: mizar
+          mountPath: /home
+      containers:
+      - name: mizar-daemon
+        image: mizarnet/dropletd:{{network_provider_version}}
+        env:
+        - name: FEATUREGATE_BWQOS
+          value: 'false'
+        securityContext:
+          privileged: true
+      volumes:
+      - name: mizar
+        hostPath:
+          path: /var
+          type: Directory

--- a/third_party/mizar/mizar-operator.yaml
+++ b/third_party/mizar/mizar-operator.yaml
@@ -1,0 +1,41 @@
+# mizar operator
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mizar-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mizar-operator
+  template:
+    metadata:
+      labels:
+        app: mizar-operator
+        mizar: operator
+    spec:
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      nodeName: "{{tp_master_name}}"
+      terminationGracePeriodSeconds: 5
+      serviceAccountName: mizar-operator
+      hostNetwork: true
+      containers:
+      - name: mizar-operator
+        image: mizarnet/endpointopr:{{network_provider_version}}
+        env:
+        - name: CLUSTER_VPC_VNI
+          value: "{{cluster_vpc_vni_id}}"
+        - name: FEATUREGATE_BWQOS
+          value: 'false'
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: /kubeconf
+      volumes:
+      - name: kubeconfig
+        hostPath:
+          path: /etc/kubernetes
+          type: Directory


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:
1.  kube-proxy of rp nodes connecting to tp masters2. 
2. multitenancy network isolation for n-TP x n-RP scale out architecture3. 
3. Deploy mizar daemon and operator after tp and rp ready4. 
4. mizar preliminary installtion does not have binary installed

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Tested on scenarios blow:

1.Kubeup (scale up) with mizar: successfully except known pods issue (event-exporter, kubernetes-dashboard pods failure)
```
$ kubectl get pods -AT | grep mizar
system   default       mizar-daemon-blvc5                                   7161814908282533227   1/1     Running            0          15m
system   default       mizar-daemon-rgjk6                                   3033908129129480042   1/1     Running            0          15m
system   default       mizar-operator-5c97f7478d-rxpm6                      3516196545653413385   1/1     Running            0          15m
```
2.Kubeup (scale out 2x2) with mizar: successfully except known pods issue (event-exporter, kubernetes-dashboard pods failure)
```
$ kubectl get pods -AT --kubeconfig=/home/sonyali/go/src/k8s.io/arktos/cluster/kubeconfig.tp-1 -owide | grep mizar
system   default       mizar-daemon-4rd98                                        6290163628105095960   1/1     Running            0          7m14s   10.40.0.8      sonyaperf2-022822-rp-2-minion-group-j1lr   <none>           <none>
system   default       mizar-daemon-7r94p                                        7560323719207198367   1/1     Running            0          7m14s   10.40.0.7      sonyaperf2-022822-rp-1-minion-group-ftpx   <none>           <none>
system   default       mizar-daemon-9887b7c44-9h4rg                              3632676228300579381   1/1     Running            0          7m13s   10.40.0.2      sonyaperf2-022822-tp-1-master              <none>           <none>
system   default       mizar-daemon-c79bg                                        4963340321871473986   1/1     Running            0          7m14s   10.40.0.6      sonyaperf2-022822-rp-1-minion-group-k3f2   <none>           <none>
system   default       mizar-daemon-jv7jq                                        8307233202106541144   1/1     Running            0          7m14s   10.40.0.4      sonyaperf2-022822-rp-1-master              <none>           <none>
system   default       mizar-daemon-mnsf4                                        2425280013211035679   1/1     Running            0          7m14s   10.40.0.9      sonyaperf2-022822-rp-2-minion-group-z89f   <none>           <none>
system   default       mizar-daemon-wnmzj                                        3539508513320992722   1/1     Running            0          7m14s   10.40.0.5      sonyaperf2-022822-rp-2-master              <none>           <none>
system   default       mizar-operator-599b5f46b8-tmv5n                           1919556708710504061   1/1     Running            0          7m12s   10.40.0.2      sonyaperf2-022822-tp-1-master              <none>           <none>

$ kubectl get pods -AT --kubeconfig=/home/sonyali/go/src/k8s.io/arktos/cluster/kubeconfig.tp-2 -owide | grep mizar
system   default       mizar-daemon-58b54dc75f-l7kr7                             3766799826180179002   1/1     Running   0          8m9s    10.40.0.3     sonyaperf2-022822-tp-2-master              <none>           <none>
system   default       mizar-operator-d9c67967d-hsp6c                            8180541538099338008   1/1     Running   0          8m9s    10.40.0.3     sonyaperf2-022822-tp-2-master              <none>           <none>
```
3.Kubeup (scale up with default network): successfully
4.Kubeup (scale up with default network) + kubemark ( scale up with default network): successfully
5.Kubeup (scale up with default network) + kubemark ( scale out 1x1 with default network): successfully

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
