### PR TITLE
kube-up support vpc range (#1397)

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -942,6 +942,16 @@ EOF
 DISABLE_NETWORK_SERVICE_SUPPORT: $(yaml-quote ${DISABLE_NETWORK_SERVICE_SUPPORT})
 EOF
     fi
+    if [ -n "${MIZAR_VPC_RANGE_START:-}" ]; then
+      cat >>$file <<EOF
+MIZAR_VPC_RANGE_START: $(yaml-quote ${MIZAR_VPC_RANGE_START})
+EOF
+    fi
+    if [ -n "${MIZAR_VPC_RANGE_END:-}" ]; then
+      cat >>$file <<EOF
+MIZAR_VPC_RANGE_END: $(yaml-quote ${MIZAR_VPC_RANGE_END})
+EOF
+    fi
     if [ -n "${INITIAL_ETCD_CLUSTER:-}" ]; then
       cat >>$file <<EOF
 INITIAL_ETCD_CLUSTER: $(yaml-quote ${INITIAL_ETCD_CLUSTER})

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -369,6 +369,15 @@ if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
   fi
 fi
 
+VPC_RANGE_START=${VPC_RANGE_START:-11}
+VPC_RANGE_END=${VPC_RANGE_END:-99}
+
+if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+  FEATURE_GATES="${FEATURE_GATES},MizarVPCRangeNoOverlap=true"
+  MIZAR_VPC_RANGE_START=${VPC_RANGE_START:-}
+  MIZAR_VPC_RANGE_END=${VPC_RANGE_END:-}
+fi
+
 # Optional: Install cluster DNS.
 # Set CLUSTER_DNS_CORE_DNS to 'false' to install kube-dns instead of CoreDNS.
 CLUSTER_DNS_CORE_DNS="${CLUSTER_DNS_CORE_DNS:-true}"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -382,6 +382,15 @@ if [ -z ${DISABLE_NETWORK_SERVICE_SUPPORT} ]; then # when enabled
   fi
 fi
 
+VPC_RANGE_START=${VPC_RANGE_START:-11}
+VPC_RANGE_END=${VPC_RANGE_END:-99}
+
+if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+  FEATURE_GATES="${FEATURE_GATES},MizarVPCRangeNoOverlap=true"
+  MIZAR_VPC_RANGE_START=${VPC_RANGE_START:-}
+  MIZAR_VPC_RANGE_END=${VPC_RANGE_END:-}
+fi
+
 # Optional: Install cluster DNS.
 # Set CLUSTER_DNS_CORE_DNS to 'false' to install kube-dns instead of CoreDNS.
 CLUSTER_DNS_CORE_DNS="${CLUSTER_DNS_CORE_DNS:-true}"

--- a/cluster/gce/gci/configure-helper-common.sh
+++ b/cluster/gce/gci/configure-helper-common.sh
@@ -2314,6 +2314,13 @@ function start-kube-controller-manager {
     params+=" --resource-providers=${rp_kubeconfigs}"
   fi
 
+  if [[ "${NETWORK_PROVIDER:-}" == "mizar" ]]; then
+    if [[ -n "${MIZAR_VPC_RANGE_START:-}" && -n "${MIZAR_VPC_RANGE_END:-}" ]]; then
+      params+=" --vpc-range-start=${MIZAR_VPC_RANGE_START}"
+      params+=" --vpc-range-end=${MIZAR_VPC_RANGE_END}"
+    fi
+  fi
+
   ##switch to enable/disable kube-controller-manager leader-elect: --leader-elect=true/false
   if [[ "${ENABLE_KCM_LEADER_ELECT:-true}" == "false" ]]; then
     params+=" --leader-elect=false"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind feature


**What this PR does / why we need it**:
This is a followup for https://github.com/CentaurusInfra/arktos/pull/1398
kube-up.sh support VPC range for each TP

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
No additional env added when start cluster, kube-up will automatically assign vac range for each TP between 11-99.

Tested on scenarios blow:

Kubeup (scale up) with mizar: successfully and vpc_range bound to kube-controller-manger
Kubeup (scale up with default network): successfully, no vpc_range bound to kube-controller-manger
Kubeup (scale out 2x2) with mizar: successfully and TP servers have vpc_range bound to kube-controller-manger

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
