### PR TITLE
VPC start ip range fix: only generate ip start from range [11, 19]U[21,99]

### DIFF
--- a/pkg/controller/mizar/mizar-arktos-network-controller.go
+++ b/pkg/controller/mizar/mizar-arktos-network-controller.go
@@ -258,7 +258,7 @@ func generateVPCSpec(vpcName string) (int, *MizarVPC) {
 	// This is a simplified version to avoid reserved internal address - however, it may collision with real external ip address.
 	// Will log as an issue and solve in the future
 	// randomize ip start segment:
-	ipStart := ran.Intn(100) + 11 // IpStart range [11, 99] - 20
+	ipStart := ran.Intn(89) + 11 // IpStart range [11, 99] - 20
 
 	// Exclude 20 as it is used by mizar internally
 	if ipStart == 20 {

--- a/pkg/controller/mizar/mizar-arktos-network-controller_test.go
+++ b/pkg/controller/mizar/mizar-arktos-network-controller_test.go
@@ -44,7 +44,7 @@ func TestGenerateVPCSpec(t *testing.T) {
 }
 
 func verifyIpStart(t *testing.T, ipStart int) {
-	assert.True(t, ipStart >= 1, "VPC started should be in range [11, 20) or [21, 99], got %d", ipStart)
+	assert.True(t, ipStart >= 11 && ipStart <= 99 && ipStart != 20, "VPC started should be in range [11, 20) or [21, 99], got %d", ipStart)
 }
 
 func verifyVPCSpec(t *testing.T, vpcSpec *MizarVPC) {


### PR DESCRIPTION
Check in this change for Hong's further test for ContainerCreating issue