### PR TITLE
kube-up support vpc range

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -942,6 +942,16 @@ EOF
 DISABLE_NETWORK_SERVICE_SUPPORT: $(yaml-quote ${DISABLE_NETWORK_SERVICE_SUPPORT})
 EOF
     fi
+    if [ -n "${MIZAR_VPC_RANGE_START:-}" ]; then
+      cat >>$file <<EOF
+MIZAR_VPC_RANGE_START: $(yaml-quote ${MIZAR_VPC_RANGE_START})
+EOF
+    fi
+    if [ -n "${MIZAR_VPC_RANGE_END:-}" ]; then
+      cat >>$file <<EOF
+MIZAR_VPC_RANGE_END: $(yaml-quote ${MIZAR_VPC_RANGE_END})
+EOF
+    fi
     if [ -n "${INITIAL_ETCD_CLUSTER:-}" ]; then
       cat >>$file <<EOF
 INITIAL_ETCD_CLUSTER: $(yaml-quote ${INITIAL_ETCD_CLUSTER})

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -369,6 +369,15 @@ if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
   fi
 fi
 
+VPC_RANGE_START=${VPC_RANGE_START:-11}
+VPC_RANGE_END=${VPC_RANGE_END:-99}
+
+if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+  FEATURE_GATES="${FEATURE_GATES},MizarVPCRangeNoOverlap=true"
+  MIZAR_VPC_RANGE_START=${VPC_RANGE_START:-}
+  MIZAR_VPC_RANGE_END=${VPC_RANGE_END:-}
+fi
+
 # Optional: Install cluster DNS.
 # Set CLUSTER_DNS_CORE_DNS to 'false' to install kube-dns instead of CoreDNS.
 CLUSTER_DNS_CORE_DNS="${CLUSTER_DNS_CORE_DNS:-true}"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -382,6 +382,15 @@ if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
   fi
 fi
 
+VPC_RANGE_START=${VPC_RANGE_START:-11}
+VPC_RANGE_END=${VPC_RANGE_END:-99}
+
+if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+  FEATURE_GATES="${FEATURE_GATES},MizarVPCRangeNoOverlap=true"
+  MIZAR_VPC_RANGE_START=${VPC_RANGE_START:-}
+  MIZAR_VPC_RANGE_END=${VPC_RANGE_END:-}
+fi
+
 # Optional: Install cluster DNS.
 # Set CLUSTER_DNS_CORE_DNS to 'false' to install kube-dns instead of CoreDNS.
 CLUSTER_DNS_CORE_DNS="${CLUSTER_DNS_CORE_DNS:-true}"

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -2314,6 +2314,13 @@ function start-kube-controller-manager {
     params+=" --resource-providers=${rp_kubeconfigs}"
   fi
 
+  if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+    if [[ -n "${MIZAR_VPC_RANGE_START:-}" && -n "${MIZAR_VPC_RANGE_END:-}" ]]; then
+      params+=" --vpc-range-start=${MIZAR_VPC_RANGE_START}"
+      params+=" --vpc-range-end=${MIZAR_VPC_RANGE_END}"
+    fi
+  fi
+
   ##switch to enable/disable kube-controller-manager leader-elect: --leader-elect=true/false
   if [[ "${ENABLE_KCM_LEADER_ELECT:-true}" == "false" ]]; then
     params+=" --leader-elect=false"

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1706,6 +1706,16 @@ EOF
 TENANT_SERVER_KUBECONFIGS: $(yaml-quote ${TENANT_SERVER_KUBECONFIGS})
 EOF
   fi
+  if [ -n "${MIZAR_VPC_RANGE_START:-}" ]; then
+      cat >>$file <<EOF
+MIZAR_VPC_RANGE_START: $(yaml-quote ${MIZAR_VPC_RANGE_START})
+EOF
+    fi
+    if [ -n "${MIZAR_VPC_RANGE_END:-}" ]; then
+      cat >>$file <<EOF
+MIZAR_VPC_RANGE_END: $(yaml-quote ${MIZAR_VPC_RANGE_END})
+EOF
+    fi
 }
 
 function build-proxy-kube-env {
@@ -3268,6 +3278,7 @@ function prepare-master {
 
 function prepare-tpmaster {
   local tpserver_name=""
+  local vpc_range_num=$(((VPC_RANGE_END-VPC_RANGE_START)/SCALEOUT_TP_COUNT))
   for num in $(seq ${SCALEOUT_TP_COUNT:-1}); do
     tpserver_name="-tp-${num}-master"
     TPSERVER_NAME[$num]="${INSTANCE_PREFIX}${tpserver_name}"
@@ -3280,9 +3291,18 @@ function prepare-tpmaster {
 
     if [[ ${num} == 1 ]]; then
       TPCONFIG_METADATA="tp-${num}=${RESOURCE_DIRECTORY}/kubeconfig${KUBEMARK_PREFIX}.tp-${num}"
+      MIZAR_VPC_RANGE_START[$num]=${VPC_RANGE_START}
     else
       TPCONFIG_METADATA=${TPCONFIG_METADATA},"tp-${num}=${RESOURCE_DIRECTORY}/kubeconfig${KUBEMARK_PREFIX}.tp-${num}"
+      MIZAR_VPC_RANGE_START[$num]=$((VPC_RANGE_START+vpc_range_num*(num-1)+1))
     fi
+
+    if [[ ${num} == ${SCALEOUT_TP_COUNT} ]]; then
+      MIZAR_VPC_RANGE_END[$num]=${VPC_RANGE_END}
+    else
+      MIZAR_VPC_RANGE_END[$num]=$((VPC_RANGE_START+vpc_range_num*num))
+    fi
+
     create-static-ip "${TPSERVER_NAME[$num]}-ip" "${REGION}"
     TPSERVER_RESERVED_IP[$num]=$(gcloud compute addresses describe "${TPSERVER_NAME[$num]}-ip" \
           --project "${PROJECT}" --region "${REGION}" -q --format='value(address)')
@@ -3331,6 +3351,8 @@ function create-tpmaster {
   MASTER_ADVERTISE_ADDRESS="${TPSERVER_RESERVED_INTERNAL_IP[$tp_sequence]}"
   KUBERNETES_MASTER_INTERNAL_IP="${TPSERVER_RESERVED_INTERNAL_IP[$tp_sequence]}"
   KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig${KUBEMARK_PREFIX}.tp-$tp_sequence"
+  MIZAR_VPC_RANGE_START="${MIZAR_VPC_RANGE_START[$tp_sequence]}"
+  MIZAR_VPC_RANGE_END="${MIZAR_VPC_RANGE_END[$tp_sequence]}"
 
   if [[ "${REGISTER_MASTER_KUBELET:-}" == "true" ]]; then
     KUBELET_APISERVER="${TPSERVER_RESERVED_IP[${tp_sequence}]}"
@@ -3353,6 +3375,8 @@ function create-rpmaster {
   MASTER_ADVERTISE_ADDRESS="${RPSERVER_RESERVED_INTERNAL_IP[$rp_sequence]}"
   KUBERNETES_MASTER_INTERNAL_IP="${RPSERVER_RESERVED_INTERNAL_IP[$rp_sequence]}"
   KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig${KUBEMARK_PREFIX}.rp-$rp_sequence"
+  MIZAR_VPC_RANGE_START=""
+  MIZAR_VPC_RANGE_END=""
 
   if [[ "${REGISTER_MASTER_KUBELET:-}" == "true" ]]; then
     KUBELET_APISERVER="${RPSERVER_RESERVED_IP[${rp_sequence}]}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind feature


**What this PR does / why we need it**:
kube-up.sh support  VPC range for each TP

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
No additional env added when start  cluster, kube-up will automatically assign vac range for each TP between 11-99.

Tested on scenarios blow:

1. Kubeup (scale up) with mizar: successfully and vpc_range bound to kube-controller-manger
2. Kubeup (scale up with default network): successfully, no vpc_range bound to kube-controller-manger
3. Kubeup (scale up with default network) + kubemark ( scale up with default network: 100 nodes): successfully
4. Kubeup (scale out 1x1, 2x2) with mizar: successfully and TP servers have vpc_range bound to kube-controller-manger

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
